### PR TITLE
0.6.3

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -92,6 +92,9 @@ li.tab-link.current[data-tab="b2b"] {
 .woocommerce-order-received.collector-b2c-b2b .woocommerce-order-details,
 .woocommerce-order-received.collector-b2c .woocommerce-order-details,
 .woocommerce-order-received.collector-b2b .woocommerce-order-details,
+.woocommerce-order-received.collector-b2c-b2b .woocommerce-customer-details,
+.woocommerce-order-received.collector-b2c .woocommerce-customer-details,
+.woocommerce-order-received.collector-b2b .woocommerce-customer-details,
 .woocommerce-order-received.collector-b2c-b2b h1.entry-title,
 .woocommerce-order-received.collector-b2c h1.entry-title,
 .woocommerce-order-received.collector-b2b h1.entry-title {

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -225,7 +225,9 @@
                 dataType: 'json',
                 data: {
                     action  : 'get_checkout_thank_you',
-                    order_id : wc_collector_checkout.order_id
+                    order_id : wc_collector_checkout.order_id,
+                    purchase_status : wc_collector_checkout.purchase_status,
+                    public_token: wc_collector_checkout.public_token
                 },
                 success: function(data) {
                     var publicToken = data.data.publicToken;
@@ -267,7 +269,8 @@
 
     function collector_post_form() {
         var data = {
-            'action': 'get_customer_data'
+            'action': 'get_customer_data',
+            'public_token': wc_collector_checkout.public_token
         };
         jQuery.post(wc_collector_checkout.get_customer_data_url, data, function (data) {
             if (true === data.success) {

--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -168,8 +168,8 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 			'customer_type'	=> $customer_type,
 		);
 		
-		WC()->session->__unset( 'collector_public_token' );
-		WC()->session->__unset( 'collector_private_id' );
+		//WC()->session->__unset( 'collector_public_token' );
+		//WC()->session->__unset( 'collector_private_id' );
 		wp_send_json_success( $return );
 		wp_die();
 	}

--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -72,7 +72,7 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 				WC()->session->set( 'collector_public_token', $decode->data->publicToken );
 				WC()->session->set( 'collector_private_id', $decode->data->privateId );
 				WC()->session->set( 'collector_customer_type', $customer_type );
-
+				
 				wp_send_json_success( $return );
 				wp_die();
 			} else {
@@ -158,18 +158,30 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 	public static function get_checkout_thank_you() {
 		$order_id 			= '';
 		$order_id 			= sanitize_text_field($_POST['order_id']);
-		$public_token 		= get_post_meta( $order_id, '_collector_public_token', true );
+		$purchase_status 	= sanitize_text_field($_POST['purchase_status']);
 		$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
 		$test_mode 			= $collector_settings['test_mode'];
-		$customer_type		= get_post_meta( $order_id, '_collector_customer_type', true );
+		
+		// If something went wrong in get_customer_data() - display a "thank you page light"
+		if( 'not-completed' == $purchase_status ) {
+			$public_token 		= sanitize_text_field($_POST['public_token']);
+			if( WC()->session->get( 'collector_customer_type' ) ) {
+				$customer_type 	= WC()->session->get( 'collector_customer_type' );
+			} else {
+				$customer_type	= 'b2c';
+			}
+			
+		} else {
+			$public_token 		= get_post_meta( $order_id, '_collector_public_token', true );
+			$customer_type		= get_post_meta( $order_id, '_collector_customer_type', true );	
+		}
+		
 		$return = array(
 			'publicToken' 	=> $public_token,
 			'test_mode'   	=> $test_mode,
 			'customer_type'	=> $customer_type,
 		);
 		
-		//WC()->session->__unset( 'collector_public_token' );
-		//WC()->session->__unset( 'collector_private_id' );
 		wp_send_json_success( $return );
 		wp_die();
 	}
@@ -183,7 +195,7 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 		$customer_data 	= new Collector_Checkout_Requests_Get_Checkout_Information( $private_id, $customer_type );
 		$customer_data 	= $customer_data->request();
 		$decoded_json 	= json_decode( $customer_data );
-
+		
 		if( 'PurchaseCompleted' == $decoded_json->data->status ) {
 			// Save the payment method and payment id
 			$payment_method = $decoded_json->data->purchase->paymentMethod;
@@ -207,9 +219,9 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 			wp_send_json_success( $return );
 			wp_die();
 		} else {
-			// We didn't get a status PurchaseCompleted from Collector so we redirect the customer back to checkout page and display the iframe again
+			// We didn't get a status PurchaseCompleted from Collector (but the Collector redirectPageUri has been triggered) so we redirect the customer to thank you page
 			$return = array();
-			$url = add_query_arg( array( 'purchase-status' =>'not-completed' ), wc_get_checkout_url() );
+			$url = add_query_arg( array( 'purchase-status' =>'not-completed', 'public-token' => sanitize_text_field($_POST['public_token']) ), wc_get_endpoint_url('order-received', '', get_permalink(wc_get_page_id('checkout'))) );
 			$return['redirect_url'] = $url;
 			Collector_Checkout::log('Payment complete triggered for private id ' . $private_id . ' but status is not PurchaseCompleted in Collectors system. Current status: ' . var_export($decoded_json->data->status, true));
 			wp_send_json_error( $return );

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -302,6 +302,13 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 			return '<div class="collector-checkout-thankyou"></div>';
 			
 		}
+		if( isset( $_GET['purchase-status'] ) && 'not-completed' == $_GET['purchase-status'] ) {
+			// Unset Collector token and id
+			WC()->session->__unset( 'collector_public_token' );
+			WC()->session->__unset( 'collector_private_id' );
+			WC()->cart->empty_cart();
+			return '<div class="collector-checkout-thankyou"></div>';
+		}
 
 		return $text;
 	}

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -295,7 +295,7 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 	 * @return string
 	 */
 	public function collector_thankyou_order_received_text( $text, $order ) {
-		if( 'collector_checkout' == $order->get_payment_method() ) {
+		if( is_object( $order ) && 'collector_checkout' == $order->get_payment_method() ) {
 			return '<div class="collector-checkout-thankyou"></div>';
 			
 		}

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -280,7 +280,7 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 	            update_post_meta( $order_id, '_collector_org_nr', $org_nr );
 	            WC()->session->__unset( 'collector_org_nr' );
             }
-            
+            // Unset Collector token and id
 			WC()->session->__unset( 'collector_public_token' );
 			WC()->session->__unset( 'collector_private_id' );
 		} else {

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -280,6 +280,9 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 	            update_post_meta( $order_id, '_collector_org_nr', $org_nr );
 	            WC()->session->__unset( 'collector_org_nr' );
             }
+            
+			WC()->session->__unset( 'collector_public_token' );
+			WC()->session->__unset( 'collector_private_id' );
 		} else {
 			// @todo - add logging here.
 		}

--- a/classes/requests/class-collector-checkout-requests-get-checkout-information.php
+++ b/classes/requests/class-collector-checkout-requests-get-checkout-information.php
@@ -29,7 +29,7 @@ class Collector_Checkout_Requests_Get_Checkout_Information extends Collector_Che
 			'headers' => $this->request_header( '', $this->path ),
 			'method'  => 'GET',
 		);
-		$this->log( 'Collector checkout information request args: ' . var_export( $request_args, true ) );
+		$this->log( 'Collector get checkout information request args (to ' . $this->path . '): ' . var_export( $request_args, true ) );
 		return $request_args;
 	}
 

--- a/classes/requests/class-collector-checkout-requests-get-checkout-information.php
+++ b/classes/requests/class-collector-checkout-requests-get-checkout-information.php
@@ -27,6 +27,7 @@ class Collector_Checkout_Requests_Get_Checkout_Information extends Collector_Che
 	private function get_request_args() {
 		$request_args = array(
 			'headers' => $this->request_header( '', $this->path ),
+			'timeout' => 10,
 			'method'  => 'GET',
 		);
 		$this->log( 'Collector get checkout information request args (to ' . $this->path . '): ' . var_export( $request_args, true ) );

--- a/classes/requests/class-collector-checkout-requests-initialize-checkout.php
+++ b/classes/requests/class-collector-checkout-requests-initialize-checkout.php
@@ -36,6 +36,7 @@ class Collector_Checkout_Requests_Initialize_Checkout extends Collector_Checkout
 	private function get_request_args() {
 		$request_args = array(
 			'headers' => $this->request_header( $this->request_body(), $this->path ),
+			'timeout' => 10,
 			'body'    => $this->request_body(),
 			'method'  => 'POST',
 		);

--- a/classes/requests/class-collector-checkout-requests-update-cart.php
+++ b/classes/requests/class-collector-checkout-requests-update-cart.php
@@ -26,6 +26,7 @@ class Collector_Checkout_Requests_Update_Cart extends Collector_Checkout_Request
 	private function get_request_args() {
 		$request_args = array(
 			'headers' => $this->request_header( $this->request_body(), $this->path ),
+			'timeout' => 10,
 			'body'    => $this->request_body(),
 			'method'  => 'PUT',
 		);

--- a/classes/requests/class-collector-checkout-requests-update-fees.php
+++ b/classes/requests/class-collector-checkout-requests-update-fees.php
@@ -26,6 +26,7 @@ class Collector_Checkout_Requests_Update_Fees extends Collector_Checkout_Request
 	private function get_request_args() {
 		$request_args = array(
 			'headers' => $this->request_header( $this->request_body(), $this->path ),
+			'timeout' => 10,
 			'body'    => $this->request_body(),
 			'method'  => 'PUT',
 		);

--- a/classes/requests/class-collector-checkout-requests-update-reference.php
+++ b/classes/requests/class-collector-checkout-requests-update-reference.php
@@ -29,6 +29,7 @@ class Collector_Checkout_Requests_Update_Reference extends Collector_Checkout_Re
 	private function get_request_args() {
 		$request_args = array(
 			'headers' => $this->request_header( $this->request_body(), $this->path ),
+			'timeout' => 10,
 			'body'    => $this->request_body(),
 			'method'  => 'PUT',
 		);

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -107,7 +107,11 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 				}
 				if( is_wc_endpoint_url( 'order-received' ) ) {
 					$is_thank_you_page = true;
-					$order_id = wc_get_order_id_by_order_key(sanitize_text_field($_GET['key']));
+					if( isset( $_GET['key'] ) ) {
+						$order_id = wc_get_order_id_by_order_key(sanitize_text_field($_GET['key']));
+					} else {
+						$order_id = '';
+					}
 				} else {
 					$is_thank_you_page = false;
 					$order_id = '';
@@ -184,14 +188,16 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 			
 			// Hide the Order overview data on thankyou page if it's a Collector Checkout purchase
 			if( is_wc_endpoint_url( 'order-received' ) ) {
-				$order_id = wc_get_order_id_by_order_key( wc_clean( $_GET['key'] ) );
-				$order = wc_get_order( $order_id );
-				if( 'collector_checkout' == $order->get_payment_method() ) {
-					$custom_css = "
-	                .woocommerce-order-overview {
-			                        display: none;
-							}";
-					wp_add_inline_style( 'collector_checkout', $custom_css );
+				if( isset( $_GET['key'] ) ) {
+					$order_id = wc_get_order_id_by_order_key( wc_clean( $_GET['key'] ) );
+					$order = wc_get_order( $order_id );
+					if( 'collector_checkout' == $order->get_payment_method() ) {
+						$custom_css = "
+		                .woocommerce-order-overview {
+				                        display: none;
+								}";
+						wp_add_inline_style( 'collector_checkout', $custom_css );
+					}
 				}
 			}
 			

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -105,6 +105,11 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 				} else {
 					$locale = 'sv';
 				}
+				if( isset( $_GET['public-token'] ) ) {
+					$public_token = sanitize_text_field($_GET['public-token']);
+				} else {
+					$public_token = '';
+				}
 				if( is_wc_endpoint_url( 'order-received' ) ) {
 					$is_thank_you_page = true;
 					if( isset( $_GET['key'] ) ) {
@@ -112,15 +117,23 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 					} else {
 						$order_id = '';
 					}
+					if( isset( $_GET['purchase-status'] ) ) {
+						$purchase_status = sanitize_text_field( $_GET['purchase-status'] );
+					} else {
+						$purchase_status = '';
+					}
 				} else {
 					$is_thank_you_page = false;
 					$order_id = '';
+					$purchase_status = '';
 				}
 				wp_localize_script( 'checkout', 'wc_collector_checkout', array(
 					'ajaxurl' 						=> admin_url( 'admin-ajax.php' ),
 					'locale' 						=> $locale,
 					'is_thank_you_page'             => $is_thank_you_page,
 					'order_id'             			=> $order_id,
+					'public_token'             		=> $public_token,
+					'purchase_status'             	=> $purchase_status,
 					'default_customer_type' 		=> wc_collector_get_default_customer_type(),
 					'collector_nonce' 				=> wp_create_nonce( 'collector_nonce' ),
 					'refresh_checkout_fragment_url'	=> WC_AJAX::get_endpoint( 'update_fragment' ),


### PR DESCRIPTION
* Fix - Fallback order creation improvements. Send customer to order received page when redirectPageUri is hit, even if we can’t confirm the order in Collectors system. If then, display a simplified thank you page.
* Fix - Logging improvement
* Fix - Remove errors when accessing the order received page without order being created.
* Fix - Unset Collector sessions correctly on order received page.
* Tweak - Increased timeout to 10 seconds when communicating with Collector.
* Tweak - Improved logging in anti fraud callback.
* Tweak - CSS update to set WC customer details section width the same as Collector iframe in order received page.