### PR TITLE
V1.0.0

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -111,7 +111,7 @@
     // Set the correct checked radio button
 	$( document ).ready(function() {
         $('.collector-checkout-tabs li').removeClass('current');
-        $('li[data-tab="' + wc_collector_checkout.default_customer_type + '"]').addClass('current');
+        $('li[data-tab="' + wc_collector_checkout.selected_customer_type + '"]').addClass('current');
     });
 
 	// Suspend Collector Checkout during WooCommerce checkout update

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -375,8 +375,10 @@
 function checkout_error() {
     console.log('checkout error');
 	if ("collector_checkout" === $("input[name='payment_method']:checked").val()) {
+        var error_message = $( ".woocommerce-NoticeGroup-checkout" ).text();
         var data = {
-            'action': 'checkout_error'
+            'action': 'checkout_error',
+            'error_message': error_message,
         };
         
         jQuery.post(wc_collector_checkout.checkout_error, data, function (data) {

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -357,7 +357,7 @@
                             } else {
                                 console.log(wc_checkout_params.i18n_checkout_error);
                             }
-                            checkout_error();
+                            checkout_error( result.messages );
                         }
                     },
                     error: function (jqXHR, textStatus, errorThrown) {
@@ -372,22 +372,22 @@
     }
 
     // When WooCommerce checkout submission fails
-function checkout_error() {
-    console.log('checkout error');
-	if ("collector_checkout" === $("input[name='payment_method']:checked").val()) {
-        var error_message = $( ".woocommerce-NoticeGroup-checkout" ).text();
-        var data = {
-            'action': 'checkout_error',
-            'error_message': error_message,
-        };
+    function checkout_error( error_messages ) {
+        console.log('checkout error ' + $( error_messages ).text() );
         
-        jQuery.post(wc_collector_checkout.checkout_error, data, function (data) {
-            if (true === data.success) {
-                console.log('Collector checkout error');
-                console.log(data.data.redirect_url);
-                window.location.href = data.data.redirect_url;
-            }
-        });
+        if ("collector_checkout" === $("input[name='payment_method']:checked").val()) {
+            var data = {
+                'action': 'checkout_error',
+                'error_message': $( error_messages ).text(),
+            };
+            
+            jQuery.post(wc_collector_checkout.checkout_error, data, function (data) {
+                if (true === data.success) {
+                    console.log('Collector checkout error');
+                    console.log(data.data.redirect_url);
+                    window.location.href = data.data.redirect_url;
+                }
+            });
+        }
     }
-}
 }(jQuery));

--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -489,8 +489,14 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 		$create_order->update_order_reference_in_collector( $order, $customer_type, $private_id );
 
 		//Add order note
-		$order->add_order_note( __( 'This order was made as a fallback due to an error in the checkout, please verify the order with Collector.', 'collector-checkout-for-woocommerce' ) );
-
+		if ( ! empty( $_POST['error_message'] ) ) { // Input var okay.
+			$error_message = 'Error message: ' . sanitize_text_field( trim( $_POST['error_message'] ) );
+		} else {
+			$error_message = 'Error message could not be retreived';
+		}
+		$note = sprintf( __( 'This order was made as a fallback due to an error in the checkout (%s). Please verify the order with Collector.', 'collector-checkout-for-woocommerce' ), $error_message );
+		$order->add_order_note( $note );
+		
 		$redirect_url = $order->get_checkout_order_received_url();
 		$return = array( 'redirect_url'	=>	$redirect_url );
 		wp_send_json_success( $return );

--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -398,8 +398,10 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 			$email                  = isset( $customer_data['customer_data']->data->businessCustomer->email ) ? $customer_data['customer_data']->data->businessCustomer->email : '.';
 
 			$org_nr                 = isset( $customer_data['customer_data']->data->businessCustomer->organizationNumber ) ? $customer_data['customer_data']->data->businessCustomer->organizationNumber : '.';
+			$invoice_reference		= isset( $customer_data['customer_data']->data->businessCustomer->invoiceReference ) ? $customer_data['customer_data']->data->businessCustomer->invoiceReference : '.';
 
 			WC()->session->set( 'collector_org_nr', $org_nr );
+			WC()->session->set( 'collector_invoice_reference', $invoice_reference );
 		}
 		$countryCode            = isset( $customer_data['customer_data']->data->countryCode ) ? $customer_data['customer_data']->data->countryCode : $base_country;
 

--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -455,6 +455,15 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 
 		//Add fees to order.
 		$create_order->add_order_fees( $order );
+
+		// Maybe add invoice fee to order
+		if ( 'DirectInvoice' == WC()->session->get( 'collector_payment_method' ) ) {
+			$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
+			$product_id = $collector_settings['collector_invoice_fee'];
+			if( $product_id ) {
+				wc_collector_add_invoice_fee_to_order( $order_id, $product_id );
+			}
+		}
 		
 		//Add shipping to order.
 		$create_order->add_order_shipping( $order );

--- a/classes/class-collector-checkout-api-callbacks.php
+++ b/classes/class-collector-checkout-api-callbacks.php
@@ -85,7 +85,7 @@ class Collector_Api_Callbacks {
 	 * @throws Exception WC_Data_Exception.
 	 */
 	public function check_order_status( $private_id, $public_token, $customer_type, $order ) {
-		$response 			= new Collector_Checkout_Requests_Get_Checkout_Information( $private_id, $customer_type );
+		$response 			= new Collector_Checkout_Requests_Get_Checkout_Information( $private_id, $customer_type, $order->get_currency() );
 		$response 			= $response->request();
 		$collector_order 	= json_decode( $response );
 		

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -184,51 +184,12 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 	public function process_payment( $order_id, $retry = false ) {
 		$order = wc_get_order( $order_id );
 
+		// Maybe add invoice fee to order
 		if ( 'DirectInvoice' == WC()->session->get( 'collector_payment_method' ) ) {
 			$product_id = $this->get_option( 'collector_invoice_fee' );
-			
 			if( $product_id ) {
-
-				$product = wc_get_product( $product_id );
-				
-				if ( is_object( $product ) ) {
-					$tax_display_mode 	= get_option('woocommerce_tax_display_shop');
-					$price 				= wc_get_price_excluding_tax( $product );
-					
-					if ( $product->is_taxable() ) {
-						$product_tax = true;
-					} else {
-						$product_tax = false;
-					}
-					
-					$_tax = new WC_Tax();
-					$tmp_rates = $_tax->get_base_tax_rates( $product->get_tax_class() );
-					$_vat = array_shift( $tmp_rates );// Get the rate 
-					//Check what kind of tax rate we have 
-					if( $product->is_taxable() && isset($_vat['rate']) ) {
-						$vat_rate=round($_vat['rate']);
-					} else {
-						//if empty, set 0% as rate
-						$vat_rate = 0;
-					}
-					
-					$collector_fee            	= new stdClass();
-					$collector_fee->id        	= sanitize_title( $product->get_title() );
-					$collector_fee->name      	= $product->get_title();
-					$collector_fee->amount    	= $price;
-					$collector_fee->taxable   	= $product_tax;
-					$collector_fee->tax       	= $vat_rate;
-					$collector_fee->tax_data  	= array();
-					$collector_fee->tax_class 	= $product->get_tax_class();
-					$fee_id                   	= $order->add_fee( $collector_fee );
-		
-					if ( ! $fee_id ) {
-						$order->add_order_note( __( 'Unable to add Collector Bank Invoice Fee to the order.', 'collector-checkout-for-woocommerce' ) );
-					}
-					$order->calculate_totals( true );
-				}
+				wc_collector_add_invoice_fee_to_order( $order_id, $product_id );
 			}
-			
 		}
 
 		WC()->session->__unset( 'collector_customer_order_note' );

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -112,13 +112,14 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 				$collector_b2c_se 	= $collector_settings['collector_merchant_id_se_b2c'];
 				$collector_b2b_se 	= $collector_settings['collector_merchant_id_se_b2b'];
 				$collector_b2c_no 	= $collector_settings['collector_merchant_id_no_b2c'];
+				$collector_b2b_no 	= $collector_settings['collector_merchant_id_no_b2b'];
 	
 				// Currency check.
 				if ( ! in_array( get_woocommerce_currency(), array( 'NOK', 'SEK' ) ) ) {
 					return false;
 				}
 				// Store ID check
-				if( 'NOK' == get_woocommerce_currency() && ! $collector_b2c_no ) {
+				if( 'NOK' == get_woocommerce_currency() && ( ! $collector_b2c_no && ! $collector_b2b_no  ) ) {
 					return false;
 				}
 				if( 'SEK' == get_woocommerce_currency() && ( ! $collector_b2c_se && ! $collector_b2b_se  ) ) {

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -310,7 +310,7 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
             // Check if there is a invoice refernce set, if so add post meta
             if ( WC()->session->get( 'collector_invoice_reference' ) ) {
 	            $invoice_reference = WC()->session->get( 'collector_invoice_reference' );
-	            update_post_meta( $order_id, 'collector_invoice_reference', $invoice_reference );
+	            update_post_meta( $order_id, '_collector_invoice_reference', $invoice_reference );
 	            WC()->session->__unset( 'collector_invoice_reference' );
             }
             // Unset Collector token and id
@@ -404,9 +404,12 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 
     public function add_org_nr_to_order( $order ) {
 	    if ( 'collector_checkout' === $order->get_payment_method() ) {
-		    $order_id = $order->get_order_number();
+		    $order_id = $order->get_id();
 		    if ( get_post_meta( $order_id, '_collector_org_nr' ) ) {
-			    echo '<p><strong>' . __( 'Org Nr', 'collector-checkout-for-woocommerce' ) . ':</strong> ' . get_post_meta( $order_id, '_collector_org_nr', true ) . '</p>';
+			    echo '<p class="form-field form-field-wide"><strong>' . __( 'Org Nr', 'collector-checkout-for-woocommerce' ) . ':</strong> ' . get_post_meta( $order_id, '_collector_org_nr', true ) . '</p>';
+			}
+			if ( get_post_meta( $order_id, '_collector_invoice_reference' ) ) {
+			    echo '<p class="form-field form-field-wide"><strong>' . __( 'Invoice reference', 'collector-checkout-for-woocommerce' ) . ':</strong> ' . get_post_meta( $order_id, '_collector_invoice_reference', true ) . '</p>';
 		    }
 	    }
     }

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -277,9 +277,11 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 				$order->payment_complete( $payment_id );
 			} elseif( 'Signing' == $payment_status ) {
 				$order->add_order_note( __( 'Order is waiting for electronic signing by customer. Payment ID: ', 'woocommerce-gateway-klarna' ) . $payment_id );
+				update_post_meta( $order_id, '_transaction_id', $payment_id );
 				$order->update_status( 'on-hold' );
 			} else {
 				$order->add_order_note( __( 'Order is PENDING APPROVAL by Collector. Payment ID: ', 'woocommerce-gateway-klarna' ) . $payment_id );
+				update_post_meta( $order_id, '_transaction_id', $payment_id );
 				$order->update_status( 'on-hold' );
 			}
 			

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -306,6 +306,13 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 	            update_post_meta( $order_id, '_collector_org_nr', $org_nr );
 	            WC()->session->__unset( 'collector_org_nr' );
             }
+            
+            // Check if there is a invoice refernce set, if so add post meta
+            if ( WC()->session->get( 'collector_invoice_reference' ) ) {
+	            $invoice_reference = WC()->session->get( 'collector_invoice_reference' );
+	            update_post_meta( $order_id, 'collector_invoice_reference', $invoice_reference );
+	            WC()->session->__unset( 'collector_invoice_reference' );
+            }
             // Unset Collector token and id
 			wc_collector_unset_sessions();
 

--- a/classes/class-collector-checkout-gdpr.php
+++ b/classes/class-collector-checkout-gdpr.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Compliance with European Union's General Data Protection Regulation.
+ *
+ * @class    Collector_Checkout_GDPR
+ * @version  1.0.0
+ * @package  Collector_Checkout/Classes
+ * @category Class
+ * @author   Krokedil
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+class Collector_Checkout_GDPR {
+	public function __construct() {
+		add_action( 'admin_init', array( $this, 'privacy_declarations' ) );
+		//add_filter( 'wp_privacy_personal_data_exporters', array( $this, 'register_exporters' ) );
+		//add_filter( 'wp_privacy_personal_data_erasers', array( $this, 'register_erasers' ) );
+	}
+	public function privacy_declarations() {
+		if ( function_exists( 'wp_add_privacy_policy_content' ) ) {
+			$content =
+				__( 'When you place an order in the webstore with Collector Checkout as the choosen payment method, ' .
+					'information about the products in the order (namne, price, quantity, SKU) is sent to Collector Bank. ' .
+					'When the purchase is finalized Collector Bank sends your billing and shipping address back to the webstore. ' .
+					'This data plus an unique identifier for the purchase is then stored as billing and shipping data in the order in WooCommerce.',
+					'collector-checkout-for-woocommerce' );
+			wp_add_privacy_policy_content(
+				'Collector Checkout for WooCommerce',
+				wp_kses_post( wpautop( $content ) )
+			);
+		}
+	}
+}
+$wc_collector_checkout_gdpr = new Collector_Checkout_GDPR();

--- a/classes/class-collector-checkout-instant-checkout.php
+++ b/classes/class-collector-checkout-instant-checkout.php
@@ -13,7 +13,11 @@ class Collector_Checkout_Instant_Checkout {
 		$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
 		$instant_checkout = $collector_settings['collector_instant_checkout'];
 		if ( is_product() && 'no' !== $instant_checkout ) {
-			//echo '<br><br><script src="https://checkout-uat.collector.se/collector-instant-loader.js" data-lang="sv-SE"></script>';
+			if( 'NOK' == get_woocommerce_currency() ) {
+				$locale = 'nb-NO';
+			} else {
+				$locale = 'sv-SE';
+			}
 			?>
 			
 			<button id="button-instant-checkout" type="button" class="single_add_to_cart_button button alt button-expand-collapse is-collapsed">Snabbköp<span class="button-expand-collapse-additional"> denna vara</span></button>
@@ -29,7 +33,7 @@ class Collector_Checkout_Instant_Checkout {
 							<script
 							    type="text/javascript"
 							    src="https://checkout-uat.collector.se/collector-instant-loader.js"
-							    data-lang="sv-SE"
+							    data-lang="<?php echo $locale;?>"
 							    data-theme="core"
 							    data-instance-id="INSTANT_CHECKOUT_MODAL">
 							</script>

--- a/classes/requests/class-collector-checkout-requests-get-checkout-information.php
+++ b/classes/requests/class-collector-checkout-requests-get-checkout-information.php
@@ -7,10 +7,16 @@ class Collector_Checkout_Requests_Get_Checkout_Information extends Collector_Che
 
 	public $path = '';
 
-	public function __construct( $private_id, $customer_type ) {
+	public function __construct( $private_id, $customer_type, $currency = false ) {
 		parent::__construct();
+
+		// Use current selected (or store base) currency if it's not passed in the constructor
+		if( empty( $currency ) ) {
+			$currency = get_woocommerce_currency();
+		}
+		
 		$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
-		switch ( get_woocommerce_currency() ) {
+		switch ( $currency ) {
 			case 'SEK' :
 				$store_id = $collector_settings['collector_merchant_id_se_' . $customer_type];
 				break;

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -292,12 +292,13 @@ function wc_collector_get_available_customer_types() {
 	$collector_b2c_se 	= $collector_settings['collector_merchant_id_se_b2c'];
 	$collector_b2b_se 	= $collector_settings['collector_merchant_id_se_b2b'];
 	$collector_b2c_no 	= $collector_settings['collector_merchant_id_no_b2c'];
+	$collector_b2b_no 	= $collector_settings['collector_merchant_id_no_b2b'];
 
-	if( 'SEK' == get_woocommerce_currency() && $collector_b2c_se && $collector_b2b_se ) {
+	if( ( 'SEK' == get_woocommerce_currency() && $collector_b2c_se && $collector_b2b_se ) || ( 'NOK' == get_woocommerce_currency() && $collector_b2c_no && $collector_b2b_no ) ) {
 		return 'collector-b2c-b2b';
 	} elseif( ( 'SEK' == get_woocommerce_currency() && $collector_b2c_se ) || ( 'NOK' == get_woocommerce_currency() && $collector_b2c_no ) ) {
 		return 'collector-b2c';
-	} elseif( $collector_b2b_se ) {
+	} elseif( $collector_b2b_se || $collector_b2b_no ) {
 		return 'collector-b2b';
 	}
 }
@@ -309,22 +310,40 @@ function wc_collector_get_default_customer_type() {
 	$collector_b2c_se 		= $collector_settings['collector_merchant_id_se_b2c'];
 	$collector_b2b_se 		= $collector_settings['collector_merchant_id_se_b2b'];
 	$collector_b2c_no 		= $collector_settings['collector_merchant_id_no_b2c'];
+	$collector_b2b_no 		= $collector_settings['collector_merchant_id_no_b2b'];
 	
-	if( $collector_b2c_no && 'NOK' == get_woocommerce_currency() ) {
-		return 'b2c';
-	} elseif( $collector_b2c_se && empty( $default_customer_type ) ) {
-		return 'b2c';
-	} elseif( $collector_b2b_se && empty( $default_customer_type ) ) {
-		return 'b2b';
-	} elseif( $collector_b2c_se && 'b2c' == $default_customer_type ) {
-		return 'b2c';
-	} elseif( $collector_b2b_se && 'b2b' == $default_customer_type ) {
-		return 'b2b';
-	} elseif( empty( $collector_b2c_se ) && !empty( $collector_b2b_se ) && 'b2c' == $default_customer_type ) {
-		return 'b2b';
-	} else {
-		return 'b2c';
+	if( 'NOK' == get_woocommerce_currency() ) {
+		if( $collector_b2c_no && empty( $default_customer_type ) ) {
+			return 'b2c';
+		} elseif( $collector_b2b_no && empty( $default_customer_type ) ) {
+			return 'b2b';
+		} elseif( $collector_b2c_no && 'b2c' == $default_customer_type ) {
+			return 'b2c';
+		} elseif( $collector_b2b_no && 'b2b' == $default_customer_type ) {
+			return 'b2b';
+		} elseif( empty( $collector_b2c_no ) && !empty( $collector_b2b_no ) && 'b2c' == $default_customer_type ) {
+			return 'b2b';
+		} else {
+			return 'b2c';
+		}
 	}
+
+	if( 'SEK' == get_woocommerce_currency() ) {
+		if( $collector_b2c_se && empty( $default_customer_type ) ) {
+			return 'b2c';
+		} elseif( $collector_b2b_se && empty( $default_customer_type ) ) {
+			return 'b2b';
+		} elseif( $collector_b2c_se && 'b2c' == $default_customer_type ) {
+			return 'b2c';
+		} elseif( $collector_b2b_se && 'b2b' == $default_customer_type ) {
+			return 'b2b';
+		} elseif( empty( $collector_b2c_se ) && !empty( $collector_b2b_se ) && 'b2c' == $default_customer_type ) {
+			return 'b2b';
+		} else {
+			return 'b2c';
+		}
+	}
+	
 }
 
 /**

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -154,6 +154,7 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 					'payment_successful'			=> $payment_successful,
 					'purchase_status'             	=> $purchase_status,
 					'default_customer_type' 		=> wc_collector_get_default_customer_type(),
+					'selected_customer_type' 		=> wc_collector_get_selected_customer_type(),
 					'collector_nonce' 				=> wp_create_nonce( 'collector_nonce' ),
 					'refresh_checkout_fragment_url'	=> WC_AJAX::get_endpoint( 'update_fragment' ),
 					'get_public_token_url'   		=> WC_AJAX::get_endpoint( 'get_public_token' ),
@@ -315,7 +316,7 @@ function wc_collector_get_default_customer_type() {
 	if( 'NOK' == get_woocommerce_currency() ) {
 		if( $collector_b2c_no && empty( $default_customer_type ) ) {
 			return 'b2c';
-		} elseif( $collector_b2b_no && empty( $default_customer_type ) ) {
+		} elseif( $collector_b2b_no && empty( $default_customer_type ) ) {		
 			return 'b2b';
 		} elseif( $collector_b2c_no && 'b2c' == $default_customer_type ) {
 			return 'b2c';
@@ -344,6 +345,19 @@ function wc_collector_get_default_customer_type() {
 		}
 	}
 	
+}
+
+function wc_collector_get_selected_customer_type() {
+	$selected_customer_type = false;
+	if ( method_exists( WC()->session, 'get' ) ) {
+		$selected_customer_type = WC()->session->get( 'collector_customer_type' );
+	}
+
+	if( empty( $selected_customer_type ) ) {
+		$selected_customer_type = wc_collector_get_default_customer_type();
+	}
+
+	return $selected_customer_type;
 }
 
 /**

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -8,11 +8,15 @@
  * Plugin Name:     Collector Checkout for WooCommerce
  * Plugin URI:      https://krokedil.se/collector/
  * Description:     Extends WooCommerce. Provides a <a href="https://www.collector.se/" target="_blank">Collector Checkout</a> checkout for WooCommerce.
- * Version:         0.9.4
+ * Version:         1.0.0
  * Author:          Krokedil
  * Author URI:      https://krokedil.se/
  * Text Domain:     collector-checkout-for-woocommerce
  * Domain Path:     /languages
+ * 
+ * WC requires at least: 3.0.0
+ * WC tested up to: 3.4.0
+ *
  * Copyright:       © 2017-2018 Krokedil.
  * License:         GNU General Public License v3.0
  * License URI:     http://www.gnu.org/licenses/gpl-3.0.html
@@ -24,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'COLLECTOR_BANK_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'COLLECTOR_BANK_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'COLLECTOR_BANK_VERSION', '0.9.4' );
+define( 'COLLECTOR_BANK_VERSION', '1.0.0' );
 
 if ( ! class_exists( 'Collector_Checkout' ) ) {
 	class Collector_Checkout {

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -64,6 +64,8 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 			include_once( COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-checkout-api-callbacks.php' );
 			include_once( COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-checkout-status.php' );
 			include_once( COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-checkout-templates.php' );
+			include_once( COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-checkout-gdpr.php' );
+
 			include_once( COLLECTOR_BANK_PLUGIN_DIR . '/includes/collector-checkout-for-woocommerce-functions.php' );
 			
 			// Include and add the Gateway

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -87,3 +87,50 @@ function collector_wc_calculate_totals() {
 	WC()->cart->calculate_shipping();
 	WC()->cart->calculate_totals();
 }
+
+/**
+ * Unset Collector public token and private id
+ */
+function wc_collector_add_invoice_fee_to_order( $order_id, $product_id ) {
+	$result = false;
+	$order = wc_get_order( $order_id );
+	$product = wc_get_product( $product_id );
+				
+	if ( is_object( $product ) && is_object( $order ) ) {
+		$tax_display_mode 	= get_option('woocommerce_tax_display_shop');
+		$price 				= wc_get_price_excluding_tax( $product );
+		
+		if ( $product->is_taxable() ) {
+			$product_tax = true;
+		} else {
+			$product_tax = false;
+		}
+		
+		$_tax = new WC_Tax();
+		$tmp_rates = $_tax->get_base_tax_rates( $product->get_tax_class() );
+		$_vat = array_shift( $tmp_rates );// Get the rate 
+		//Check what kind of tax rate we have 
+		if( $product->is_taxable() && isset($_vat['rate']) ) {
+			$vat_rate=round($_vat['rate']);
+		} else {
+			//if empty, set 0% as rate
+			$vat_rate = 0;
+		}
+		
+		$collector_fee            	= new stdClass();
+		$collector_fee->id        	= sanitize_title( $product->get_title() );
+		$collector_fee->name      	= $product->get_title();
+		$collector_fee->amount    	= $price;
+		$collector_fee->taxable   	= $product_tax;
+		$collector_fee->tax       	= $vat_rate;
+		$collector_fee->tax_data  	= array();
+		$collector_fee->tax_class 	= $product->get_tax_class();
+		$fee_id                   	= $order->add_fee( $collector_fee );
+
+		if ( ! $fee_id ) {
+			$order->add_order_note( __( 'Unable to add Collector Bank Invoice Fee to the order.', 'collector-checkout-for-woocommerce' ) );
+		}
+		$result = $order->calculate_totals( true );
+	}
+	return $result;
+}

--- a/includes/collector-checkout-settings.php
+++ b/includes/collector-checkout-settings.php
@@ -80,6 +80,13 @@ return apply_filters( 'collector_checkout_settings',
 			'default'       => '',
 			'desc_tip'      => true,
 		),
+		'collector_merchant_id_no_b2b'     => array(
+			'title'         => __( 'Merchant ID Norway B2B', 'collector-checkout-for-woocommerce' ),
+			'type'          => 'text',
+			'description'   => __( 'Enter your Collector Checkout Merchant ID for B2B purchases in Norway', 'collector-checkout-for-woocommerce' ),
+			'default'       => '',
+			'desc_tip'      => true,
+		),
 		'checkout_settings_title' => array(
 			'title' => __( 'Checkout settings', 'collector-checkout-for-woocommerce' ),
 			'type'  => 'title',

--- a/readme.txt
+++ b/readme.txt
@@ -2,11 +2,11 @@
 Contributors: collectorbank, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, collector, checkout
 Requires at least: 4.7
-Tested up to: 4.9.5
+Tested up to: 4.9.6
 Requires PHP: 5.6
 Stable tag: trunk
 WC requires at least: 3.0.0
-WC tested up to: 3.3.5
+WC tested up to: 3.4.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -39,6 +39,17 @@ For help setting up and configuring Collector Checkout for WooCommerce please re
 
 
 == CHANGELOG ==
+= 2018.05.17  	- version 1.0.0 =
+* Feature		- Add support for B2B Norway.
+* Feature		- Add support for wp_add_privacy_policy_content (for GDPR compliance). More info: https://core.trac.wordpress.org/attachment/ticket/43473/PRIVACY-POLICY-CONTENT-HOOK.md.
+* Tweak			- Add order note in fallback order creation describing reason why checkout form submission failed.
+* Tweak			- Save Collector field Invoice reference in WooCommerce order for B2B purchases.
+* Tweak			- Added wc_collector_get_selected_customer_type() helper function. Used to display current selected customer type in frontend better.
+* Fix			- Fixed Instant checkout for Norway.
+* Fix			- Use order currency instead of store base currency in GET request to Collector after order is created in Woocommerce.
+* Fix			- Store Collector paymentId as _transaction_id even for orders with status On hold.
+* Fix			- Add invoice fee in fallback order creation process (if needed).
+
 = 2018.04.19  	- version 0.9.4 =
 * Fix			- Change how Collector order activation response is interpret so activations also works for part payment.
 * Tweak         - Create new Collector session if currency is changed.  


### PR DESCRIPTION
* Feature - Add support for B2B Norway.
* Feature	- Add support for wp_add_privacy_policy_content (for GDPR compliance). More info: https://core.trac.wordpress.org/attachment/ticket/43473/PRIVACY-POLICY-CONTENT-HOOK.md.
* Tweak - Add order note in fallback order creation describing reason why checkout form submission failed.
* Tweak - Save Collector field Invoice reference in WooCommerce order for B2B purchases.
* Tweak - Added wc_collector_get_selected_customer_type() helper function. Used to display current selected customer type in frontend better.
* Fix - Fixed Instant checkout for Norway.
* Fix	- Use order currency instead of store base currency in GET request to Collector after order is created in Woocommerce.
* Fix	- Store Collector paymentId as _transaction_id even for orders with status On hold.
* Fix	- Add invoice fee in fallback order creation process (if needed).