### PR TITLE
1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+SyncToy_fd3c94d9-f910-42eb-9cc1-68d6bcc566d8.dat

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -28,6 +28,7 @@
                 }
                 checkout_initiated = 'yes';
             } else {
+                $('#collector-bank-iframe').empty();
                 $('#collector-bank-iframe').append('<ul class="woocommerce-error"><li>' + data.data + '</li></ul>');
                 console.log('error');
                 console.log(data.data);

--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -62,7 +62,7 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 			$decode			= json_decode( $request );
 			
 			if ( is_wp_error( $request ) || empty( $request ) ) {
-					$return =  sprintf( '%s <a href="%s" class="button wc-forward">%s</a>', __( 'Could not connect to Collector.', 'collector-checkout-for-woocommerce' ), wc_get_checkout_url(), __( 'Try again', 'collector-checkout-for-woocommerce' ) );
+					$return =  sprintf( '%s <a href="%s" class="button wc-forward">%s</a>', __( 'Could not connect to Collector. Error message: ', 'collector-checkout-for-woocommerce' ) . $request->get_error_message(), wc_get_checkout_url(), __( 'Try again', 'collector-checkout-for-woocommerce' ) );
 				wp_send_json_error( $return );
 				wp_die();
 

--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -88,6 +88,9 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 	}
 
 	public static function update_checkout() {
+
+		wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
+
 		WC()->cart->calculate_shipping();
 		WC()->cart->calculate_fees();
 		WC()->cart->calculate_totals();
@@ -130,6 +133,9 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 		if ( ! wp_verify_nonce( $_REQUEST['nonce'], 'collector_nonce' ) ) {
 			exit( 'Nonce can not be verified.' );
 		}
+
+		wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
+		
 		$update_needed = 'no';
 		
 		// Get customer data from Collector

--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -360,9 +360,9 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 
 	public static function verify_customer_data( $customer_data ) {
 		$base_country = WC()->countries->get_base_country();
-		if ( 'SE' === $base_country ) {
+		if ( 'SE' === $base_country || 'FI' === $base_country ) {
 			$fallback_postcode = 11111;
-		} else if ( 'NO' === $base_country ) {
+		} else if ( 'NO' === $base_country || 'DK' === $base_country ) {
 			$fallback_postcode = 1111;
 		}
 		if ( 'PrivateCustomer' === $customer_data['customer_data']->data->customerType ) {

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -109,13 +109,16 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 		if ( 'yes' === $this->enabled ) {
 			if ( ! is_admin() ) {
 				$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
-				$collector_b2c_se 	= $collector_settings['collector_merchant_id_se_b2c'];
-				$collector_b2b_se 	= $collector_settings['collector_merchant_id_se_b2b'];
-				$collector_b2c_no 	= $collector_settings['collector_merchant_id_no_b2c'];
-				$collector_b2b_no 	= $collector_settings['collector_merchant_id_no_b2b'];
+				$collector_b2c_se 	= ( isset( $collector_settings['collector_merchant_id_se_b2c'] ) ) ? $collector_settings['collector_merchant_id_se_b2c'] : '';
+				$collector_b2b_se 	= ( isset( $collector_settings['collector_merchant_id_se_b2b'] ) ) ? $collector_settings['collector_merchant_id_se_b2b'] : '';
+				$collector_b2c_no 	= ( isset( $collector_settings['collector_merchant_id_no_b2c'] ) ) ? $collector_settings['collector_merchant_id_no_b2c'] : '';
+				$collector_b2b_no 	= ( isset( $collector_settings['collector_merchant_id_no_b2b'] ) ) ? $collector_settings['collector_merchant_id_no_b2b'] : '';
+				$collector_b2c_dk 	= ( isset( $collector_settings['collector_merchant_id_dk_b2c'] ) ) ? $collector_settings['collector_merchant_id_dk_b2c'] : '';
+				$collector_b2c_fi 	= ( isset( $collector_settings['collector_merchant_id_fi_b2c'] ) ) ? $collector_settings['collector_merchant_id_fi_b2c'] : '';
+				$collector_b2b_fi 	= ( isset( $collector_settings['collector_merchant_id_fi_b2b'] ) ) ? $collector_settings['collector_merchant_id_fi_b2b'] : '';
 	
 				// Currency check.
-				if ( ! in_array( get_woocommerce_currency(), array( 'NOK', 'SEK' ) ) ) {
+				if ( ! in_array( get_woocommerce_currency(), array( 'NOK', 'SEK', 'DKK', 'EUR' ) ) ) {
 					return false;
 				}
 				// Store ID check
@@ -123,6 +126,12 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 					return false;
 				}
 				if( 'SEK' == get_woocommerce_currency() && ( ! $collector_b2c_se && ! $collector_b2b_se  ) ) {
+					return false;
+				}
+				if( 'DKK' == get_woocommerce_currency() && ( ! $collector_b2c_dk  ) ) {
+					return false;
+				}
+				if( 'EUR' == get_woocommerce_currency() && ( ! $collector_b2c_fi && ! $collector_b2b_fi  ) ) {
 					return false;
 				}
 			}

--- a/classes/class-collector-checkout-gdpr.php
+++ b/classes/class-collector-checkout-gdpr.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Collector_Checkout_GDPR {
 	public function __construct() {
 		add_action( 'admin_init', array( $this, 'privacy_declarations' ) );
+		add_action( 'init', array( $this, 'maybe_add_privacy_policy_text' ) );
 		//add_filter( 'wp_privacy_personal_data_exporters', array( $this, 'register_exporters' ) );
 		//add_filter( 'wp_privacy_personal_data_erasers', array( $this, 'register_erasers' ) );
 	}
@@ -29,6 +30,32 @@ class Collector_Checkout_GDPR {
 				'Collector Checkout for WooCommerce',
 				wp_kses_post( wpautop( $content ) )
 			);
+		}
+	}
+
+	/**
+	 * Maybe adds the terms checkbox to the checkout.
+	 *
+	 * @return void
+	 */
+	public function maybe_add_privacy_policy_text() {
+		$settings                    = get_option( 'woocommerce_collector_checkout_settings' );
+		$display_privacy_policy_text = $settings['display_privacy_policy_text'];
+		if ( 'above' == $display_privacy_policy_text ) {
+			add_action( 'collector_wc_before_iframe', array( $this, 'wc_display_privacy_policy_text' ) );
+		} elseif ( 'below' == $display_privacy_policy_text ) {
+			add_action( 'collector_wc_after_iframe', array( $this, 'wc_display_privacy_policy_text' ) );
+		}
+	}
+
+	/**
+	 * Gets the terms template.
+	 *
+	 * @return void
+	 */
+	public function wc_display_privacy_policy_text() {
+		if ( function_exists( 'wc_checkout_privacy_policy_text' ) ) {
+			echo wc_checkout_privacy_policy_text();
 		}
 	}
 }

--- a/classes/class-collector-checkout-gdpr.php
+++ b/classes/class-collector-checkout-gdpr.php
@@ -39,8 +39,8 @@ class Collector_Checkout_GDPR {
 	 * @return void
 	 */
 	public function maybe_add_privacy_policy_text() {
-		$settings                    = get_option( 'woocommerce_collector_checkout_settings' );
-		$display_privacy_policy_text = $settings['display_privacy_policy_text'];
+		$settings                    	= get_option( 'woocommerce_collector_checkout_settings' );
+		$display_privacy_policy_text 	= ( isset( $settings['display_privacy_policy_text'] ) ) ? $settings['display_privacy_policy_text'] : '';
 		if ( 'above' == $display_privacy_policy_text ) {
 			add_action( 'collector_wc_before_iframe', array( $this, 'wc_display_privacy_policy_text' ) );
 		} elseif ( 'below' == $display_privacy_policy_text ) {

--- a/classes/class-collector-checkout-instant-checkout.php
+++ b/classes/class-collector-checkout-instant-checkout.php
@@ -15,6 +15,10 @@ class Collector_Checkout_Instant_Checkout {
 		if ( is_product() && 'no' !== $instant_checkout ) {
 			if( 'NOK' == get_woocommerce_currency() ) {
 				$locale = 'nb-NO';
+			} elseif( 'DKK' == get_woocommerce_currency() ) {
+				$locale = 'en-DK';
+			} elseif( 'EUR' == get_woocommerce_currency() ) {
+				$locale = 'fi-FI';
 			} else {
 				$locale = 'sv-SE';
 			}

--- a/classes/class-collector-checkout-post-checkout.php
+++ b/classes/class-collector-checkout-post-checkout.php
@@ -88,6 +88,11 @@ class Collector_Checkout_Post_Checkout {
 	 **/
 	public function collector_order_number( $order_number, $order ) {
 		if( is_admin() ) {
+			// Check if function get_current_screen() exist
+			if ( ! function_exists( 'get_current_screen' ) ) {
+				return $order_number;
+			}
+
 			$current_screen = get_current_screen();
 			if( 'edit-shop_order' == $current_screen->id ) {
 				$collector_payment_id = get_post_meta( $order->id, '_collector_payment_id', true );

--- a/classes/class-collector-checkout-post-checkout.php
+++ b/classes/class-collector-checkout-post-checkout.php
@@ -51,8 +51,6 @@ class Collector_Checkout_Post_Checkout {
 	function check_callback() {
 		if ( strpos( $_SERVER["REQUEST_URI"], 'module/collectorcheckout/invoicestatus' ) !== false ) {
 
-			header( "HTTP/1.1 200 Ok" );
-
 			if( isset( $_GET['InvoiceNo'] ) && isset( $_GET['OrderNo'] ) && isset( $_GET['InvoiceStatus'] ) ) {
 				Collector_Checkout::log( 'Collector Invoice Status Change callback hit' );
 				$collector_payment_id = wc_clean( $_GET['InvoiceNo'] );
@@ -75,8 +73,10 @@ class Collector_Checkout_Post_Checkout {
 					} elseif ( '5' == $_GET['InvoiceStatus'] ) {
 						$order->update_status( 'failed' );
 					}
+					header( "HTTP/1.1 200 Ok" );
 				} else {
 					Collector_Checkout::log( 'Invoice status callback from Collector but we could not find the corresponding order in WC. Collector InvoiceNo: ' . wc_clean( $_GET['InvoiceNo'] ) . '. InvoiceStatus: ' . wc_clean( $_GET['InvoiceStatus'] ) . '. OrderNo: ' . wc_clean( $_GET['OrderNo'] ) );
+					header("HTTP/1.0 404 Not Found");
 				}
 			}
 			die();	

--- a/classes/requests/class-collector-checkout-requests-get-checkout-information.php
+++ b/classes/requests/class-collector-checkout-requests-get-checkout-information.php
@@ -23,6 +23,12 @@ class Collector_Checkout_Requests_Get_Checkout_Information extends Collector_Che
 			case 'NOK' :
 				$store_id = $collector_settings['collector_merchant_id_no_' . $customer_type];
 				break;
+			case 'DKK' :
+				$store_id = $collector_settings['collector_merchant_id_dk_' . $customer_type];
+				break;
+			case 'EUR' :
+				$store_id = $collector_settings['collector_merchant_id_fi_' . $customer_type];
+				break;
 			default :
 				$store_id = $collector_settings['collector_merchant_id_se_' . $customer_type];
 				break;

--- a/classes/requests/class-collector-checkout-requests-initialize-checkout.php
+++ b/classes/requests/class-collector-checkout-requests-initialize-checkout.php
@@ -58,6 +58,8 @@ class Collector_Checkout_Requests_Initialize_Checkout extends Collector_Checkout
 		$request = wp_remote_request( $request_url, $this->get_request_args() );
 		if ( is_wp_error( $request ) ) {
 			$this->log( 'Collector init checkout request response ERROR: ' . stripslashes_deep( json_encode( $request->get_error_message() ) ) . ' (Request endpoint: ' . $request_url . ')' );			
+		} elseif( 200 !== $request['response']['code'] ) {
+			$request = new WP_Error( $request['response']['code'], $request['response']['message'] );
 		} else {
 			$this->log( 'Collector init checkout request response: ' . stripslashes_deep( json_encode( $request ) ) . ' (Request endpoint: ' . $request_url . ')' );
 			$request = wp_remote_retrieve_body( $request );

--- a/classes/requests/class-collector-checkout-requests-initialize-checkout.php
+++ b/classes/requests/class-collector-checkout-requests-initialize-checkout.php
@@ -59,6 +59,7 @@ class Collector_Checkout_Requests_Initialize_Checkout extends Collector_Checkout
 		if ( is_wp_error( $request ) ) {
 			$this->log( 'Collector init checkout request response ERROR: ' . stripslashes_deep( json_encode( $request->get_error_message() ) ) . ' (Request endpoint: ' . $request_url . ')' );			
 		} elseif( 200 !== $request['response']['code'] ) {
+			$this->log( 'Collector init checkout request response ERROR: ' . stripslashes_deep( json_encode( $request ) ) . ' (Request endpoint: ' . $request_url . ')' );
 			$request = new WP_Error( $request['response']['code'], $request['response']['message'] );
 		} else {
 			$this->log( 'Collector init checkout request response: ' . stripslashes_deep( json_encode( $request ) ) . ' (Request endpoint: ' . $request_url . ')' );

--- a/classes/requests/class-collector-checkout-requests-initialize-checkout.php
+++ b/classes/requests/class-collector-checkout-requests-initialize-checkout.php
@@ -23,6 +23,14 @@ class Collector_Checkout_Requests_Initialize_Checkout extends Collector_Checkout
 				$country_code = 'NO';
 				$this->store_id = $collector_settings['collector_merchant_id_no_' . $customer_type];
 				break;
+			case 'DKK' :
+				$country_code = 'DK';
+				$this->store_id = $collector_settings['collector_merchant_id_dk_' . $customer_type];
+				break;
+			case 'EUR' :
+				$country_code = 'FI';
+				$this->store_id = $collector_settings['collector_merchant_id_fi_' . $customer_type];
+				break;
 			default :
 				$country_code = 'SE';
 				$this->store_id = $collector_settings['collector_merchant_id_se_' . $customer_type];

--- a/classes/requests/class-collector-checkout-requests-instant-checkout.php
+++ b/classes/requests/class-collector-checkout-requests-instant-checkout.php
@@ -14,9 +14,33 @@ class Collector_Checkout_Requests_Instant_Checkout extends Collector_Checkout_Re
 	public function __construct( $customer_token, $customer_type = 'b2c' ) {
 		parent::__construct();
 		$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
-		$this->store_id = $collector_settings['collector_merchant_id_se_' . $customer_type];
+
+		switch ( get_woocommerce_currency() ) {
+			case 'SEK' :
+				$country_code = 'SE';
+				$this->store_id = $collector_settings['collector_merchant_id_se_' . $customer_type];
+				break;
+			case 'NOK' :
+				$country_code = 'NO';
+				$this->store_id = $collector_settings['collector_merchant_id_no_' . $customer_type];
+				break;
+			case 'DKK' :
+				$country_code = 'DK';
+				$this->store_id = $collector_settings['collector_merchant_id_dk_' . $customer_type];
+				break;
+			case 'EUR' :
+				$country_code = 'FI';
+				$this->store_id = $collector_settings['collector_merchant_id_fi_' . $customer_type];
+				break;
+			default :
+				$country_code = 'SE';
+				$this->store_id = $collector_settings['collector_merchant_id_se_' . $customer_type];
+				break;
+		}
+
+		$this->customer_type = $customer_type;
+		$this->country_code = $country_code;
 		$this->terms_page = esc_url( get_permalink( wc_get_page_id( 'terms' ) ) );
-		$this->customer_token = $customer_token;
 	}
 
 	private function get_request_args() {
@@ -40,7 +64,7 @@ class Collector_Checkout_Requests_Instant_Checkout extends Collector_Checkout_Re
 	protected function request_body() {
 		$formatted_request_body = array(
 			'storeId'           => $this->store_id,
-			'countryCode'       => 'SE',
+			'countryCode'       => $this->country_code,
 			'reference'         => '',
 			'redirectPageUri'   => WC()->cart->get_checkout_url() . '?payment_successful=1',
 			'merchantTermsUri'  => $this->terms_page,

--- a/classes/requests/class-collector-checkout-requests-update-cart.php
+++ b/classes/requests/class-collector-checkout-requests-update-cart.php
@@ -16,6 +16,12 @@ class Collector_Checkout_Requests_Update_Cart extends Collector_Checkout_Request
 			case 'NOK' :
 				$store_id = $collector_settings['collector_merchant_id_no_' . $customer_type];
 				break;
+			case 'DKK' :
+				$store_id = $collector_settings['collector_merchant_id_dk_' . $customer_type];
+				break;
+			case 'EUR' :
+				$store_id = $collector_settings['collector_merchant_id_fi_' . $customer_type];
+				break;
 			default :
 				$store_id = $collector_settings['collector_merchant_id_se_' . $customer_type];
 				break;

--- a/classes/requests/class-collector-checkout-requests-update-fees.php
+++ b/classes/requests/class-collector-checkout-requests-update-fees.php
@@ -16,6 +16,12 @@ class Collector_Checkout_Requests_Update_Fees extends Collector_Checkout_Request
 			case 'NOK' :
 				$store_id = $collector_settings['collector_merchant_id_no_' . $customer_type];
 				break;
+			case 'DKK' :
+				$store_id = $collector_settings['collector_merchant_id_dk_' . $customer_type];
+				break;
+			case 'EUR' :
+				$store_id = $collector_settings['collector_merchant_id_fi_' . $customer_type];
+				break;
 			default :
 				$store_id = $collector_settings['collector_merchant_id_se_' . $customer_type];
 				break;

--- a/classes/requests/class-collector-checkout-requests-update-reference.php
+++ b/classes/requests/class-collector-checkout-requests-update-reference.php
@@ -18,6 +18,12 @@ class Collector_Checkout_Requests_Update_Reference extends Collector_Checkout_Re
 			case 'NOK' :
 				$store_id = $collector_settings['collector_merchant_id_no_' . $customer_type];
 				break;
+			case 'DKK' :
+				$store_id = $collector_settings['collector_merchant_id_dk_' . $customer_type];
+				break;
+			case 'EUR' :
+				$store_id = $collector_settings['collector_merchant_id_fi_' . $customer_type];
+				break;
 			default :
 				$store_id = $collector_settings['collector_merchant_id_se_' . $customer_type];
 				break;

--- a/classes/requests/soap/class-collector-checkout-soap-requests-activate-invoice.php
+++ b/classes/requests/soap/class-collector-checkout-soap-requests-activate-invoice.php
@@ -32,6 +32,14 @@ class Collector_Checkout_SOAP_Requests_Activate_Invoice {
 				$country_code = 'NO';
 				$this->store_id = $collector_settings['collector_merchant_id_no_' . $customer_type];
 				break;
+			case 'DKK' :
+				$country_code = 'DK';
+				$this->store_id = $collector_settings['collector_merchant_id_dk_' . $customer_type];
+				break;
+			case 'EUR' :
+				$country_code = 'FI';
+				$this->store_id = $collector_settings['collector_merchant_id_fi_' . $customer_type];
+				break;
 			default :
 				$country_code = 'SE';
 				$this->store_id = $collector_settings['collector_merchant_id_se_' . $customer_type];

--- a/classes/requests/soap/class-collector-checkout-soap-requests-cancel-invoice.php
+++ b/classes/requests/soap/class-collector-checkout-soap-requests-cancel-invoice.php
@@ -31,6 +31,14 @@ class Collector_Checkout_SOAP_Requests_Cancel_Invoice {
 				$country_code = 'NO';
 				$this->store_id = $collector_settings['collector_merchant_id_no_' . $customer_type];
 				break;
+			case 'DKK' :
+				$country_code = 'DK';
+				$this->store_id = $collector_settings['collector_merchant_id_dk_' . $customer_type];
+				break;
+			case 'EUR' :
+				$country_code = 'FI';
+				$this->store_id = $collector_settings['collector_merchant_id_fi_' . $customer_type];
+				break;
 			default :
 				$country_code = 'SE';
 				$this->store_id = $collector_settings['collector_merchant_id_se_' . $customer_type];

--- a/classes/requests/soap/class-collector-checkout-soap-requests-credit-payment.php
+++ b/classes/requests/soap/class-collector-checkout-soap-requests-credit-payment.php
@@ -30,6 +30,14 @@ class Collector_Checkout_SOAP_Requests_Credit_Payment {
 				$country_code = 'NO';
 				$this->store_id = $collector_settings['collector_merchant_id_no_' . $customer_type];
 				break;
+			case 'DKK' :
+				$country_code = 'DK';
+				$this->store_id = $collector_settings['collector_merchant_id_dk_' . $customer_type];
+				break;
+			case 'EUR' :
+				$country_code = 'FI';
+				$this->store_id = $collector_settings['collector_merchant_id_fi_' . $customer_type];
+				break;
 			default :
 				$country_code = 'SE';
 				$this->store_id = $collector_settings['collector_merchant_id_se_' . $customer_type];

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -8,14 +8,14 @@
  * Plugin Name:     Collector Checkout for WooCommerce
  * Plugin URI:      https://krokedil.se/collector/
  * Description:     Extends WooCommerce. Provides a <a href="https://www.collector.se/" target="_blank">Collector Checkout</a> checkout for WooCommerce.
- * Version:         1.0.0
+ * Version:         1.1.0
  * Author:          Krokedil
  * Author URI:      https://krokedil.se/
  * Text Domain:     collector-checkout-for-woocommerce
  * Domain Path:     /languages
  * 
  * WC requires at least: 3.0.0
- * WC tested up to: 3.4.0
+ * WC tested up to: 3.4.4
  *
  * Copyright:       © 2017-2018 Krokedil.
  * License:         GNU General Public License v3.0
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'COLLECTOR_BANK_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'COLLECTOR_BANK_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'COLLECTOR_BANK_VERSION', '1.0.0' );
+define( 'COLLECTOR_BANK_VERSION', '1.1.0' );
 
 if ( ! class_exists( 'Collector_Checkout' ) ) {
 	class Collector_Checkout {

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -114,8 +114,12 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 				
 				if( 'NOK' == get_woocommerce_currency() ) {
 					$locale = 'nb-NO';
+				} elseif( 'DKK' == get_woocommerce_currency() ) {
+					$locale = 'en-DK';
+				} elseif( 'EUR' == get_woocommerce_currency() ) {
+					$locale = 'fi-FI';
 				} else {
-					$locale = 'sv';
+					$locale = 'sv-SE';
 				}
 				if( isset( $_GET['public-token'] ) ) {
 					$public_token = sanitize_text_field($_GET['public-token']);
@@ -296,16 +300,20 @@ $collector_checkout = new Collector_Checkout();
 
 function wc_collector_get_available_customer_types() {
 	$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
-	$collector_b2c_se 	= $collector_settings['collector_merchant_id_se_b2c'];
-	$collector_b2b_se 	= $collector_settings['collector_merchant_id_se_b2b'];
-	$collector_b2c_no 	= $collector_settings['collector_merchant_id_no_b2c'];
-	$collector_b2b_no 	= $collector_settings['collector_merchant_id_no_b2b'];
+	
+	$collector_b2c_se 	= ( isset( $collector_settings['collector_merchant_id_se_b2c'] ) ) ? $collector_settings['collector_merchant_id_se_b2c'] : '';
+	$collector_b2b_se 	= ( isset( $collector_settings['collector_merchant_id_se_b2b'] ) ) ? $collector_settings['collector_merchant_id_se_b2b'] : '';
+	$collector_b2c_no 	= ( isset( $collector_settings['collector_merchant_id_no_b2c'] ) ) ? $collector_settings['collector_merchant_id_no_b2c'] : '';
+	$collector_b2b_no 	= ( isset( $collector_settings['collector_merchant_id_no_b2b'] ) ) ? $collector_settings['collector_merchant_id_no_b2b'] : '';
+	$collector_b2c_dk 	= ( isset( $collector_settings['collector_merchant_id_dk_b2c'] ) ) ? $collector_settings['collector_merchant_id_dk_b2c'] : '';
+	$collector_b2c_fi 	= ( isset( $collector_settings['collector_merchant_id_fi_b2c'] ) ) ? $collector_settings['collector_merchant_id_fi_b2c'] : '';
+	$collector_b2b_fi 	= ( isset( $collector_settings['collector_merchant_id_fi_b2b'] ) ) ? $collector_settings['collector_merchant_id_fi_b2b'] : '';
 
-	if( ( 'SEK' == get_woocommerce_currency() && $collector_b2c_se && $collector_b2b_se ) || ( 'NOK' == get_woocommerce_currency() && $collector_b2c_no && $collector_b2b_no ) ) {
+	if( ( 'SEK' == get_woocommerce_currency() && $collector_b2c_se && $collector_b2b_se ) || ( 'NOK' == get_woocommerce_currency() && $collector_b2c_no && $collector_b2b_no ) || ( 'EUR' == get_woocommerce_currency() && $collector_b2c_fi && $collector_b2b_fi ) ) {
 		return 'collector-b2c-b2b';
-	} elseif( ( 'SEK' == get_woocommerce_currency() && $collector_b2c_se ) || ( 'NOK' == get_woocommerce_currency() && $collector_b2c_no ) ) {
+	} elseif( ( 'SEK' == get_woocommerce_currency() && $collector_b2c_se ) || ( 'NOK' == get_woocommerce_currency() && $collector_b2c_no ) || ( 'DKK' == get_woocommerce_currency() && $collector_b2c_dk ) || ( 'EUR' == get_woocommerce_currency() && $collector_b2c_fi ) ) {
 		return 'collector-b2c';
-	} elseif( $collector_b2b_se || $collector_b2b_no ) {
+	} elseif( $collector_b2b_se || $collector_b2b_no || $collector_b2b_fi ) {
 		return 'collector-b2b';
 	}
 }
@@ -314,10 +322,13 @@ function wc_collector_get_default_customer_type() {
 	$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
 		
 	$default_customer_type 	= $collector_settings['collector_default_customer'];
-	$collector_b2c_se 		= $collector_settings['collector_merchant_id_se_b2c'];
-	$collector_b2b_se 		= $collector_settings['collector_merchant_id_se_b2b'];
-	$collector_b2c_no 		= $collector_settings['collector_merchant_id_no_b2c'];
-	$collector_b2b_no 		= $collector_settings['collector_merchant_id_no_b2b'];
+	$collector_b2c_se 		= ( isset( $collector_settings['collector_merchant_id_se_b2c'] ) ) ? $collector_settings['collector_merchant_id_se_b2c'] : '';
+	$collector_b2b_se 		= ( isset( $collector_settings['collector_merchant_id_se_b2b'] ) ) ? $collector_settings['collector_merchant_id_se_b2b'] : '';
+	$collector_b2c_no 		= ( isset( $collector_settings['collector_merchant_id_no_b2c'] ) ) ? $collector_settings['collector_merchant_id_no_b2c'] : '';
+	$collector_b2b_no 		= ( isset( $collector_settings['collector_merchant_id_no_b2b'] ) ) ? $collector_settings['collector_merchant_id_no_b2b'] : '';
+	$collector_b2c_dk 		= ( isset( $collector_settings['collector_merchant_id_dk_b2c'] ) ) ? $collector_settings['collector_merchant_id_dk_b2c'] : '';
+	$collector_b2c_fi 		= ( isset( $collector_settings['collector_merchant_id_fi_b2c'] ) ) ? $collector_settings['collector_merchant_id_fi_b2c'] : '';
+	$collector_b2b_fi 		= ( isset( $collector_settings['collector_merchant_id_fi_b2b'] ) ) ? $collector_settings['collector_merchant_id_fi_b2b'] : '';
 	
 	if( 'NOK' == get_woocommerce_currency() ) {
 		if( $collector_b2c_no && empty( $default_customer_type ) ) {
@@ -349,6 +360,26 @@ function wc_collector_get_default_customer_type() {
 		} else {
 			return 'b2c';
 		}
+	}
+
+	if( 'EUR' == get_woocommerce_currency() ) {
+		if( $collector_b2c_fi && empty( $default_customer_type ) ) {
+			return 'b2c';
+		} elseif( $collector_b2b_fi && empty( $default_customer_type ) ) {
+			return 'b2b';
+		} elseif( $collector_b2c_fi && 'b2c' == $default_customer_type ) {
+			return 'b2c';
+		} elseif( $collector_b2b_fi && 'b2b' == $default_customer_type ) {
+			return 'b2b';
+		} elseif( empty( $collector_b2c_fi ) && !empty( $collector_b2b_fi ) && 'b2c' == $default_customer_type ) {
+			return 'b2b';
+		} else {
+			return 'b2c';
+		}
+	}
+
+	if( 'DKK' == get_woocommerce_currency() ) {
+		return 'b2c';
 	}
 	
 }

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -40,8 +40,7 @@ function collector_wc_show_snippet() {
 		$request 		= $init_checkout->request();
 		
 		if ( is_wp_error( $request ) || empty( $request ) ) {
-			$return =  '<ul class="woocommerce-error"><li>' . sprintf( '%s <a href="%s" class="button wc-forward">%s</a>', __( 'Could not connect to Collector.', 'collector-checkout-for-woocommerce' ), wc_get_checkout_url(), __( 'Try again', 'collector-checkout-for-woocommerce' ) ) . '</li></ul>';
-			
+			$return =  '<ul class="woocommerce-error"><li>' . sprintf( '%s <a href="%s" class="button wc-forward">%s</a>', __( 'Could not connect to Collector. Error message: ', 'collector-checkout-for-woocommerce' ) . $request->get_error_message(), wc_get_checkout_url(), __( 'Try again', 'collector-checkout-for-woocommerce' ) ) . '</li></ul>';
 		} else {
 			$decode	= json_decode( $request );
 			WC()->session->set( 'collector_public_token', $decode->data->publicToken );

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -8,8 +8,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 function collector_wc_show_snippet() {
 	if( 'NOK' == get_woocommerce_currency() ) {
 		$locale = 'nb-NO';
+	} elseif( 'DKK' == get_woocommerce_currency() ) {
+		$locale = 'en-DK';
+	} elseif( 'EUR' == get_woocommerce_currency() ) {
+		$locale = 'fi-FI';
 	} else {
-		$locale = 'sv';
+		$locale = 'sv-SE';
 	}
 	
 	$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );

--- a/includes/collector-checkout-settings.php
+++ b/includes/collector-checkout-settings.php
@@ -85,6 +85,35 @@ $settings = array(
 		'default'       => '',
 		'desc_tip'      => true,
 	),
+	'fi_settings_title' => array(
+		'title'			=> __( 'Finland', 'collector-checkout-for-woocommerce' ),
+		'type'  		=> 'title',
+	),
+	'collector_merchant_id_fi_b2c'     => array(
+		'title'         => __( 'Merchant ID Finland B2C', 'collector-checkout-for-woocommerce' ),
+		'type'          => 'text',
+		'description'   => __( 'Enter your Collector Checkout Merchant ID for B2C purchases in Finland', 'collector-checkout-for-woocommerce' ),
+		'default'       => '',
+		'desc_tip'      => true,
+	),
+	'collector_merchant_id_fi_b2b'     => array(
+		'title'         => __( 'Merchant ID Finland B2B', 'collector-checkout-for-woocommerce' ),
+		'type'          => 'text',
+		'description'   => __( 'Enter your Collector Checkout Merchant ID for B2B purchases in Finland', 'collector-checkout-for-woocommerce' ),
+		'default'       => '',
+		'desc_tip'      => true,
+	),
+	'dk_settings_title' => array(
+		'title'			=> __( 'Denmark', 'collector-checkout-for-woocommerce' ),
+		'type'  		=> 'title',
+	),
+	'collector_merchant_id_dk_b2c'     => array(
+		'title'         => __( 'Merchant ID Denmark B2C', 'collector-checkout-for-woocommerce' ),
+		'type'          => 'text',
+		'description'   => __( 'Enter your Collector Checkout Merchant ID for B2C purchases in Denmark', 'collector-checkout-for-woocommerce' ),
+		'default'       => '',
+		'desc_tip'      => true,
+	),
 	'checkout_settings_title' => array(
 		'title' => __( 'Checkout settings', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',

--- a/includes/collector-checkout-settings.php
+++ b/includes/collector-checkout-settings.php
@@ -6,165 +6,187 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Settings for Collector Checkout
  */
-
-return apply_filters( 'collector_checkout_settings',
-	array(
-		'enabled' => array(
-			'title'   => __( 'Enable/Disable', 'collector-checkout-for-woocommerce' ),
-			'type'    => 'checkbox',
-			'label'   => __( 'Enable Collector Checkout', 'collector-checkout-for-woocommerce' ),
-			'default' => 'no',
+$settings = array(
+	'enabled' => array(
+		'title'   => __( 'Enable/Disable', 'collector-checkout-for-woocommerce' ),
+		'type'    => 'checkbox',
+		'label'   => __( 'Enable Collector Checkout', 'collector-checkout-for-woocommerce' ),
+		'default' => 'no',
+	),
+	'title'   => array(
+		'title'         => __( 'Title', 'collector-checkout-for-woocommerce' ),
+		'type'          => 'text',
+		'description'   => __( 'This is the title that the user sees on the checkout page for Collector Checkout.', 'collector-checkout-for-woocommerce' ),
+		'default'       => __( 'Collector Checkout', 'collector-checkout-for-woocommerce' ),
+	),
+	/*
+	'description' => array(
+		'title'         => __( 'Description', 'collector-checkout-for-woocommerce' ),
+		'type'          => 'text',
+		'description'   => __( 'This controls the description which the user sees during checkout.', 'krokedil-ecster-pay-for-woocommerce' ),
+		'default'       => __( 'Pay using Collector Checkout.', 'collector-checkout-for-woocommerce' ),
+		'desc_tip'      => true,
+	),
+	*/
+	'collector_username'  => array(
+		'title'         => __( 'Username', 'collector-checkout-for-woocommerce' ),
+		'type'          => 'text',
+		'description'   => __( 'Enter your Collector Checkout Username', 'collector-checkout-for-woocommerce' ),
+		'default'       => '',
+		'desc_tip'      => true,
+	),
+	'collector_password'     => array(
+		'title'         => __( 'Password', 'collector-checkout-for-woocommerce' ),
+		'type'          => 'text',
+		'description'   => __( 'Enter your Collector Checkout Password', 'collector-checkout-for-woocommerce' ),
+		'default'       => '',
+		'desc_tip'      => true,
+	),
+	'collector_shared_key'     => array(
+		'title'         => __( 'Shared Key', 'collector-checkout-for-woocommerce' ),
+		'type'          => 'text',
+		'description'   => __( 'Enter your Collector Checkout Shared Key', 'collector-checkout-for-woocommerce' ),
+		'default'       => '',
+		'desc_tip'      => true,
+	),
+	'se_settings_title' => array(
+		'title'			=> __( 'Sweden', 'collector-checkout-for-woocommerce' ),
+		'type'  		=> 'title',
+	),
+	'collector_merchant_id_se_b2c'     => array(
+		'title'         => __( 'Merchant ID Sweden B2C', 'collector-checkout-for-woocommerce' ),
+		'type'          => 'text',
+		'description'   => __( 'Enter your Collector Checkout Merchant ID for B2C purchases in Sweden', 'collector-checkout-for-woocommerce' ),
+		'default'       => '',
+		'desc_tip'      => true,
+	),
+	'collector_merchant_id_se_b2b'     => array(
+		'title'         => __( 'Merchant ID Sweden B2B', 'collector-checkout-for-woocommerce' ),
+		'type'          => 'text',
+		'description'   => __( 'Enter your Collector Checkout Merchant ID for B2B purchases in Sweden', 'collector-checkout-for-woocommerce' ),
+		'default'       => '',
+		'desc_tip'      => true,
+	),
+	'no_settings_title' => array(
+		'title' => __( 'Norway', 'collector-checkout-for-woocommerce' ),
+		'type'  => 'title',
+	),
+	'collector_merchant_id_no_b2c'     => array(
+		'title'         => __( 'Merchant ID Norway B2C', 'collector-checkout-for-woocommerce' ),
+		'type'          => 'text',
+		'description'   => __( 'Enter your Collector Checkout Merchant ID for B2C purchases in Norway', 'collector-checkout-for-woocommerce' ),
+		'default'       => '',
+		'desc_tip'      => true,
+	),
+	'collector_merchant_id_no_b2b'     => array(
+		'title'         => __( 'Merchant ID Norway B2B', 'collector-checkout-for-woocommerce' ),
+		'type'          => 'text',
+		'description'   => __( 'Enter your Collector Checkout Merchant ID for B2B purchases in Norway', 'collector-checkout-for-woocommerce' ),
+		'default'       => '',
+		'desc_tip'      => true,
+	),
+	'checkout_settings_title' => array(
+		'title' => __( 'Checkout settings', 'collector-checkout-for-woocommerce' ),
+		'type'  => 'title',
+	),
+	'collector_invoice_fee' => array(
+		'title'         => __( 'Invoice fee ID', 'collector-checkout-for-woocommerce' ),
+		'type'          => 'text',
+		'description'   => sprintf( __( 'Create a hidden (simple) product that acts as the invoice fee. Enter the product <strong>ID</strong> number in this textfield. Leave blank to disable. <a href="%s" target="_blank">Read more</a>.', 'collector-checkout-for-woocommerce' ), 'http://docs.krokedil.com/documentation/collector-checkout-for-woocommerce/#8' ),
+		'default'       => '',
+		'desc_tip'      => false,
+	),
+	'collector_default_customer'   	=> array(
+		'title'         => __( 'Default customer', 'collector-checkout-for-woocommerce' ),
+		'type'          => 'select',
+		'description' 	=> __( 'Sets the default customer/checkout type for Collector Checkout (if offering both B2B & B2C)', 'collector-checkout-for-woocommerce' ),
+		'options' => array(
+			'b2c'   => __( 'B2C', 'collector-checkout-for-woocommerce' ),
+			'b2b'   => __( 'B2B', 'collector-checkout-for-woocommerce' ),
 		),
-		'title'   => array(
-			'title'         => __( 'Title', 'collector-checkout-for-woocommerce' ),
-			'type'          => 'text',
-			'description'   => __( 'This is the title that the user sees on the checkout page for Collector Checkout.', 'collector-checkout-for-woocommerce' ),
-			'default'       => __( 'Collector Checkout', 'collector-checkout-for-woocommerce' ),
-		),
-		/*
-		'description' => array(
-			'title'         => __( 'Description', 'collector-checkout-for-woocommerce' ),
-			'type'          => 'text',
-			'description'   => __( 'This controls the description which the user sees during checkout.', 'krokedil-ecster-pay-for-woocommerce' ),
-			'default'       => __( 'Pay using Collector Checkout.', 'collector-checkout-for-woocommerce' ),
-			'desc_tip'      => true,
-		),
-		*/
-		'collector_username'  => array(
-			'title'         => __( 'Username', 'collector-checkout-for-woocommerce' ),
-			'type'          => 'text',
-			'description'   => __( 'Enter your Collector Checkout Username', 'collector-checkout-for-woocommerce' ),
-			'default'       => '',
-			'desc_tip'      => true,
-		),
-		'collector_password'     => array(
-			'title'         => __( 'Password', 'collector-checkout-for-woocommerce' ),
-			'type'          => 'text',
-			'description'   => __( 'Enter your Collector Checkout Password', 'collector-checkout-for-woocommerce' ),
-			'default'       => '',
-			'desc_tip'      => true,
-		),
-		'collector_shared_key'     => array(
-			'title'         => __( 'Shared Key', 'collector-checkout-for-woocommerce' ),
-			'type'          => 'text',
-			'description'   => __( 'Enter your Collector Checkout Shared Key', 'collector-checkout-for-woocommerce' ),
-			'default'       => '',
-			'desc_tip'      => true,
-		),
-		'se_settings_title' => array(
-			'title'			=> __( 'Sweden', 'collector-checkout-for-woocommerce' ),
-			'type'  		=> 'title',
-		),
-		'collector_merchant_id_se_b2c'     => array(
-			'title'         => __( 'Merchant ID Sweden B2C', 'collector-checkout-for-woocommerce' ),
-			'type'          => 'text',
-			'description'   => __( 'Enter your Collector Checkout Merchant ID for B2C purchases in Sweden', 'collector-checkout-for-woocommerce' ),
-			'default'       => '',
-			'desc_tip'      => true,
-		),
-		'collector_merchant_id_se_b2b'     => array(
-			'title'         => __( 'Merchant ID Sweden B2B', 'collector-checkout-for-woocommerce' ),
-			'type'          => 'text',
-			'description'   => __( 'Enter your Collector Checkout Merchant ID for B2B purchases in Sweden', 'collector-checkout-for-woocommerce' ),
-			'default'       => '',
-			'desc_tip'      => true,
-		),
-		'no_settings_title' => array(
-			'title' => __( 'Norway', 'collector-checkout-for-woocommerce' ),
-			'type'  => 'title',
-		),
-		'collector_merchant_id_no_b2c'     => array(
-			'title'         => __( 'Merchant ID Norway B2C', 'collector-checkout-for-woocommerce' ),
-			'type'          => 'text',
-			'description'   => __( 'Enter your Collector Checkout Merchant ID for B2C purchases in Norway', 'collector-checkout-for-woocommerce' ),
-			'default'       => '',
-			'desc_tip'      => true,
-		),
-		'collector_merchant_id_no_b2b'     => array(
-			'title'         => __( 'Merchant ID Norway B2B', 'collector-checkout-for-woocommerce' ),
-			'type'          => 'text',
-			'description'   => __( 'Enter your Collector Checkout Merchant ID for B2B purchases in Norway', 'collector-checkout-for-woocommerce' ),
-			'default'       => '',
-			'desc_tip'      => true,
-		),
-		'checkout_settings_title' => array(
-			'title' => __( 'Checkout settings', 'collector-checkout-for-woocommerce' ),
-			'type'  => 'title',
-		),
-		'collector_invoice_fee' => array(
-			'title'         => __( 'Invoice fee ID', 'collector-checkout-for-woocommerce' ),
-			'type'          => 'text',
-			'description'   => sprintf( __( 'Create a hidden (simple) product that acts as the invoice fee. Enter the product <strong>ID</strong> number in this textfield. Leave blank to disable. <a href="%s" target="_blank">Read more</a>.', 'collector-checkout-for-woocommerce' ), 'http://docs.krokedil.com/documentation/collector-checkout-for-woocommerce/#8' ),
-			'default'       => '',
-			'desc_tip'      => false,
-		),
-		'collector_default_customer'   	=> array(
-			'title'         => __( 'Default customer', 'collector-checkout-for-woocommerce' ),
-			'type'          => 'select',
-			'description' 	=> __( 'Sets the default customer/checkout type for Collector Checkout (if offering both B2B & B2C)', 'collector-checkout-for-woocommerce' ),
-			'options' => array(
-				'b2c'   => __( 'B2C', 'collector-checkout-for-woocommerce' ),
-				'b2b'   => __( 'B2B', 'collector-checkout-for-woocommerce' ),
-			),
-			'default'       => 'b2c',
-		),
-		'instnt_buy_settings_title' => array(
-			'title' => __( 'Instant Buy settings', 'collector-checkout-for-woocommerce' ),
-			'type'  => 'title',
-		),
-		'collector_instant_checkout' => array(
-			'title'         => __( 'Instant Buy', 'collector-checkout-for-woocommerce' ),
-			'type'          => 'checkbox',
-			'label'         => __( 'Enable Instant Buy feature on single product pages', 'collector-checkout-for-woocommerce' ),
-			'default'       => 'no',
-			'desc_tip'    	=> true
-		),
-		'button_color'             => array(
-			'title'       	=> __( 'Button color', 'collector-checkout-for-woocommerce' ),
-			'type'        	=> 'color',
-			'description' 	=> __( 'Instant Buy button color. Leave blank to use your theme <em>Add to cart</em> button color.', 'collector-checkout-for-woocommerce' ),
-			'default'     	=> '',
-			'desc_tip'    	=> true
-		),
-		'button_color_text'        => array(
-			'title'       	=> __( 'Button text color', 'collector-checkout-for-woocommerce' ),
-			'type'        	=> 'color',
-			'description' 	=> __( 'Instant Buy button text color', 'collector-checkout-for-woocommerce' ),
-			'default'     	=> '',
-			'desc_tip'    	=> true
-		),
-		'order_management_settings_title' => array(
-			'title' 		=> __( 'Order management settings', 'collector-checkout-for-woocommerce' ),
-			'type'  		=> 'title',
-		),
-		'manage_collector_orders' => array(
-			'title'         => __( 'Manage orders', 'collector-checkout-for-woocommerce' ),
-			'type'          => 'checkbox',
-			'label'         => __( 'Enable WooCommerce to manage orders in Collectors backend (when order status changes to Cancelled and Completed in WooCommerce).', 'collector-checkout-for-woocommerce' ),
-			'default'       => 'yes',
-		),
-		'display_invoice_no' => array(
-			'title'         => __( 'Invoice number on order page', 'collector-checkout-for-woocommerce' ),
-			'type'          => 'checkbox',
-			'label'         => __( 'Display Collector Invoice Number after WooCommerce Order Number on WooCommerce order page (-> WooCommerce -> Orders).', 'collector-checkout-for-woocommerce' ),
-			'default'       => 'yes',
-		),
-		'test_mode_settings_title' => array(
-			'title' => __( 'Test Mode Settings', 'collector-checkout-for-woocommerce' ),
-			'type'  => 'title',
-		),
-		'test_mode'         => array(
-			'title'         => __( 'Test mode', 'collector-checkout-for-woocommerce' ),
-			'type'          => 'checkbox',
-			'label'         => __( 'Enable Test mode for Collector Checkout.', 'collector-checkout-for-woocommerce' ),
-			'default'       => 'no',
-		),
-		'debug_mode'       	=> array(
-			'title'         => __( 'Debug', 'collector-checkout-for-woocommerce' ),
-			'type'          => 'checkbox',
-			'label'       	=> __( 'Enable logging.', 'collector-checkout-for-woocommerce' ),
-			'description' 	=> sprintf( __( 'Log Collector events, in <code>%s</code>', 'collector-checkout-for-woocommerce' ), wc_get_log_file_path( 'collector_checkout' ) ),
-			'default'       => 'no',
-		),
-	)
+		'default'       => 'b2c',
+	),
+	'instnt_buy_settings_title' => array(
+		'title' => __( 'Instant Buy settings', 'collector-checkout-for-woocommerce' ),
+		'type'  => 'title',
+	),
+	'collector_instant_checkout' => array(
+		'title'         => __( 'Instant Buy', 'collector-checkout-for-woocommerce' ),
+		'type'          => 'checkbox',
+		'label'         => __( 'Enable Instant Buy feature on single product pages', 'collector-checkout-for-woocommerce' ),
+		'default'       => 'no',
+		'desc_tip'    	=> true
+	),
+	'button_color'             => array(
+		'title'       	=> __( 'Button color', 'collector-checkout-for-woocommerce' ),
+		'type'        	=> 'color',
+		'description' 	=> __( 'Instant Buy button color. Leave blank to use your theme <em>Add to cart</em> button color.', 'collector-checkout-for-woocommerce' ),
+		'default'     	=> '',
+		'desc_tip'    	=> true
+	),
+	'button_color_text'        => array(
+		'title'       	=> __( 'Button text color', 'collector-checkout-for-woocommerce' ),
+		'type'        	=> 'color',
+		'description' 	=> __( 'Instant Buy button text color', 'collector-checkout-for-woocommerce' ),
+		'default'     	=> '',
+		'desc_tip'    	=> true
+	),
+	'order_management_settings_title' => array(
+		'title' 		=> __( 'Order management settings', 'collector-checkout-for-woocommerce' ),
+		'type'  		=> 'title',
+	),
+	'manage_collector_orders' => array(
+		'title'         => __( 'Manage orders', 'collector-checkout-for-woocommerce' ),
+		'type'          => 'checkbox',
+		'label'         => __( 'Enable WooCommerce to manage orders in Collectors backend (when order status changes to Cancelled and Completed in WooCommerce).', 'collector-checkout-for-woocommerce' ),
+		'default'       => 'yes',
+	),
+	'display_invoice_no' => array(
+		'title'         => __( 'Invoice number on order page', 'collector-checkout-for-woocommerce' ),
+		'type'          => 'checkbox',
+		'label'         => __( 'Display Collector Invoice Number after WooCommerce Order Number on WooCommerce order page (-> WooCommerce -> Orders).', 'collector-checkout-for-woocommerce' ),
+		'default'       => 'yes',
+	),
+	'test_mode_settings_title' => array(
+		'title' => __( 'Test Mode Settings', 'collector-checkout-for-woocommerce' ),
+		'type'  => 'title',
+	),
+	'test_mode'         => array(
+		'title'         => __( 'Test mode', 'collector-checkout-for-woocommerce' ),
+		'type'          => 'checkbox',
+		'label'         => __( 'Enable Test mode for Collector Checkout.', 'collector-checkout-for-woocommerce' ),
+		'default'       => 'no',
+	),
+	'debug_mode'       	=> array(
+		'title'         => __( 'Debug', 'collector-checkout-for-woocommerce' ),
+		'type'          => 'checkbox',
+		'label'       	=> __( 'Enable logging.', 'collector-checkout-for-woocommerce' ),
+		'description' 	=> sprintf( __( 'Log Collector events, in <code>%s</code>', 'collector-checkout-for-woocommerce' ), wc_get_log_file_path( 'collector_checkout' ) ),
+		'default'       => 'no',
+	),
 );
+
+$wc_version = defined( 'WC_VERSION' ) && WC_VERSION ? WC_VERSION : null;
+
+if ( version_compare( $wc_version, '3.4', '>=' ) ) {
+	$new_settings = array();
+	foreach ( $settings as $key => $value ) {
+		$new_settings[ $key ] = $value;
+		if ( 'collector_shared_key' === $key ) {
+			$new_settings['display_privacy_policy_text'] = array(
+				'title'   => __( 'Display checkout privacy policy text', 'collector-checkout-for-woocommerce' ),
+				'label'   => __( 'Select if you want to show the <em>Checkout privacy policy</em> text on the checkout page, and where you want to display it.', 'collector-checkout-for-woocommerce' ),
+				'type'    => 'select',
+				'default' => 'no',
+				'options' => array(
+					'no'    => __( 'Do not display', 'collector-checkout-for-woocommerce' ),
+					'above' => __( 'Display above checkout', 'collector-checkout-for-woocommerce' ),
+					'below' => __( 'Display below checkout', 'collector-checkout-for-woocommerce' ),
+				),
+			);
+		}
+	}
+	$settings = $new_settings;
+}
+
+return apply_filters( 'collector_checkout_settings', $settings );

--- a/readme.txt
+++ b/readme.txt
@@ -2,11 +2,11 @@
 Contributors: collectorbank, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, collector, checkout
 Requires at least: 4.7
-Tested up to: 4.9.6
+Tested up to: 4.9.8
 Requires PHP: 5.6
 Stable tag: trunk
 WC requires at least: 3.0.0
-WC tested up to: 3.4.0
+WC tested up to: 3.4.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -39,6 +39,17 @@ For help setting up and configuring Collector Checkout for WooCommerce please re
 
 
 == CHANGELOG ==
+= 2018.05.17  	- version 1.1.0 =
+* Feature		- Added support for B2C B2B Finland.
+* Feature		- Added support for B2C Denmark.
+* Feature		- Added setting for displaying privacy policy text in checkout.
+* Tweak			- Display response message in frontend if response code isn’t 200 on initialize checkout request.
+* Tweak			- Improved http response for anti-fraud control (respons with 404 if Woo order hasn't been created yet).
+* Tweak			- Improved error messaging/logging when request to Collector fails.
+* Fix			- Maybe define constant WOOCOMMERCE_CHECKOUT in ajax functions.
+* Fix			- Check if function get_current_screen() exist before tying to add collector invoice number to WC order number.
+
+
 = 2018.05.17  	- version 1.0.0 =
 * Feature		- Add support for B2B Norway.
 * Feature		- Add support for wp_add_privacy_policy_content (for GDPR compliance). More info: https://core.trac.wordpress.org/attachment/ticket/43473/PRIVACY-POLICY-CONTENT-HOOK.md.

--- a/templates/form-checkout.php
+++ b/templates/form-checkout.php
@@ -25,6 +25,7 @@ do_action( 'collector_wc_before_checkout_form' );
 		if ( count( $available_payment_gateways ) > 1 ){ ?>
             <a class="button" id="collector_change_payment_method" href="#"><?php  echo __( 'Select another payment method', 'collector-checkout-for-woocommerce' ) ?></a>
 		<?php } ?>
+		<?php do_action( 'collector_wc_before_iframe' ); ?>
 		<?php if( 'collector-b2c-b2b' == wc_collector_get_available_customer_types() ) { ?>
             <ul class="collector-checkout-tabs">
                 <li class="tab-link current" data-tab="b2c"><?php _e( 'Privatperson', 'woocommerce' ); ?></li>
@@ -34,6 +35,7 @@ do_action( 'collector_wc_before_checkout_form' );
         <div id="collector-bank-iframe">
 	        <?php collector_wc_show_snippet(); ?>
         </div>
+		<?php do_action( 'collector_wc_after_iframe' ); ?>
 
     </form>
 


### PR DESCRIPTION
* Feature	- Added support for B2C B2B Finland.
* Feature	- Added support for B2C Denmark.
* Feature	- Added setting for displaying privacy policy text in checkout.
* Tweak - Display response message in frontend if response code isn’t 200 on initialize checkout request.
* Tweak - Improved http response for anti-fraud control (respons with 404 if Woo order hasn't been created yet).
* Tweak - Improved error messaging/logging when request to Collector fails.
* Fix - Maybe define constant WOOCOMMERCE_CHECKOUT in ajax functions.
* Fix - Check if function get_current_screen() exist before tying to add collector invoice number to WC order number.