### PR TITLE
V1.1.1

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -294,7 +294,7 @@
             if (true === data.success) {
 		            var datastring = 'billing_first_name=' + data.data.customer_data.billingFirstName +
                     '&billing_last_name=' + data.data.customer_data.billingLastName +
-                    '&billing_company=' + data.data.customer_data.companyName +
+                    '&billing_company=' + data.data.customer_data.billingCompanyName +
                     '&billing_country=' + data.data.customer_data.countryCode +
                     '&billing_address_1=' + data.data.customer_data.billingAddress +
                     '&billing_postcode=' + data.data.customer_data.billingPostalCode +
@@ -303,7 +303,7 @@
                     '&billing_email=' + data.data.customer_data.email +
                     '&shipping_first_name=' + data.data.customer_data.shippingFirstName +
                     '&shipping_last_name=' + data.data.customer_data.shippingLastName +
-                    '&shipping_company=' + data.data.customer_data.companyName +
+                    '&shipping_company=' + data.data.customer_data.shippingCompanyName +
                     '&shipping_country=' + data.data.customer_data.countryCode +
                     '&shipping_address_1=' + data.data.customer_data.shippingAddress +
                     '&shipping_postcode=' + data.data.customer_data.shippingPostalCode +

--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -380,7 +380,8 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 			$billing_postal_code    = isset( $customer_data['customer_data']->data->customer->billingAddress->postalCode ) ? $customer_data['customer_data']->data->customer->billingAddress->postalCode : isset( $customer_data['customer_data']->data->customer->deliveryAddress->postalCode ) ? $customer_data['customer_data']->data->customer->deliveryAddress->postalCode : $fallback_postcode;
 			$billing_city           = isset( $customer_data['customer_data']->data->customer->billingAddress->city ) ? $customer_data['customer_data']->data->customer->billingAddress->city : isset( $customer_data['customer_data']->data->customer->deliveryAddress->city ) ? $customer_data['customer_data']->data->customer->deliveryAddress->city : '.';
 
-			$company_name           = '';
+			$billing_company_name   = '';
+			$shipping_company_name  = '';
 			$org_nr                 = '';
 
 			$phone                  = isset( $customer_data['customer_data']->data->customer->mobilePhoneNumber ) ? $customer_data['customer_data']->data->customer->mobilePhoneNumber : '.';
@@ -397,9 +398,10 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 
 			$billing_first_name     = isset( $customer_data['customer_data']->data->businessCustomer->firstName ) ? $customer_data['customer_data']->data->businessCustomer->firstName : '.';
 			$billing_last_name      = isset( $customer_data['customer_data']->data->businessCustomer->lastName ) ? $customer_data['customer_data']->data->businessCustomer->lastName : '.';
+			$billing_company_name   = isset( $customer_data['customer_data']->data->businessCustomer->companyName ) ? $customer_data['customer_data']->data->businessCustomer->companyName : '.';
 			$shipping_first_name    = isset( $customer_data['customer_data']->data->businessCustomer->firstName ) ? $customer_data['customer_data']->data->businessCustomer->firstName : '.';
 			$shipping_last_name     = isset( $customer_data['customer_data']->data->businessCustomer->lastName ) ? $customer_data['customer_data']->data->businessCustomer->lastName : '.';
-			$company_name           = isset( $customer_data['customer_data']->data->businessCustomer->companyName ) ? $customer_data['customer_data']->data->businessCustomer->companyName : '.';
+			$shipping_company_name  = isset( $customer_data['customer_data']->data->businessCustomer->deliveryAddress->companyName ) ? $customer_data['customer_data']->data->businessCustomer->deliveryAddress->companyName : $customer_data['customer_data']->data->businessCustomer->companyName;
 			$phone                  = isset( $customer_data['customer_data']->data->businessCustomer->mobilePhoneNumber ) ? $customer_data['customer_data']->data->businessCustomer->mobilePhoneNumber : '.';
 			$email                  = isset( $customer_data['customer_data']->data->businessCustomer->email ) ? $customer_data['customer_data']->data->businessCustomer->email : '.';
 
@@ -415,13 +417,14 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 		$customer_information = array(
 			'billingFirstName'      =>  $billing_first_name,
 			'billingLastName'       =>  $billing_last_name,
-			'companyName'           =>  $company_name,
+			'billingCompanyName'    =>  $billing_company_name,
 			'billingAddress'        =>  $billing_address,
 			'billingAddress2'       =>  $billing_address2,
 			'billingPostalCode'     =>  $billing_postal_code,
 			'billingCity'           =>  $billing_city,
 			'shippingFirstName'     =>  $shipping_first_name,
 			'shippingLastName'      =>  $shipping_last_name,
+			'shippingCompanyName'   =>  $shipping_company_name,
 			'shippingAddress'       =>  $shipping_address,
 			'shippingAddress2'      =>  $shipping_address2,
 			'shippingPostalCode'    =>  $shipping_postal_code,

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'COLLECTOR_BANK_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'COLLECTOR_BANK_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'COLLECTOR_BANK_VERSION', '1.1.0' );
+define( 'COLLECTOR_BANK_VERSION', '1.1.1' );
 
 if ( ! class_exists( 'Collector_Checkout' ) ) {
 	class Collector_Checkout {

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:     Collector Checkout for WooCommerce
  * Plugin URI:      https://krokedil.se/collector/
  * Description:     Extends WooCommerce. Provides a <a href="https://www.collector.se/" target="_blank">Collector Checkout</a> checkout for WooCommerce.
- * Version:         1.1.0
+ * Version:         1.1.1
  * Author:          Krokedil
  * Author URI:      https://krokedil.se/
  * Text Domain:     collector-checkout-for-woocommerce

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,10 @@ For help setting up and configuring Collector Checkout for WooCommerce please re
 
 
 == CHANGELOG ==
+= 2018.08.14  	- version 1.1.1 =
+* Fix 			- Save Shipping company name correctly in WooCommerce order.
+* Fix			- Prevent duplicate orders if Collector confirmation page is reloaded manually by customer during create Woo order process.
+
 = 2018.05.17  	- version 1.1.0 =
 * Feature		- Added support for B2C B2B Finland.
 * Feature		- Added support for B2C Denmark.


### PR DESCRIPTION
* Fix - Save Shipping company name correctly in WooCommerce order.
* Fix	- Prevent duplicate orders if Collector confirmation page is reloaded manually by customer during create Woo order process.