### PR TITLE
Version 1.5.0

### DIFF
--- a/classes/class-collector-checkout-api-callbacks.php
+++ b/classes/class-collector-checkout-api-callbacks.php
@@ -340,7 +340,7 @@ class Collector_Api_Callbacks {
 	 * Set order status function
 	 */
 	public function set_order_status( $order, $collector_order ) {
-		if ( 'Preliminary' === $collector_order->data->purchase->result ) {
+		if ( 'Preliminary' === $collector_order->data->purchase->result || 'Completed' === $collector_order->data->purchase->result ) {
 			$order->payment_complete( $collector_order->data->purchase->purchaseIdentifier );
 			$order->add_order_note( 'Payment via Collector Checkout. Payment ID: ' . sanitize_key( $collector_order->data->purchase->purchaseIdentifier ) );
 			Collector_Checkout::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to Processing/Completed.' );

--- a/classes/class-collector-checkout-confirmation.php
+++ b/classes/class-collector-checkout-confirmation.php
@@ -372,11 +372,15 @@ class Collector_Checkout_Confirmation {
 	 * Saves Collector data to WooCommerce order as meta field.
 	 *
 	 * @param string $order_id WooCommerce order id.
-	 * @param array  $data  Posted data.
 	 */
 	public function save_collector_order_data( $order_id ) {
+		$order = wc_get_order( $order_id );
+
+		if ( 'collector_checkout' !== $order->get_payment_method() ) {
+			return;
+		}
+
 		if ( method_exists( WC()->session, 'get' ) ) {
-			$order = wc_get_order( $order_id );
 
 			if ( WC()->session->get( 'collector_private_id' ) ) {
 

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -20,6 +20,22 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 			'refunds',
 		);
 
+		if( null !== get_current_screen() ) {
+			
+			$current_screen = get_current_screen();
+			
+			if( 'shop_order' === $current_screen->post_type && ( isset($_GET['action']) && 'edit' === $_GET['action'] ) && isset($_GET['post'])) {
+				
+				$order_id = $_GET['post'];
+				$order = wc_get_order( $order_id );
+				if ( 'collector_checkout' === $order->get_payment_method() && 'Swish' === get_post_meta( $order_id, '_collector_payment_method', true ) ) {
+					if (($key = array_search('refunds', $this->supports)) !== false) {
+						unset($this->supports[$key]);
+					}
+				}
+			}
+		}	
+
 		add_action(
 			'woocommerce_update_options_payment_gateways_' . $this->id,
 			array(

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -47,6 +47,7 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 		// Function to handle the thankyou page.
 		add_action( 'woocommerce_thankyou_collector_checkout', array( $this, 'collector_thankyou' ) );
 		add_filter( 'woocommerce_thankyou_order_received_text', array( $this, 'collector_thankyou_order_received_text' ), 10, 2 );
+		add_action( 'woocommerce_thankyou', array( $this, 'maybe_delete_collector_sessions' ), 100, 1 );
 
 		// Body class
 		add_filter( 'body_class', array( $this, 'add_body_class' ) );
@@ -262,14 +263,23 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 				update_post_meta( $order_id, '_collector_invoice_reference', $invoice_reference );
 				WC()->session->__unset( 'collector_invoice_reference' );
 			}
-			// Unset Collector token and id
-			wc_collector_unset_sessions();
 
 		} else {
 			// @todo - add logging here.
 			Collector_Checkout::log( 'collector_thankyou page hit but collector_private_id session not existing.' );
 		}
 
+	}
+
+	/**
+	 * Delete the Collector stored sessions.
+	 *
+	 * @param int $order_id WooCommerce order id.
+	 * @return void
+	 */
+	public function maybe_delete_collector_sessions( $order_id ) {
+		// Unset Collector token and id.
+		wc_collector_unset_sessions();
 	}
 
 	/**

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -206,7 +206,7 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 			}
 
 			if ( ! $order->has_status( 'on-hold' ) ) {
-				if ( 'Preliminary' == $payment_status ) {
+				if ( 'Preliminary' === $payment_status || 'Completed' === $payment_status ) {
 					$order->payment_complete( $payment_id );
 				} elseif ( 'Signing' == $payment_status ) {
 					$order->add_order_note( __( 'Order is waiting for electronic signing by customer. Payment ID: ', 'woocommerce-gateway-klarna' ) . $payment_id );

--- a/classes/class-collector-checkout-post-checkout.php
+++ b/classes/class-collector-checkout-post-checkout.php
@@ -28,6 +28,13 @@ class Collector_Checkout_Post_Checkout {
 				$order->add_order_note( __( 'Could not activate Collector reservation, Collector reservation is already activated.', 'collector-checkout-for-woocommerce' ) );
 				return;
 			}
+
+			$collector_payment_method = get_post_meta( $order_id, '_collector_payment_method', true );
+			if ( 'Swish' === $collector_payment_method ) {
+				$order->add_order_note( sprintf( __( 'No activation needed in Collector\'s system since %s payments is charged directly during purchase.', 'dibs-easy-for-woocommerce' ), $collector_payment_method ) );
+				return;
+			}
+
 			$activate_order = new Collector_Checkout_SOAP_Requests_Activate_Invoice( $order_id );
 			$activate_order->request( $order_id );
 		}
@@ -38,6 +45,12 @@ class Collector_Checkout_Post_Checkout {
 		if ( 'collector_checkout' === $order->get_payment_method() ) {
 			if ( get_post_meta( $order_id, '_collector_order_cancelled', true ) ) {
 				$order->add_order_note( __( 'Could not cancel Collector reservation, Collector reservation is already cancelled.', 'collector-checkout-for-woocommerce' ) );
+				return;
+			}
+
+			$collector_payment_method = get_post_meta( $order_id, '_collector_payment_method', true );
+			if ( 'Swish' === $collector_payment_method ) {
+				$order->add_order_note( sprintf( __( 'No cancellation performed in Collector\'s system. %1$s payments should be manually handled directly with %1$s/your bank.', 'dibs-easy-for-woocommerce' ), $collector_payment_method ) );
 				return;
 			}
 			$cancel_order = new Collector_Checkout_SOAP_Requests_Cancel_Invoice( $order_id );

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -8,16 +8,16 @@
  * Plugin Name:     Collector Checkout for WooCommerce
  * Plugin URI:      https://krokedil.se/collector/
  * Description:     Extends WooCommerce. Provides a <a href="https://www.collector.se/" target="_blank">Collector Checkout</a> checkout for WooCommerce.
- * Version:         1.4.3
+ * Version:         1.5.0
  * Author:          Krokedil
  * Author URI:      https://krokedil.se/
  * Text Domain:     collector-checkout-for-woocommerce
  * Domain Path:     /languages
  *
  * WC requires at least: 3.0.0
- * WC tested up to: 3.9.0
+ * WC tested up to: 3.9.2
  *
- * Copyright:       © 2017-2019 Krokedil.
+ * Copyright:       © 2017-2020 Krokedil.
  * License:         GNU General Public License v3.0
  * License URI:     http://www.gnu.org/licenses/gpl-3.0.html
  */
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'COLLECTOR_BANK_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'COLLECTOR_BANK_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'COLLECTOR_BANK_VERSION', '1.4.3' );
+define( 'COLLECTOR_BANK_VERSION', '1.5.0' );
 
 if ( ! class_exists( 'Collector_Checkout' ) ) {
 	class Collector_Checkout {

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -81,9 +81,17 @@ function collector_wc_show_snippet() {
  * Unset Collector public token and private id
  */
 function wc_collector_unset_sessions() {
-	WC()->session->__unset( 'collector_public_token' );
-	WC()->session->__unset( 'collector_private_id' );
-	WC()->session->__unset( 'collector_currency' );
+	if ( method_exists( WC()->session, '__unset' ) ) {
+		if ( WC()->session->get( 'collector_public_token' ) ) {
+			WC()->session->__unset( 'collector_public_token' );
+		}
+		if ( WC()->session->get( 'collector_private_id' ) ) {
+			WC()->session->__unset( 'collector_private_id' );
+		}
+		if ( WC()->session->get( 'collector_currency' ) ) {
+			WC()->session->__unset( 'collector_currency' );
+		}
+	}
 }
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 5.3.2
 Requires PHP: 5.6
 Stable tag: trunk
 WC requires at least: 3.0.0
-WC tested up to: 3.8.1
+WC tested up to: 3.9.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -39,6 +39,12 @@ For help setting up and configuring Collector Checkout for WooCommerce please re
 
 
 == CHANGELOG ==
+= 2020.02.19    - versiom 1.5.0 =
+* Feature       - Added support for Swish as external payment method in the checkout.
+* Tweak         - Trigger payment_complete() ofr Collector orders with the status of "Completed".
+* Fix           - Delete sessions related to Collector on order received page, even when Collector isn't the selected payment gateway for the order.
+* Fix           - Don't try to save Collector specific info to order if other payment method is used.
+
 = 2020.01.30    - versiom 1.4.3 =
 * Enhancement   - Saving shipping reference to order as post meta. (Support for refunds made on orders with "Table Rate Shipping" as the shipping).
 * Fix           - Improved logic for when shipping gets created via API Callback.


### PR DESCRIPTION
* Feature - Added support for Swish as external payment method in the checkout.
* Tweak - Trigger payment_complete() ofr Collector orders with the status of "Completed".
* Fix - Delete sessions related to Collector on order received page, even when Collector isn't the selected payment gateway for the order.
* Fix - Don't try to save Collector specific info to order if other payment method is used.