### PR TITLE
V1.5.1

### DIFF
--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -20,7 +20,8 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 			'refunds',
 		);
 
-		if( null !== get_current_screen() ) {
+		// Do not allow refunds via Collector for Swish orders.
+		if( function_exists( 'get_current_screen' ) && null !== get_current_screen() ) {
 			
 			$current_screen = get_current_screen();
 			

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:     Collector Checkout for WooCommerce
  * Plugin URI:      https://krokedil.se/collector/
  * Description:     Extends WooCommerce. Provides a <a href="https://www.collector.se/" target="_blank">Collector Checkout</a> checkout for WooCommerce.
- * Version:         1.5.0
+ * Version:         1.5.1
  * Author:          Krokedil
  * Author URI:      https://krokedil.se/
  * Text Domain:     collector-checkout-for-woocommerce
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'COLLECTOR_BANK_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'COLLECTOR_BANK_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'COLLECTOR_BANK_VERSION', '1.5.0' );
+define( 'COLLECTOR_BANK_VERSION', '1.5.1' );
 
 if ( ! class_exists( 'Collector_Checkout' ) ) {
 	class Collector_Checkout {

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,9 @@ For help setting up and configuring Collector Checkout for WooCommerce please re
 
 
 == CHANGELOG ==
+= 2020.02.20    - versiom 1.5.1 =
+* Fix           - Do not try to call WP function get_current_screen() if it hasn't been defined.
+
 = 2020.02.19    - versiom 1.5.0 =
 * Feature       - Added support for Swish as external payment method in the checkout.
 * Tweak         - Trigger payment_complete() ofr Collector orders with the status of "Completed".


### PR DESCRIPTION
* Fix - Do not try to call WP function get_current_screen() if it hasn't been defined.