### PR TITLE
Develop delivery module

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -90,3 +90,11 @@ ul.collector-checkout-tabs li.current:after {
     max-width: 600px; /* Could be more or less, depending on screen size */
     text-align: center;
 }
+
+/* Hide shipping methods in order review if displayed in Collector iframe */
+
+.collector-delivery-module ul#shipping_method {
+    position: absolute;
+    top: -9999px;
+    left: -9999px;
+}

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -79,7 +79,51 @@
             );
             window.collector.checkout.api.resume();
         }
-	});
+    });
+    
+    document.addEventListener("collectorCheckoutShippingUpdated", function(listener){
+        console.log('collectorCheckoutShippingUpdated');
+        console.log(listener);
+
+        if ( wc_collector_checkout.is_thank_you_page === 'no' ) {
+
+            $( '.woocommerce-checkout-review-order-table' ).block({
+                message: null,
+                overlayCSS: {
+                    background: '#fff',
+                    opacity: 0.6
+                }
+            });
+
+            window.collector.checkout.api.suspend();
+            $.ajax(
+                wc_collector_checkout.update_delivery_module_shipping_url,
+                {
+                    type: 'POST',
+                    dataType: 'json',
+                    data: {
+                        action  : 'update_delivery_module_shipping',
+                        data : listener.detail,
+                        nonce: wc_collector_checkout.collector_nonce,
+                    },
+                    complete: function( response ) {
+                        console.log('update_delivery_module_shipping done');
+                        var currentCollectorShippingMethod = document.querySelector('[id*="collector_delivery_module"]');
+                        console.log('test');
+                        console.log(currentCollectorShippingMethod);
+                        
+                        if( currentCollectorShippingMethod.id ) {
+                            $( '#shipping_method #' + currentCollectorShippingMethod.id ).prop( 'checked', true );
+                            // $( 'body' ).trigger( 'collector_shipping_option_changed', [ data ]);
+                            $( 'body' ).trigger( 'update_checkout' );
+                        }
+                        $( '.woocommerce-checkout-review-order-table' ).unblock();
+                    }
+                }
+            );
+            window.collector.checkout.api.resume();
+        }
+    });
 	
 	// Customer change B2B / B2C
 	$(document).on('click', '.collector-checkout-tabs li',function() {
@@ -109,6 +153,8 @@
             console.log('Updated checkout event');
             //$('#place_order').remove();
         }
+        // Display shipping price if Delivery module is active.
+        maybeDisplayShippingPrice();
     });
     // Change from Collector Checkout payment method
     $(document).on( 'click', '#collector_change_payment_method', function () {
@@ -319,6 +365,36 @@
             $( '#shipping_postcode' ).val( ( ( data.shipping_postcode ) ? data.shipping_postcode : '' ) );
             $( '#shipping_country' ).val( ( ( data.shipping_country ) ? data.shipping_country.toUpperCase() : '' ) );
            
+        }
+    }
+
+    // Display Shipping Price in order review if Display shipping methods in iframe settings is active.
+    function maybeDisplayShippingPrice() {
+        // Check if we already have set the price. If we have, return.
+        if( $('.collector-shipping').length ) {
+            return;
+        }
+
+        var paymentMethod = $("input[name='payment_method']:checked").val()
+        
+        if ( 'collector_checkout' === paymentMethod && 'yes' === wc_collector_checkout.delivery_module && 'no' === wc_collector_checkout.is_collector_confirmation ) {
+            if ( $( '#shipping_method input[type=\'radio\']' ).length ) {
+                // Multiple shipping options available.
+                $( '#shipping_method input[type=\'radio\']:checked' ).each( function() {
+                    var idVal = $( this ).attr( 'id' );
+                    var shippingPrice = $( 'label[for=\'' + idVal + '\'] .amount' ).text();
+                    console.log(shippingPrice);
+                    $( '.woocommerce-shipping-totals td' ).append( shippingPrice );
+                    $( '.woocommerce-shipping-totals ul' ).hide();
+                    $( '.woocommerce-shipping-totals td' ).addClass( 'collector-shipping' );
+                });
+            } else {
+                // Only one shipping option available.
+                var idVal = $( '#shipping_method input[name=\'shipping_method[0]\']' ).attr( 'id' );
+                var shippingPrice = $( 'label[for=\'' + idVal + '\'] .amount' ).text();
+                $( '.woocommerce-shipping-totals td' ).html( shippingPrice );
+                $( '.woocommerce-shipping-totals td' ).addClass( 'collector-shipping' );
+            }
         }
     }
     

--- a/classes/class-collector-checkout-api-callbacks.php
+++ b/classes/class-collector-checkout-api-callbacks.php
@@ -478,10 +478,7 @@ class Collector_Api_Callbacks {
 		$order->calculate_totals();
 		$order->save();
 
-		// Set order status in Woo
-		$this->set_order_status( $order, $collector_order );
-
-		// Check order total and compare it with Woo
+		// Set order status in Woo.
 		$this->set_order_status( $order, $collector_order );
 
 		// Remove database table row data.

--- a/classes/class-collector-checkout-api-callbacks.php
+++ b/classes/class-collector-checkout-api-callbacks.php
@@ -366,6 +366,36 @@ class Collector_Api_Callbacks {
 				// Save shipping reference to order.
 				update_post_meta( $order->get_id(), '_collector_shipping_reference', $cart_item->id );
 
+			} elseif ( 'Frakt' === $cart_item->id ) {
+				// Collector Delivery Module Shipping.
+				$args = array(
+					'order_item_name' => $cart_item->description,
+					'order_item_type' => 'shipping',
+				);
+
+				$item_id = wc_add_order_item( $order->get_id(), $args );
+
+				if ( $item_id ) {
+					if ( $cart_item->unitPrice > 0 ) {
+						if ( $cart_item->vat > 0 ) {
+							$line_total_excl_vat = round( $cart_item->unitPrice / ( 1 + ( $cart_item->vat / 100 ) ), 2 );
+							$line_total_vat      = $cart_item->unitPrice - $line_total_excl_vat;
+						} else {
+							$line_total_excl_vat = round( $cart_item->unitPrice, 2 );
+							$line_total_vat      = 0;
+						}
+					} else {
+						$line_total_excl_vat = 0;
+						$line_total_vat      = 0;
+					}
+					wc_add_order_item_meta( $item_id, '_qty', 1 );
+					wc_add_order_item_meta( $item_id, 'cost', wc_format_decimal( $line_total_excl_vat ) );
+					wc_add_order_item_meta( $item_id, 'total_tax', wc_format_decimal( $line_total_vat ) );
+
+				}
+				// Save shipping reference to order.
+				update_post_meta( $order->get_id(), '_collector_shipping_reference', $cart_item->id );
+
 			} elseif ( strpos( $cart_item->id, 'invoicefee|' ) !== false ) {
 
 				// Invoice fee.

--- a/classes/class-collector-checkout-delivery-module.php
+++ b/classes/class-collector-checkout-delivery-module.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Delivery module class.
+ *
+ * @package Collector_Checkout/Classes
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+/**
+ * Collector_Delivery_Module class.
+ */
+class Collector_Delivery_Module {
+
+	/**
+	 * The reference the *Singleton* instance of this class.
+	 *
+	 * @var $instance
+	 */
+	protected static $instance;
+
+	/**
+	 * Returns the *Singleton* instance of this class.
+	 *
+	 * @return self::$instance The *Singleton* instance.
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Plugin actions.
+	 */
+	public function __construct() {
+		add_action( 'woocommerce_checkout_update_order_review', array( $this, 'clear_shipping_and_recalculate' ) );
+		add_action( 'woocommerce_admin_order_data_after_shipping_address', array( $this, 'admin_order_meta' ), 10, 1 );
+	}
+
+	/**
+	 * Clears the shipping calculations to prevent errors.
+	 *
+	 * @return void
+	 */
+	public function clear_shipping_and_recalculate() {
+		$available_gateways = WC()->payment_gateways()->get_available_payment_gateways();
+		reset( $available_gateways );
+
+		if ( 'collector_checkout' === WC()->session->get( 'chosen_payment_method' ) ) {
+			// If Collector Checkout is the chosen payment method.
+			WC()->session->set( 'collector_delivery_module_enabled', true );
+			WC()->session->__unset( 'shipping_for_package_0' );
+			WC()->cart->calculate_shipping();
+		} elseif ( ( null === WC()->session->get( 'chosen_payment_method' ) || '' === WC()->session->get( 'chosen_payment_method' ) ) && 'collector_checkout' === key( $available_gateways ) ) {
+			// If no payment method is chosen but Collector Checkout is the first payment method.
+			WC()->session->set( 'collector_delivery_module_enabled', true );
+			WC()->session->__unset( 'shipping_for_package_0' );
+			WC()->cart->calculate_shipping();
+		} else {
+			if ( null !== WC()->session->get( 'collector_delivery_module_enabled' ) ) {
+				WC()->session->__unset( 'shipping_for_package_0' );
+				WC()->session->__unset( 'collector_delivery_module_enabled' );
+			}
+		}
+	}
+
+	/**
+	 * Display Shipping info in order if order contain a Collector Delivery Module shipping method.
+	 *
+	 * @param object $order WooCommerce order.
+	 * @return mixed Prints the html displayed in order admin.
+	 */
+	public function admin_order_meta( $order ) {
+		$order_id                = $order->get_id();
+		$collector_delivery_data = json_decode( get_post_meta( $order_id, '_collector_delivery_module_data', true ), true );
+
+		if ( ! empty( $collector_delivery_data['servicePointName'] ) ) {
+			$pickup_service = $collector_delivery_data['carrierName'];
+			$pickup_name    = $collector_delivery_data['servicePointName'];
+
+			$shipment_id = $collector_delivery_data['pendingShipment']['id'];
+
+			$pickup_service_text = sprintf( '<strong>%1$s</strong> %2$s<br>', __( 'Service:', 'krokedil-shipping-connector' ), wc_clean( $pickup_service ) );
+			$pickup_name_text    = sprintf( '<strong>%1$s</strong> %2$s<br>', __( 'Pickup Point:', 'krokedil-shipping-connector' ), wc_clean( $pickup_name ) );
+			$shipment_id_text    = sprintf( '<strong>%1$s</strong> %2$s<br>', __( 'Shipment ID:', 'krokedil-shipping-connector' ), wc_clean( $shipment_id ) );
+
+			printf(
+				'<h3>%1$s</h3><div class="unifaun"><p>%2$s%3$s%4$s</p></div>',
+				esc_html__( 'Shipment information', 'krokedil-shipping-connector' ),
+				wp_kses_post( $pickup_service_text ),
+				wp_kses_post( $pickup_name_text ),
+				wp_kses_post( $shipment_id_text )
+			);
+		}
+
+	}
+
+}
+
+Collector_Delivery_Module::get_instance();

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -64,7 +64,6 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 		);
 
 		// Function to handle the thankyou page.
-		add_action( 'woocommerce_thankyou_collector_checkout', array( $this, 'collector_thankyou' ) );
 		add_filter( 'woocommerce_thankyou_order_received_text', array( $this, 'collector_thankyou_order_received_text' ), 10, 2 );
 		add_action( 'woocommerce_thankyou', array( $this, 'maybe_delete_collector_sessions' ), 100, 1 );
 
@@ -214,93 +213,98 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 			Collector_Checkout::log( 'Update Collector order reference for order - ' . $order->get_order_number() );
 		}
 
+		$process_payment = $this->process_collector_payment_in_order( $order_id );
+
 		return array(
 			'result'   => 'success',
 			'redirect' => $this->get_return_url( $order ),
 		);
 	}
 
+	/**
+	 * Processes the Collector Payment and sets post metas.
+	 *
+	 * @param string $order_id The WooCommerce order id.
+	 * @return void
+	 */
+	public function process_collector_payment_in_order( $order_id ) {
 
-	public function collector_thankyou( $order_id ) {
-		$order = wc_get_order( $order_id );
-		if ( WC()->session->get( 'collector_private_id' ) ) {
+		$order         = wc_get_order( $order_id );
+		$private_id    = get_post_meta( $order_id, '_collector_private_id', true );
+		$customer_type = get_post_meta( $order_id, '_collector_customer_type', true );
 
-			$private_id = get_post_meta( $order_id, '_collector_private_id', true );
-			Collector_Checkout::log( 'collector_thankyou page hit for private_id ' . $private_id );
+		Collector_Checkout::log( 'Process Collector Payment for private_id ' . $private_id );
 
-			$customer_type  = get_post_meta( $order_id, '_collector_customer_type', true );
-			$payment_data   = new Collector_Checkout_Requests_Get_Checkout_Information( $private_id, $customer_type );
-			$payment_data   = $payment_data->request();
-			$payment_data   = json_decode( $payment_data );
-			$payment_status = $payment_data->data->purchase->result;
-			$payment_method = $payment_data->data->purchase->paymentName;
-			$payment_id     = $payment_data->data->purchase->purchaseIdentifier;
+		$payment_data   = new Collector_Checkout_Requests_Get_Checkout_Information( $private_id, $customer_type );
+		$payment_data   = $payment_data->request();
+		$payment_data   = json_decode( $payment_data );
+		$payment_status = $payment_data->data->purchase->result;
+		$payment_method = $payment_data->data->purchase->paymentName;
+		$payment_id     = $payment_data->data->purchase->purchaseIdentifier;
 
-			update_post_meta( $order_id, '_collector_payment_method', $payment_method );
-			update_post_meta( $order_id, '_collector_payment_id', $payment_id );
-			$this->save_shipping_reference_to_order( $order_id, $payment_data );
+		update_post_meta( $order_id, '_collector_payment_method', $payment_method );
+		update_post_meta( $order_id, '_collector_payment_id', $payment_id );
+		$this->save_shipping_reference_to_order( $order_id, $payment_data );
 
-			// Save shipping data.
-			if ( isset( $payment_data->data->shipping ) ) {
-				update_post_meta( $order_id, '_collector_delivery_module_data', wp_json_encode( $payment_data->data->shipping, JSON_UNESCAPED_UNICODE ) );
-				update_post_meta( $order_id, '_collector_delivery_module_reference', $payment_data->data->shipping->pendingShipment->id );
-				WC()->session->__unset( 'collector_delivery_module_enabled' );
-				WC()->session->__unset( 'collector_delivery_module_data' );
-			}
-
-			// Tie this order to a user if we have one.
-			if ( email_exists( $payment_data->data->customer->email ) ) {
-				$user    = get_user_by( 'email', $payment_data->data->customer->email );
-				$user_id = $user->ID;
-				update_post_meta( $order_id, '_customer_user', $user_id );
-			}
-
-			if ( ! $order->has_status( 'on-hold' ) ) {
-				if ( 'Preliminary' === $payment_status || 'Completed' === $payment_status ) {
-					$order->payment_complete( $payment_id );
-				} elseif ( 'Signing' == $payment_status ) {
-					$order->add_order_note( __( 'Order is waiting for electronic signing by customer. Payment ID: ', 'woocommerce-gateway-klarna' ) . $payment_id );
-					update_post_meta( $order_id, '_transaction_id', $payment_id );
-					$order->update_status( 'on-hold' );
-				} else {
-					$order->add_order_note( __( 'Order is PENDING APPROVAL by Collector. Payment ID: ', 'woocommerce-gateway-klarna' ) . $payment_id );
-					update_post_meta( $order_id, '_transaction_id', $payment_id );
-					$order->update_status( 'on-hold' );
-				}
-			}
-
-			$order->add_order_note( sprintf( __( 'Purchase via %s', 'collector-checkout-for-woocommerce' ), wc_collector_get_payment_method_name( $payment_method ) ) );
-
-			// Check if there where any empty fields, if so send mail.
-			if ( WC()->session->get( 'collector_empty_fields' ) ) {
-				$email   = get_option( 'admin_email' );
-				$subject = __( 'Order data was missing from Collector', 'collector-checkout-for-woocommerce' );
-				$message = '<p>' . __( 'The following fields had missing data from Collector, please verify the order with Collector.', 'collector-checkout-for-woocommerce' );
-				foreach ( WC()->session->get( 'collector_empty_fields' ) as $field ) {
-					$message = $message . '<br>' . $field;
-				}
-				$message = $message . '<br><a href="' . get_edit_post_link( $order_id ) . '">' . __( 'Link to the order', 'collector-checkout-for-woocommerce' ) . '</a></p>';
-				wp_mail( $email, $subject, $message );
-				WC()->session->__unset( 'collector_empty_fields' );
-			}
-			// Check if there is a org nr set, if so add post meta
-			if ( WC()->session->get( 'collector_org_nr' ) ) {
-				$org_nr = WC()->session->get( 'collector_org_nr' );
-				update_post_meta( $order_id, '_collector_org_nr', $org_nr );
-				WC()->session->__unset( 'collector_org_nr' );
-			}
-
-			// Check if there is a invoice refernce set, if so add post meta
-			if ( WC()->session->get( 'collector_invoice_reference' ) ) {
-				$invoice_reference = WC()->session->get( 'collector_invoice_reference' );
-				update_post_meta( $order_id, '_collector_invoice_reference', $invoice_reference );
-				WC()->session->__unset( 'collector_invoice_reference' );
-			}
-		} else {
-			// @todo - add logging here.
-			Collector_Checkout::log( 'collector_thankyou page hit but collector_private_id session not existing.' );
+		// Save shipping data.
+		if ( isset( $payment_data->data->shipping ) ) {
+			update_post_meta( $order_id, '_collector_delivery_module_data', wp_json_encode( $payment_data->data->shipping, JSON_UNESCAPED_UNICODE ) );
+			update_post_meta( $order_id, '_collector_delivery_module_reference', $payment_data->data->shipping->pendingShipment->id );
+			WC()->session->__unset( 'collector_delivery_module_enabled' );
+			WC()->session->__unset( 'collector_delivery_module_data' );
 		}
 
+		// Tie this order to a user if we have one.
+		if ( email_exists( $payment_data->data->customer->email ) ) {
+			$user    = get_user_by( 'email', $payment_data->data->customer->email );
+			$user_id = $user->ID;
+			update_post_meta( $order_id, '_customer_user', $user_id );
+		}
+
+		if ( ! $order->has_status( 'on-hold' ) ) {
+			if ( 'Preliminary' === $payment_status || 'Completed' === $payment_status ) {
+				$order->payment_complete( $payment_id );
+			} elseif ( 'Signing' === $payment_status ) {
+				$order->add_order_note( __( 'Order is waiting for electronic signing by customer. Payment ID: ', 'woocommerce-gateway-klarna' ) . $payment_id );
+				update_post_meta( $order_id, '_transaction_id', $payment_id );
+				$order->update_status( 'on-hold' );
+			} else {
+				$order->add_order_note( __( 'Order is PENDING APPROVAL by Collector. Payment ID: ', 'woocommerce-gateway-klarna' ) . $payment_id );
+				update_post_meta( $order_id, '_transaction_id', $payment_id );
+				$order->update_status( 'on-hold' );
+			}
+		}
+		// Translators: Collector Payment method.
+		$order->add_order_note( sprintf( __( 'Purchase via %s', 'collector-checkout-for-woocommerce' ), wc_collector_get_payment_method_name( $payment_method ) ) );
+
+		// Check if there where any empty fields, if so send mail.
+		if ( WC()->session->get( 'collector_empty_fields' ) ) {
+			$email   = get_option( 'admin_email' );
+			$subject = __( 'Order data was missing from Collector', 'collector-checkout-for-woocommerce' );
+			$message = '<p>' . __( 'The following fields had missing data from Collector, please verify the order with Collector.', 'collector-checkout-for-woocommerce' );
+			foreach ( WC()->session->get( 'collector_empty_fields' ) as $field ) {
+				$message = $message . '<br>' . $field;
+			}
+			$message = $message . '<br><a href="' . get_edit_post_link( $order_id ) . '">' . __( 'Link to the order', 'collector-checkout-for-woocommerce' ) . '</a></p>';
+			wp_mail( $email, $subject, $message );
+			WC()->session->__unset( 'collector_empty_fields' );
+		}
+		// Check if there is a org nr set, if so add post meta.
+		if ( WC()->session->get( 'collector_org_nr' ) ) {
+			$org_nr = WC()->session->get( 'collector_org_nr' );
+			update_post_meta( $order_id, '_collector_org_nr', $org_nr );
+			WC()->session->__unset( 'collector_org_nr' );
+		}
+
+		// Check if there is a invoice refernce set, if so add post meta.
+		if ( WC()->session->get( 'collector_invoice_reference' ) ) {
+			$invoice_reference = WC()->session->get( 'collector_invoice_reference' );
+			update_post_meta( $order_id, '_collector_invoice_reference', $invoice_reference );
+			WC()->session->__unset( 'collector_invoice_reference' );
+		}
+
+		// Remove database table row data.
+		remove_collector_db_row_data( $private_id );
 	}
 
 	/**

--- a/classes/class-collector-checkout-shipping-method.php
+++ b/classes/class-collector-checkout-shipping-method.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Shipping method class file.
+ *
+ * @package CollectorCheckout/Classes
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( class_exists( 'WC_Shipping_Method' ) ) {
+
+	/**
+	 * Shipping method class.
+	 */
+	class Collector_Delivery_Module_Shipping_Method extends WC_Shipping_Method {
+
+		/**
+		 * Class constructor.
+		 *
+		 * @param integer $instance_id The instance id.
+		 */
+		public function __construct( $instance_id = 0 ) {
+			$this->id                   = 'collector_delivery_module';
+			$this->instance_id          = absint( $instance_id );
+			$this->title                = 'Collector Delivery Module';
+			$this->method_title         = __( 'Collector Delivery Module', 'collector-checkout-for-woocommerce' );
+			$this->method_description   = __( 'Enables Collector Checkout Delivery Module', 'collector-checkout-for-woocommerce' );
+			$this->supports             = array(
+				'shipping-zones',
+				'instance-settings',
+				'instance-settings-modal',
+			);
+			$this->collector_tax_amount = false;
+			$this->init_form_fields();
+			$this->init_settings();
+		}
+		/**
+		 * Init form fields.
+		 */
+		public function init_form_fields() {
+			$this->instance_form_fields = array(
+				'title' => array(
+					'title'       => __( 'Collector Delivery Module', 'collector-checkout-for-woocommerce' ),
+					'type'        => 'title',
+					'description' => __( 'There are currently no settings for Collector Delivery Module since this is controlled by the TMS-provider. If other plugins adds settings, these are shown below.', 'collector-checkout-for-woocommerce' ),
+				),
+			);
+		}
+
+		/**
+		 * Check if shipping method should be available.
+		 *
+		 * @param array $package The shipping package.
+		 * @return boolean
+		 */
+		public function is_available( $package ) {
+
+			if ( null !== WC()->session->get( 'collector_delivery_module_enabled' ) && WC()->session->get( 'collector_delivery_module_enabled' ) ) {
+				return true;
+			}
+			return false;
+		}
+
+		/**
+		 * Calculate shipping cost.
+		 *
+		 * @param array $package The shipping package.
+		 * @return void
+		 */
+		public function calculate_shipping( $package = array() ) {
+			$label = 'Collector Delivery Module';
+			$cost  = 0;
+			if ( null !== WC()->session->get( 'collector_private_id' ) ) {
+				$private_id    = WC()->session->get( 'collector_private_id' );
+				$customer_type = WC()->session->get( 'collector_customer_type' );
+
+				if ( method_exists( WC()->session, 'get' ) && ! empty( WC()->session->get( 'collector_delivery_module_data' )['label'] ) && ! empty( WC()->session->get( 'collector_delivery_module_data' )['cost'] ) ) {
+					$shipping_data = WC()->session->get( 'collector_delivery_module_data' );
+				} else {
+					$collector_order = new Collector_Checkout_Requests_Get_Checkout_Information( $private_id, $customer_type );
+					$collector_order = $collector_order->request();
+					$collector_order = json_decode( $collector_order );
+
+					if ( isset( $collector_order->data->fees->shipping ) ) {
+						$shipping_data = array(
+							'label'        => $collector_order->data->fees->shipping->description,
+							'shipping_id'  => $collector_order->data->fees->shipping->id,
+							'cost'         => $collector_order->data->fees->shipping->unitPrice,
+							'shipping_vat' => $collector_order->data->fees->shipping->vat,
+						);
+						WC()->session->set( 'collector_delivery_module_data', $shipping_data );
+					} else {
+						$shipping_data = array(
+							'label'        => 'Collector',
+							'shipping_id'  => '',
+							'cost'         => 0,
+							'shipping_vat' => 0,
+						);
+					}
+				}
+
+				if ( $shipping_data['shipping_vat'] > 0 ) {
+					$cost = $shipping_data['cost'] / ( ( $shipping_data['shipping_vat'] / 100 ) + 1 );
+				}
+				$args = array(
+					'id'      => $this->get_rate_id(),
+					'label'   => $shipping_data['label'],
+					'cost'    => round( $cost, 2 ),
+					'package' => $package,
+				);
+				WC()->session->set( 'collector_delivery_module_enabled', true );
+				$this->add_rate( $args );
+			}
+		}
+	}
+
+	add_filter( 'woocommerce_shipping_methods', 'add_collector_shipping_method' );
+	/**
+	 * Registers the shipping method.
+	 *
+	 * @param array $methods WooCommerce shipping methods.
+	 * @return array
+	 */
+	function add_collector_shipping_method( $methods ) {
+		$methods['collector_delivery_module'] = 'Collector_Delivery_Module_Shipping_Method';
+		return $methods;
+	}
+}

--- a/classes/requests/class-collector-checkout-requests-initialize-checkout.php
+++ b/classes/requests/class-collector-checkout-requests-initialize-checkout.php
@@ -16,24 +16,29 @@ class Collector_Checkout_Requests_Initialize_Checkout extends Collector_Checkout
 		$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
 		switch ( get_woocommerce_currency() ) {
 			case 'SEK':
-				$country_code   = 'SE';
-				$this->store_id = $collector_settings[ 'collector_merchant_id_se_' . $customer_type ];
+				$country_code          = 'SE';
+				$this->store_id        = $collector_settings[ 'collector_merchant_id_se_' . $customer_type ];
+				$this->delivery_module = isset( $collector_settings['collector_delivery_module_se'] ) ? $collector_settings['collector_delivery_module_se'] : 'no';
 				break;
 			case 'NOK':
-				$country_code   = 'NO';
-				$this->store_id = $collector_settings[ 'collector_merchant_id_no_' . $customer_type ];
+				$country_code          = 'NO';
+				$this->store_id        = $collector_settings[ 'collector_merchant_id_no_' . $customer_type ];
+				$this->delivery_module = isset( $collector_settings['collector_delivery_module_no'] ) ? $collector_settings['collector_delivery_module_no'] : 'no';
 				break;
 			case 'DKK':
-				$country_code   = 'DK';
-				$this->store_id = $collector_settings[ 'collector_merchant_id_dk_' . $customer_type ];
+				$country_code          = 'DK';
+				$this->store_id        = $collector_settings[ 'collector_merchant_id_dk_' . $customer_type ];
+				$this->delivery_module = isset( $collector_settings['collector_delivery_module_dk'] ) ? $collector_settings['collector_delivery_module_dk'] : 'no';
 				break;
 			case 'EUR':
-				$country_code   = 'FI';
-				$this->store_id = $collector_settings[ 'collector_merchant_id_fi_' . $customer_type ];
+				$country_code          = 'FI';
+				$this->store_id        = $collector_settings[ 'collector_merchant_id_fi_' . $customer_type ];
+				$this->delivery_module = isset( $collector_settings['collector_delivery_module_fi'] ) ? $collector_settings['collector_delivery_module_fi'] : 'no';
 				break;
 			default:
-				$country_code   = 'SE';
-				$this->store_id = $collector_settings[ 'collector_merchant_id_se_' . $customer_type ];
+				$country_code          = 'SE';
+				$this->store_id        = $collector_settings[ 'collector_merchant_id_se_' . $customer_type ];
+				$this->delivery_module = isset( $collector_settings['collector_delivery_module_se'] ) ? $collector_settings['collector_delivery_module_se'] : 'no';
 				break;
 		}
 		$this->customer_type = $customer_type;
@@ -105,7 +110,9 @@ class Collector_Checkout_Requests_Initialize_Checkout extends Collector_Checkout
 			'cart'             => $this->cart(),
 			'fees'             => $this->fees(),
 		);
-
+		if ( 'yes' === $this->delivery_module ) {
+			$formatted_request_body['profileName'] = 'Shipping';
+		}
 		return wp_json_encode( $formatted_request_body );
 	}
 }

--- a/classes/requests/class-collector-checkout-requests-initialize-checkout.php
+++ b/classes/requests/class-collector-checkout-requests-initialize-checkout.php
@@ -41,9 +41,10 @@ class Collector_Checkout_Requests_Initialize_Checkout extends Collector_Checkout
 				$this->delivery_module = isset( $collector_settings['collector_delivery_module_se'] ) ? $collector_settings['collector_delivery_module_se'] : 'no';
 				break;
 		}
-		$this->customer_type = $customer_type;
-		$this->country_code  = $country_code;
-		$this->terms_page    = esc_url( get_permalink( wc_get_page_id( 'terms' ) ) );
+		$this->customer_type                = $customer_type;
+		$this->country_code                 = $country_code;
+		$this->terms_page                   = esc_url( get_permalink( wc_get_page_id( 'terms' ) ) );
+		$this->activate_validation_callback = isset( $collector_settings['activate_validation_callback'] ) ? $collector_settings['activate_validation_callback'] : 'no';
 	}
 
 	private function get_request_args() {
@@ -106,10 +107,12 @@ class Collector_Checkout_Requests_Initialize_Checkout extends Collector_Checkout
 				),
 				get_home_url() . '/wc-api/Collector_Checkout_Gateway/'
 			),
-			'validationUri'    => $validation_uri,
 			'cart'             => $this->cart(),
 			'fees'             => $this->fees(),
 		);
+		if ( 'yes' === $this->activate_validation_callback ) {
+			$formatted_request_body['validationUri'] = $validation_uri;
+		}
 		if ( 'yes' === $this->delivery_module ) {
 			$formatted_request_body['profileName'] = 'Shipping';
 		}

--- a/classes/requests/class-collector-checkout-requests-update-fees.php
+++ b/classes/requests/class-collector-checkout-requests-update-fees.php
@@ -10,20 +10,20 @@ class Collector_Checkout_Requests_Update_Fees extends Collector_Checkout_Request
 		parent::__construct();
 		$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
 		switch ( get_woocommerce_currency() ) {
-			case 'SEK' :
-				$store_id = $collector_settings['collector_merchant_id_se_' . $customer_type];
+			case 'SEK':
+				$store_id = $collector_settings[ 'collector_merchant_id_se_' . $customer_type ];
 				break;
-			case 'NOK' :
-				$store_id = $collector_settings['collector_merchant_id_no_' . $customer_type];
+			case 'NOK':
+				$store_id = $collector_settings[ 'collector_merchant_id_no_' . $customer_type ];
 				break;
-			case 'DKK' :
-				$store_id = $collector_settings['collector_merchant_id_dk_' . $customer_type];
+			case 'DKK':
+				$store_id = $collector_settings[ 'collector_merchant_id_dk_' . $customer_type ];
 				break;
-			case 'EUR' :
-				$store_id = $collector_settings['collector_merchant_id_fi_' . $customer_type];
+			case 'EUR':
+				$store_id = $collector_settings[ 'collector_merchant_id_fi_' . $customer_type ];
 				break;
-			default :
-				$store_id = $collector_settings['collector_merchant_id_se_' . $customer_type];
+			default:
+				$store_id = $collector_settings[ 'collector_merchant_id_se_' . $customer_type ];
 				break;
 		}
 		$this->path = '/merchants/' . $store_id . '/checkouts/' . $private_id . '/fees';
@@ -42,9 +42,9 @@ class Collector_Checkout_Requests_Update_Fees extends Collector_Checkout_Request
 
 	public function request() {
 		$request_url = $this->base_url . $this->path;
-		$request = wp_remote_request( $request_url, $this->get_request_args() );
+		$request     = wp_remote_request( $request_url, $this->get_request_args() );
 		if ( is_wp_error( $request ) ) {
-			$this->log( 'Collector update fees request response ERROR: ' . stripslashes_deep( json_encode( $request ) ) . ' (Request endpoint: ' . $request_url . ')' );			
+			$this->log( 'Collector update fees request response ERROR: ' . stripslashes_deep( json_encode( $request ) ) . ' (Request endpoint: ' . $request_url . ')' );
 		} else {
 			$this->log( 'Collector update fees request response: ' . stripslashes_deep( json_encode( $request ) ) . ' (Request endpoint: ' . $request_url . ')' );
 		}
@@ -52,11 +52,13 @@ class Collector_Checkout_Requests_Update_Fees extends Collector_Checkout_Request
 	}
 
 	protected function request_body() {
-		$fees = $this->fees();
+		$fees                   = $this->fees();
 		$formatted_request_body = array(
-			'shipping'                  => $fees['shipping'],
 			'directinvoicenotification' => $fees['directinvoicenotification'],
 		);
+		if ( isset( $fees['shipping'] ) && ! empty( $fees['shipping'] ) ) {
+			$formatted_request_body['shipping'] = $fees['shipping'];
+		}
 		return wp_json_encode( $formatted_request_body );
 	}
 }

--- a/classes/requests/helpers/class-collector-checkout-requests-fees.php
+++ b/classes/requests/helpers/class-collector-checkout-requests-fees.php
@@ -6,27 +6,45 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Collector_Checkout_Requests_Fees {
 
 	public $invoice_fee_id = '';
-	public $price = 0;
+	public $price          = 0;
 
 	public function __construct() {
-		$collector_settings 	= get_option( 'woocommerce_collector_checkout_settings' );
-		$invoice_fee_id 		= $collector_settings['collector_invoice_fee'];
-		$this->invoice_fee_id 	= $invoice_fee_id;
-		
+		$collector_settings   = get_option( 'woocommerce_collector_checkout_settings' );
+		$invoice_fee_id       = $collector_settings['collector_invoice_fee'];
+		$this->invoice_fee_id = $invoice_fee_id;
+
+		switch ( get_woocommerce_currency() ) {
+			case 'SEK':
+				$this->delivery_module = isset( $collector_settings['collector_delivery_module_se'] ) ? $collector_settings['collector_delivery_module_se'] : 'no';
+				break;
+			case 'NOK':
+				$this->delivery_module = isset( $collector_settings['collector_delivery_module_no'] ) ? $collector_settings['collector_delivery_module_no'] : 'no';
+				break;
+			case 'DKK':
+				$this->delivery_module = isset( $collector_settings['collector_delivery_module_dk'] ) ? $collector_settings['collector_delivery_module_dk'] : 'no';
+				break;
+			case 'EUR':
+				$this->delivery_module = isset( $collector_settings['collector_delivery_module_fi'] ) ? $collector_settings['collector_delivery_module_fi'] : 'no';
+				break;
+			default:
+				$this->delivery_module = isset( $collector_settings['collector_delivery_module_se'] ) ? $collector_settings['collector_delivery_module_se'] : 'no';
+				break;
+		}
 	}
 
 	public function fees() {
 		$fees = array();
-		$shipping = $this->get_shipping();
-		$fees['shipping'] = $shipping;
+		if ( 'no' === $this->delivery_module ) {
+			$shipping         = $this->get_shipping();
+			$fees['shipping'] = $shipping;
+		}
 
-		if( $this->invoice_fee_id ) {
-			$_product   = wc_get_product( $this->invoice_fee_id );
+		if ( $this->invoice_fee_id ) {
+			$_product = wc_get_product( $this->invoice_fee_id );
 			if ( is_object( $_product ) ) {
-				$directinvoicenotification 			= $this->get_invoice_fee( $_product );
-				$fees['directinvoicenotification'] 	= $directinvoicenotification;
+				$directinvoicenotification         = $this->get_invoice_fee( $_product );
+				$fees['directinvoicenotification'] = $directinvoicenotification;
 			}
-			
 		}
 
 		return $fees;
@@ -36,8 +54,8 @@ class Collector_Checkout_Requests_Fees {
 	public function get_shipping() {
 		if ( WC()->cart->needs_shipping() ) {
 			WC()->cart->calculate_shipping();
-			$packages = WC()->shipping->get_packages();
-			$chosen_methods = WC()->session->get( 'chosen_shipping_methods' );
+			$packages        = WC()->shipping->get_packages();
+			$chosen_methods  = WC()->session->get( 'chosen_shipping_methods' );
 			$chosen_shipping = $chosen_methods[0];
 			foreach ( $packages as $i => $package ) {
 				foreach ( $package['rates'] as $method ) {
@@ -45,18 +63,18 @@ class Collector_Checkout_Requests_Fees {
 						WC()->session->set( 'collector_chosen_shipping', $method->id );
 						if ( $method->cost > 0 ) {
 							$shipping_item = array(
-								'id' => 'shipping|' . substr( $method->id, 0, 50 ),
+								'id'          => 'shipping|' . substr( $method->id, 0, 50 ),
 								'description' => $method->label,
-								'unitPrice' => round( $method->cost + array_sum( $method->taxes ), 2 ),
-								'vat' => round( array_sum( $method->taxes ) / $method->cost, 2 ) * 100,
+								'unitPrice'   => round( $method->cost + array_sum( $method->taxes ), 2 ),
+								'vat'         => round( array_sum( $method->taxes ) / $method->cost, 2 ) * 100,
 							);
 							return $shipping_item;
 						} else {
 							$shipping_item = array(
-								'id' => 'shipping|' . $method->id,
+								'id'          => 'shipping|' . $method->id,
 								'description' => $method->label,
-								'unitPrice' => 0,
-								'vat' => 0,
+								'unitPrice'   => 0,
+								'vat'         => 0,
 							);
 							return $shipping_item;
 						}
@@ -70,22 +88,22 @@ class Collector_Checkout_Requests_Fees {
 
 		$price = wc_get_price_including_tax( $_product );
 
-		$_tax = new WC_Tax();
+		$_tax      = new WC_Tax();
 		$tmp_rates = $_tax->get_base_tax_rates( $_product->get_tax_class() );
-		$_vat = array_shift( $tmp_rates );// Get the rate.
-		//Check what kind of tax rate we have.
+		$_vat      = array_shift( $tmp_rates );// Get the rate.
+		// Check what kind of tax rate we have.
 		if ( $_product->is_taxable() && isset( $_vat['rate'] ) ) {
 			$vat_rate = round( $_vat['rate'] );
 		} else {
-			//if empty, set 0% as rate
+			// if empty, set 0% as rate
 			$vat_rate = 0;
 		}
 
 		return array(
-			'id'            => 'invoicefee|' . Collector_Checkout_Requests_Cart::get_sku( $_product, $_product->get_id() ),
-			'description'   => $_product->get_title(),
-			'unitPrice'     => round( $price, 2 ),
-			'vat'           => $vat_rate,
+			'id'          => 'invoicefee|' . Collector_Checkout_Requests_Cart::get_sku( $_product, $_product->get_id() ),
+			'description' => $_product->get_title(),
+			'unitPrice'   => round( $price, 2 ),
+			'vat'         => $vat_rate,
 		);
 	}
 }

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -74,6 +74,8 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-checkout-confirmation.php';
 			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-checkout-sessions.php';
 			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-checkout-db.php';
+			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-checkout-shipping-method.php';
+			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-checkout-delivery-module.php';
 
 			include_once COLLECTOR_BANK_PLUGIN_DIR . '/includes/collector-checkout-for-woocommerce-functions.php';
 
@@ -162,6 +164,24 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 				}
 				$collector_settings       = get_option( 'woocommerce_collector_checkout_settings' );
 				$data_action_color_button = isset( $collector_settings['checkout_button_color'] ) && ! empty( $collector_settings['checkout_button_color'] ) ? "data-action-color='" . $collector_settings['checkout_button_color'] . "'" : '';
+
+				switch ( get_woocommerce_currency() ) {
+					case 'SEK':
+						$delivery_module = isset( $collector_settings['collector_delivery_module_se'] ) ? $collector_settings['collector_delivery_module_se'] : 'no';
+						break;
+					case 'NOK':
+						$delivery_module = isset( $collector_settings['collector_delivery_module_no'] ) ? $collector_settings['collector_delivery_module_no'] : 'no';
+						break;
+					case 'DKK':
+						$delivery_module = isset( $collector_settings['collector_delivery_module_dk'] ) ? $collector_settings['collector_delivery_module_dk'] : 'no';
+						break;
+					case 'EUR':
+						$delivery_module = isset( $collector_settings['collector_delivery_module_fi'] ) ? $collector_settings['collector_delivery_module_fi'] : 'no';
+						break;
+					default:
+						$delivery_module = isset( $collector_settings['collector_delivery_module_se'] ) ? $collector_settings['collector_delivery_module_se'] : 'no';
+						break;
+				}
 				wp_localize_script(
 					'checkout',
 					'wc_collector_checkout',
@@ -178,6 +198,7 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 						'data_action_color_button'      => $data_action_color_button,
 						'default_customer_type'         => wc_collector_get_default_customer_type(),
 						'selected_customer_type'        => wc_collector_get_selected_customer_type(),
+						'delivery_module'               => $delivery_module,
 						'collector_nonce'               => wp_create_nonce( 'collector_nonce' ),
 						'refresh_checkout_fragment_url' => WC_AJAX::get_endpoint( 'update_fragment' ),
 						'get_public_token_url'          => WC_AJAX::get_endpoint( 'get_public_token' ),
@@ -187,6 +208,7 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 						'customer_adress_updated_url'   => WC_AJAX::get_endpoint( 'customer_adress_updated' ),
 						'update_checkout_url'           => WC_AJAX::get_endpoint( 'update_checkout' ),
 						'checkout_error'                => WC_AJAX::get_endpoint( 'checkout_error' ),
+						'update_delivery_module_shipping_url' => WC_AJAX::get_endpoint( 'update_delivery_module_shipping' ),
 					)
 				);
 				wp_enqueue_script( 'checkout' );

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -222,3 +222,13 @@ function get_collector_data_from_db( $private_id ) {
 	$result = Collector_Checkout_DB::get_data_entry( $private_id );
 	return $result;
 }
+
+/**
+ * Removes the database table row data.
+ *
+ * @param string $private_id Collector private id.
+ * @return void
+ */
+function remove_collector_db_row_data( $private_id ) {
+	Collector_Checkout_DB::delete_data_entry( $private_id );
+}

--- a/includes/collector-checkout-settings.php
+++ b/includes/collector-checkout-settings.php
@@ -166,6 +166,13 @@ $settings = array(
 		'default'     => '',
 		'desc_tip'    => true,
 	),
+	'activate_validation_callback'    => array(
+		'title'       => __( 'Validation Callback', 'collector-checkout-for-woocommerce' ),
+		'type'        => 'checkbox',
+		'label'       => __( 'Tick the checkbox to activate Collector Validation Callback.', 'collector-checkout-for-woocommerce' ),
+		'description' => sprintf( __( 'Triggered by Collector when customer clicks the Complete purchase button in Collector Checkout. <a href="%s" target="_blank">Read more about validation callback.</a>', 'collector-checkout-for-woocommerce' ), 'https://docs.krokedil.com/article/164-collector-checkout-introduction' ),
+		'default'     => 'yes',
+	),
 	'order_management_settings_title' => array(
 		'title' => __( 'Order management settings', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',

--- a/includes/collector-checkout-settings.php
+++ b/includes/collector-checkout-settings.php
@@ -53,6 +53,12 @@ $settings = array(
 		'title' => __( 'Sweden', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
 	),
+	'collector_delivery_module_se'    => array(
+		'title'   => __( 'Delivery module Sweden', 'collector-checkout-for-woocommerce' ),
+		'type'    => 'checkbox',
+		'label'   => __( 'Activate Delivery module for Sweden', 'collector-checkout-for-woocommerce' ),
+		'default' => 'no',
+	),
 	'collector_merchant_id_se_b2c'    => array(
 		'title'       => __( 'Merchant ID Sweden B2C', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
@@ -70,6 +76,12 @@ $settings = array(
 	'no_settings_title'               => array(
 		'title' => __( 'Norway', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
+	),
+	'collector_delivery_module_no'    => array(
+		'title'   => __( 'Delivery module Norway', 'collector-checkout-for-woocommerce' ),
+		'type'    => 'checkbox',
+		'label'   => __( 'Activate Delivery module for Norway', 'collector-checkout-for-woocommerce' ),
+		'default' => 'no',
 	),
 	'collector_merchant_id_no_b2c'    => array(
 		'title'       => __( 'Merchant ID Norway B2C', 'collector-checkout-for-woocommerce' ),
@@ -89,6 +101,12 @@ $settings = array(
 		'title' => __( 'Finland', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
 	),
+	'collector_delivery_module_fi'    => array(
+		'title'   => __( 'Delivery module Finland', 'collector-checkout-for-woocommerce' ),
+		'type'    => 'checkbox',
+		'label'   => __( 'Activate Delivery module for Finland', 'collector-checkout-for-woocommerce' ),
+		'default' => 'no',
+	),
 	'collector_merchant_id_fi_b2c'    => array(
 		'title'       => __( 'Merchant ID Finland B2C', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
@@ -106,6 +124,12 @@ $settings = array(
 	'dk_settings_title'               => array(
 		'title' => __( 'Denmark', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
+	),
+	'collector_delivery_module_dk'    => array(
+		'title'   => __( 'Delivery module Denmark', 'collector-checkout-for-woocommerce' ),
+		'type'    => 'checkbox',
+		'label'   => __( 'Activate Delivery module for Denmark', 'collector-checkout-for-woocommerce' ),
+		'default' => 'no',
 	),
 	'collector_merchant_id_dk_b2c'    => array(
 		'title'       => __( 'Merchant ID Denmark B2C', 'collector-checkout-for-woocommerce' ),


### PR DESCRIPTION
* Add support for Collector Delivery Module.
* Run payment_complete process in process_payment (instead of woocommerce_thankyou).
* Delete db entry for validation data in payment_complete process (instead of in validation callback sequence).
* Add setting for turning on/off validation callback.
* Switch from wp_schedule_single_event to as_schedule_single_action for handling notification callbacks.
* Remove double trigger of set_order_status.