### PR TITLE
V2.0.2

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -1,6 +1,9 @@
 (function ($) {
     'use strict';
     var checkout_initiated = wc_collector_checkout.checkout_initiated;
+
+    // True or false if we need to update the Collector order. Set to true on initial page load.
+	var collectorUpdateNeeded = true;
     
     function get_new_checkout_iframe( customer ) {
 	    console.log( customer );
@@ -108,11 +111,12 @@
                     },
                     complete: function( response ) {
                         console.log('update_delivery_module_shipping done');
+                        collectorUpdateNeeded = false;
                         var currentCollectorShippingMethod = document.querySelector('[id*="collector_delivery_module"]');
-                        console.log('test');
+                        //console.log('test');
                         console.log(currentCollectorShippingMethod);
                         
-                        if( currentCollectorShippingMethod.id ) {
+                        if( currentCollectorShippingMethod ) {
                             $( '#shipping_method #' + currentCollectorShippingMethod.id ).prop( 'checked', true );
                             // $( 'body' ).trigger( 'collector_shipping_option_changed', [ data ]);
                             $( 'body' ).trigger( 'update_checkout' );
@@ -240,6 +244,12 @@
 
     function update_checkout() {
         if( checkout_initiated == 'yes' && wc_collector_checkout.payment_successful == 0 ) {
+
+            if( ! collectorUpdateNeeded ) {
+                collectorUpdateNeeded = true;
+                return;
+            }
+
             console.log( 'payment_successful' );
             console.log( wc_collector_checkout.payment_successful );
             //window.collector.checkout.api.suspend();
@@ -386,7 +396,6 @@
                 $( '#shipping_method input[type=\'radio\']:checked' ).each( function() {
                     var idVal = $( this ).attr( 'id' );
                     var shippingPrice = $( 'label[for=\'' + idVal + '\'] .amount' ).text();
-                    console.log(shippingPrice);
                     $( '.woocommerce-shipping-totals td' ).append( shippingPrice );
                     $( '.woocommerce-shipping-totals ul' ).hide();
                     $( '.woocommerce-shipping-totals td' ).addClass( 'collector-shipping' );

--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -55,7 +55,7 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 
 		} else {
 
-			// Get a new public token from Collector
+			// Get a new public token from Collector.
 			$init_checkout = new Collector_Checkout_Requests_Initialize_Checkout( $customer_type );
 			$request       = $init_checkout->request();
 			$decode        = json_decode( $request );
@@ -73,11 +73,22 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 					'customer_type' => $customer_type,
 				);
 
-				// Set post metas so they can be used again later
+				// Set post metas so they can be used again later.
 				WC()->session->set( 'collector_public_token', $decode->data->publicToken );
 				WC()->session->set( 'collector_private_id', $decode->data->privateId );
 				WC()->session->set( 'collector_customer_type', $customer_type );
 				WC()->session->set( 'collector_currency', get_woocommerce_currency() );
+
+				// Save session ID and Private ID to DB.
+				$collector_checkout_sessions = new Collector_Checkout_Sessions();
+				$collector_data              = array(
+					'session_id' => $collector_checkout_sessions->get_session_id(),
+				);
+				$args                        = array(
+					'private_id' => $decode->data->privateId,
+					'data'       => $collector_data,
+				);
+				$result                      = Collector_Checkout_DB::create_data_entry( $args );
 
 				wp_send_json_success( $return );
 				wp_die();

--- a/classes/class-collector-checkout-api-callbacks.php
+++ b/classes/class-collector-checkout-api-callbacks.php
@@ -508,8 +508,8 @@ class Collector_Api_Callbacks {
 	 */
 	public function check_order_totals( $order, $collector_order ) {
 		// Check order total and compare it with Woo
-		$woo_order_total       = intval( round( $order->get_total() ) );
-		$collector_order_total = $collector_order->data->order->totalAmount;
+		$woo_order_total       = intval( round( $order->get_total() * 100, 2 ) );
+		$collector_order_total = intval( round( $collector_order->data->order->totalAmount * 100, 2 ) );
 		if ( $woo_order_total > $collector_order_total && ( $woo_order_total - $collector_order_total ) > 3 ) {
 			$order->update_status( 'on-hold', sprintf( __( 'Order needs manual review. WooCommerce order total and Collector order total do not match. Collector order total: %s.', 'collector-checkout-for-woocommerce' ), $collector_order_total ) );
 			Collector_Checkout::log( 'Order total missmatch in order:' . $order->get_order_number() . '. Woo order total: ' . $woo_order_total . '. Collector order total: ' . $collector_order_total );

--- a/classes/class-collector-checkout-delivery-module.php
+++ b/classes/class-collector-checkout-delivery-module.php
@@ -38,6 +38,7 @@ class Collector_Delivery_Module {
 	public function __construct() {
 		add_action( 'woocommerce_checkout_update_order_review', array( $this, 'clear_shipping_and_recalculate' ) );
 		add_action( 'woocommerce_admin_order_data_after_shipping_address', array( $this, 'admin_order_meta' ), 10, 1 );
+		add_filter( 'wc_get_template', array( $this, 'override_shipping_template' ), 999, 2 );
 	}
 
 	/**
@@ -96,6 +97,38 @@ class Collector_Delivery_Module {
 			);
 		}
 
+	}
+
+	/**
+	 * Overrides the default cart shipping template.
+	 *
+	 * @param string $template The absolute template path.
+	 * @param string $template_name The name of the template.
+	 * @return string
+	 */
+	public function override_shipping_template( $template, $template_name ) {
+		// If its not the cart, return.
+		if ( ! is_cart() ) {
+			return $template;
+		}
+
+		// If its not the cart/cart-shipping.php file, return.
+		if ( 'cart/cart-shipping.php' !== $template_name ) {
+			return $template;
+		}
+
+		// If Delivery module is not used for the currency/country, return.
+		if ( 'yes' !== is_collector_delivery_module() ) {
+			return $template;
+		}
+
+		if ( locate_template( 'woocommerce/collector-cart-shipping.php' ) ) {
+			$template = locate_template( 'woocommerce/collector-cart-shipping.php' );
+		} else {
+			$template = COLLECTOR_BANK_PLUGIN_DIR . '/templates/collector-cart-shipping.php';
+		}
+
+		return $template;
 	}
 
 }

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:     Collector Checkout for WooCommerce
  * Plugin URI:      https://krokedil.se/collector/
  * Description:     Extends WooCommerce. Provides a <a href="https://www.collector.se/" target="_blank">Collector Checkout</a> checkout for WooCommerce.
- * Version:         2.0.0
+ * Version:         2.0.1
  * Author:          Krokedil
  * Author URI:      https://krokedil.se/
  * Text Domain:     collector-checkout-for-woocommerce
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'COLLECTOR_BANK_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'COLLECTOR_BANK_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'COLLECTOR_BANK_VERSION', '2.0.0' );
+define( 'COLLECTOR_BANK_VERSION', '2.0.1' );
 define( 'COLLECTOR_DB_VERSION', '1' );
 
 if ( ! class_exists( 'Collector_Checkout' ) ) {

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -8,14 +8,14 @@
  * Plugin Name:     Collector Checkout for WooCommerce
  * Plugin URI:      https://krokedil.se/collector/
  * Description:     Extends WooCommerce. Provides a <a href="https://www.collector.se/" target="_blank">Collector Checkout</a> checkout for WooCommerce.
- * Version:         2.0.1
+ * Version:         2.0.2
  * Author:          Krokedil
  * Author URI:      https://krokedil.se/
  * Text Domain:     collector-checkout-for-woocommerce
  * Domain Path:     /languages
  *
  * WC requires at least: 3.8.0
- * WC tested up to: 4.7.0
+ * WC tested up to: 4.7.1
  *
  * Copyright:       © 2017-2020 Krokedil.
  * License:         GNU General Public License v3.0
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'COLLECTOR_BANK_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'COLLECTOR_BANK_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'COLLECTOR_BANK_VERSION', '2.0.1' );
+define( 'COLLECTOR_BANK_VERSION', '2.0.2' );
 define( 'COLLECTOR_DB_VERSION', '1' );
 
 if ( ! class_exists( 'Collector_Checkout' ) ) {

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -114,7 +114,7 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 			// Translations
 			load_plugin_textdomain( 'collector-checkout-for-woocommerce', false, plugin_basename( dirname( __FILE__ ) ) . '/languages' );
 
-			add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, add_action_links ) );
+			add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'add_action_links' ) );
 		}
 
 		public function load_scripts() {

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -8,14 +8,14 @@
  * Plugin Name:     Collector Checkout for WooCommerce
  * Plugin URI:      https://krokedil.se/collector/
  * Description:     Extends WooCommerce. Provides a <a href="https://www.collector.se/" target="_blank">Collector Checkout</a> checkout for WooCommerce.
- * Version:         1.5.3
+ * Version:         2.0.0
  * Author:          Krokedil
  * Author URI:      https://krokedil.se/
  * Text Domain:     collector-checkout-for-woocommerce
  * Domain Path:     /languages
  *
- * WC requires at least: 3.0.0
- * WC tested up to: 4.0.1
+ * WC requires at least: 3.8.0
+ * WC tested up to: 4.7.0
  *
  * Copyright:       © 2017-2020 Krokedil.
  * License:         GNU General Public License v3.0
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'COLLECTOR_BANK_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'COLLECTOR_BANK_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'COLLECTOR_BANK_VERSION', '1.5.3' );
+define( 'COLLECTOR_BANK_VERSION', '2.0.0' );
 define( 'COLLECTOR_DB_VERSION', '1' );
 
 if ( ! class_exists( 'Collector_Checkout' ) ) {

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -232,3 +232,31 @@ function get_collector_data_from_db( $private_id ) {
 function remove_collector_db_row_data( $private_id ) {
 	Collector_Checkout_DB::delete_data_entry( $private_id );
 }
+
+/**
+ * Checking if Collector Delivery Module is active.
+ *
+ * @return boolean
+ */
+function is_collector_delivery_module( $currency = false ) {
+	$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
+	$currency           = ! false === $currency ? $currency : get_woocommerce_currency();
+	switch ( $currency ) {
+		case 'SEK':
+			$delivery_module = isset( $collector_settings['collector_delivery_module_se'] ) ? $collector_settings['collector_delivery_module_se'] : 'no';
+			break;
+		case 'NOK':
+			$delivery_module = isset( $collector_settings['collector_delivery_module_no'] ) ? $collector_settings['collector_delivery_module_no'] : 'no';
+			break;
+		case 'DKK':
+			$delivery_module = isset( $collector_settings['collector_delivery_module_dk'] ) ? $collector_settings['collector_delivery_module_dk'] : 'no';
+			break;
+		case 'EUR':
+			$delivery_module = isset( $collector_settings['collector_delivery_module_fi'] ) ? $collector_settings['collector_delivery_module_fi'] : 'no';
+			break;
+		default:
+			$delivery_module = 'no';
+			break;
+	}
+	return $delivery_module;
+}

--- a/includes/collector-checkout-settings.php
+++ b/includes/collector-checkout-settings.php
@@ -53,12 +53,6 @@ $settings = array(
 		'title' => __( 'Sweden', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
 	),
-	'collector_delivery_module_se'    => array(
-		'title'   => __( 'Delivery module Sweden', 'collector-checkout-for-woocommerce' ),
-		'type'    => 'checkbox',
-		'label'   => __( 'Activate Delivery module for Sweden', 'collector-checkout-for-woocommerce' ),
-		'default' => 'no',
-	),
 	'collector_merchant_id_se_b2c'    => array(
 		'title'       => __( 'Merchant ID Sweden B2C', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
@@ -73,15 +67,15 @@ $settings = array(
 		'default'     => '',
 		'desc_tip'    => true,
 	),
+	'collector_delivery_module_se'    => array(
+		'title'   => __( 'Delivery module Sweden', 'collector-checkout-for-woocommerce' ),
+		'type'    => 'checkbox',
+		'label'   => __( 'Activate Delivery module for Sweden', 'collector-checkout-for-woocommerce' ),
+		'default' => 'no',
+	),
 	'no_settings_title'               => array(
 		'title' => __( 'Norway', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
-	),
-	'collector_delivery_module_no'    => array(
-		'title'   => __( 'Delivery module Norway', 'collector-checkout-for-woocommerce' ),
-		'type'    => 'checkbox',
-		'label'   => __( 'Activate Delivery module for Norway', 'collector-checkout-for-woocommerce' ),
-		'default' => 'no',
 	),
 	'collector_merchant_id_no_b2c'    => array(
 		'title'       => __( 'Merchant ID Norway B2C', 'collector-checkout-for-woocommerce' ),
@@ -97,15 +91,15 @@ $settings = array(
 		'default'     => '',
 		'desc_tip'    => true,
 	),
+	'collector_delivery_module_no'    => array(
+		'title'   => __( 'Delivery module Norway', 'collector-checkout-for-woocommerce' ),
+		'type'    => 'checkbox',
+		'label'   => __( 'Activate Delivery module for Norway', 'collector-checkout-for-woocommerce' ),
+		'default' => 'no',
+	),
 	'fi_settings_title'               => array(
 		'title' => __( 'Finland', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
-	),
-	'collector_delivery_module_fi'    => array(
-		'title'   => __( 'Delivery module Finland', 'collector-checkout-for-woocommerce' ),
-		'type'    => 'checkbox',
-		'label'   => __( 'Activate Delivery module for Finland', 'collector-checkout-for-woocommerce' ),
-		'default' => 'no',
 	),
 	'collector_merchant_id_fi_b2c'    => array(
 		'title'       => __( 'Merchant ID Finland B2C', 'collector-checkout-for-woocommerce' ),
@@ -121,15 +115,15 @@ $settings = array(
 		'default'     => '',
 		'desc_tip'    => true,
 	),
+	'collector_delivery_module_fi'    => array(
+		'title'   => __( 'Delivery module Finland', 'collector-checkout-for-woocommerce' ),
+		'type'    => 'checkbox',
+		'label'   => __( 'Activate Delivery module for Finland', 'collector-checkout-for-woocommerce' ),
+		'default' => 'no',
+	),
 	'dk_settings_title'               => array(
 		'title' => __( 'Denmark', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
-	),
-	'collector_delivery_module_dk'    => array(
-		'title'   => __( 'Delivery module Denmark', 'collector-checkout-for-woocommerce' ),
-		'type'    => 'checkbox',
-		'label'   => __( 'Activate Delivery module for Denmark', 'collector-checkout-for-woocommerce' ),
-		'default' => 'no',
 	),
 	'collector_merchant_id_dk_b2c'    => array(
 		'title'       => __( 'Merchant ID Denmark B2C', 'collector-checkout-for-woocommerce' ),
@@ -137,6 +131,12 @@ $settings = array(
 		'description' => __( 'Enter your Collector Checkout Merchant ID for B2C purchases in Denmark', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
+	),
+	'collector_delivery_module_dk'    => array(
+		'title'   => __( 'Delivery module Denmark', 'collector-checkout-for-woocommerce' ),
+		'type'    => 'checkbox',
+		'label'   => __( 'Activate Delivery module for Denmark', 'collector-checkout-for-woocommerce' ),
+		'default' => 'no',
 	),
 	'checkout_settings_title'         => array(
 		'title' => __( 'Checkout settings', 'collector-checkout-for-woocommerce' ),

--- a/readme.txt
+++ b/readme.txt
@@ -2,11 +2,11 @@
 Contributors: collectorbank, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, collector, checkout
 Requires at least: 4.7
-Tested up to: 5.4.1
+Tested up to: 5.5.3
 Requires PHP: 5.6
 Stable tag: trunk
-WC requires at least: 3.0.0
-WC tested up to: 4.0.1
+WC requires at least: 3.8.0
+WC tested up to: 4.7.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -39,6 +39,20 @@ For help setting up and configuring Collector Checkout for WooCommerce please re
 
 
 == CHANGELOG ==
+= 2020.11.17    - version 2.0.0 =
+* Feature       - Add support for Collector Delivery Module.
+* Feature       - Add validation callback logic (as an optional feature). Checks for coupon validation, products in stock, user logged in (if needed) and order amount.
+* Feature       - Add support for order management for collector_invoice payment method.
+* Tweak         - Add separate db table to store data for validation callback handling.
+* Tweak         - Use Action scheduler instead of WP cron for queuing notification callback handling.
+* Tweak         - Add WC checkout form fields to Collector Checkout template + add email address to form during customer address update callback.
+* Tweak         - Trigger change/blur after updating email address field. Adds support with MailChimp abandoned cart functionality.
+* Tweak         - Run payment_complete process in process_payment (instead of woocommerce_thankyou).
+* Tweak         - Use Collector paymentName instead of paymentMethod to store the payment mehtod used for the purchase.
+* Tweak         - Add settings link on plugin page.
+* Fix           - Updated depricated add_fee to be using add_item instead for invoice fee.
+* Fix           - Remove double trigger of set_order_status function (could cause double order notes regarding "Payment via Collector Checkout...").
+
 = 2020.05.05    - version 1.5.3 =
 * Fix           - Correct amount is refunded when some order rows is partially and some completely refunded.
 

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,9 @@ For help setting up and configuring Collector Checkout for WooCommerce please re
 
 
 == CHANGELOG ==
+= 2020.11.17    - version 2.0.1 =
+* Fix           - Fixed PHP warning in plugin_action_links filter.
+
 = 2020.11.17    - version 2.0.0 =
 * Feature       - Add support for Collector Delivery Module.
 * Feature       - Add validation callback logic (as an optional feature). Checks for coupon validation, products in stock, user logged in (if needed) and order amount.

--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,7 @@ For help setting up and configuring Collector Checkout for WooCommerce please re
 
 
 == CHANGELOG ==
-= 2020.11.17    - version 2.0.2 =
+= 2020.11.30    - version 2.0.2 =
 * Tweak         - Add separate cart shipping template if Delivery module is active. To avoid displaying fallback/standard Woo shipping methods.
 * Fix           - Reduce the amount of update requests sent to Collector when using Delivery module.
 * Fix           - Fix validation callback error that could happen when switching between B2B & B2C checkout.

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 5.5.3
 Requires PHP: 5.6
 Stable tag: trunk
 WC requires at least: 3.8.0
-WC tested up to: 4.7.0
+WC tested up to: 4.7.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -39,6 +39,13 @@ For help setting up and configuring Collector Checkout for WooCommerce please re
 
 
 == CHANGELOG ==
+= 2020.11.17    - version 2.0.2 =
+* Tweak         - Add separate cart shipping template if Delivery module is active. To avoid displaying fallback/standard Woo shipping methods.
+* Fix           - Reduce the amount of update requests sent to Collector when using Delivery module.
+* Fix           - Fix validation callback error that could happen when switching between B2B & B2C checkout.
+* Fix           - Save Collector payment meta data correctly on order creation triggered during checkout_error event. Could cause duplicate orders in Woo.
+* Fix           - Tweak in order totals check (in callback from Collector to Woo) to avoid mismatch when there actually isn't one.
+
 = 2020.11.17    - version 2.0.1 =
 * Fix           - Fixed PHP warning in plugin_action_links filter.
 

--- a/templates/collector-cart-shipping.php
+++ b/templates/collector-cart-shipping.php
@@ -11,15 +11,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $shipping_id = WC()->session->get( 'chosen_shipping_methods' )[0];
 $packages    = WC()->shipping->get_packages();
+$rate        = null;
 foreach ( $packages as $package ) {
 	if ( isset( $package['rates'] ) && isset( $package['rates'][ $shipping_id ] ) ) {
 		$rate = $package['rates'][ $shipping_id ];
 		break;
 	}
 }
-?>
-
-<tr class="woocommerce-shipping-totals shipping">
-	<th><?php esc_html_e( 'Shipping', 'woocommerce' ); ?></th>
-	<td data-title="Shipping" class="kco-shipping"><?php echo wc_cart_totals_shipping_method_label( $rate ); // WPCS: XSS ok. ?></td>
-</tr>
+if ( ! empty( $rate ) ) {
+	?>
+	<tr class="woocommerce-shipping-totals shipping">
+		<th><?php esc_html_e( 'Shipping', 'woocommerce' ); ?></th>
+		<td data-title="Shipping" class="kco-shipping"><?php echo wc_cart_totals_shipping_method_label( $rate ); // WPCS: XSS ok. ?></td>
+	</tr>
+	<?php
+}

--- a/templates/collector-cart-shipping.php
+++ b/templates/collector-cart-shipping.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Template file for the shipping section of the cart.
+ *
+ * @package Collector/Templates
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$shipping_id = WC()->session->get( 'chosen_shipping_methods' )[0];
+$packages    = WC()->shipping->get_packages();
+foreach ( $packages as $package ) {
+	if ( isset( $package['rates'] ) && isset( $package['rates'][ $shipping_id ] ) ) {
+		$rate = $package['rates'][ $shipping_id ];
+		break;
+	}
+}
+?>
+
+<tr class="woocommerce-shipping-totals shipping">
+	<th><?php esc_html_e( 'Shipping', 'woocommerce' ); ?></th>
+	<td data-title="Shipping" class="kco-shipping"><?php echo wc_cart_totals_shipping_method_label( $rate ); // WPCS: XSS ok. ?></td>
+</tr>


### PR DESCRIPTION
* Tweak - Add separate cart shipping template if Delivery module is active. To avoid displaying fallback/standard Woo shipping methods.
* Fix - Reduce the amount of update requests sent to Collector when using Delivery module.
* Fix - Fix validation callback error that could happen when switching between B2B & B2C checkout.
* Fix - Save Collector payment meta data correctly on order creation triggered during checkout_error event. Could cause duplicate orders in Woo.
* Fix - Tweak in order totals check (in callback from Collector to Woo) to avoid mismatch when there actually isn't one.