### PR TITLE
2.2.3

### DIFF
--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -129,17 +129,45 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 
 		// Check that update fees request was ok.
 		if ( is_wp_error( $collector_order_fee ) ) {
-			// Check if purchase was completed, if it was dont redirect customer.
+			// Check if purchase was completed, if it was don't redirect customer.
 			if ( 900 === $collector_order_fee->get_error_code() ) {
-				foreach ( $collector_order_fee->get_error_messages() as $error ) {
-					if ( 'Purchase_Completed' === $error->reason ) {
-						$return                 = array();
-						$return['redirect_url'] = '#';
-						wp_send_json_error( $return );
-						wp_die();
+				if ( ! empty( $collector_order_fee->get_error_message( 'Purchase_Completed' ) ) || ! empty( $collector_order_fee->get_error_message( 'Purchase_Commitment_Found' ) ) ) {
+					$return = array();
+					// Check if an order exist with this private id. If we find a match, redirect to thank you page.
+					$order_id = wc_collector_get_order_id_by_private_id( $private_id );
+					if ( ! empty( $order_id ) ) {
+						$order = wc_get_order( $order_id );
+						if ( is_object( $order ) ) {
+							$return['redirect_url'] = $order->get_checkout_order_received_url();
+						} else {
+							$return['redirect_url'] = '#900';
+						}
+					} else {
+						$return['redirect_url'] = '#900';
 					}
+					wp_send_json_error( $return );
+					wp_die();
 				}
 			}
+
+			// Check if somethings wrong with the content of the cart sent, if it was don't redirect customer.
+			if ( 400 === $collector_order_fee->get_error_code() ) {
+				if ( ! empty( $collector_order_fee->get_error_message( 'Duplicate_Articles' ) ) || ! empty( $collector_order_fee->get_error_message( 'Validation_Error' ) ) ) {
+					$return                 = array();
+					$return['redirect_url'] = '#400';
+					wp_send_json_error( $return );
+					wp_die();
+				}
+			}
+
+			// Check if the resource is temporarily locked, if it was don't redirect customer.
+			if ( 423 === $collector_order_fee->get_error_code() ) {
+				$return                 = array();
+				$return['redirect_url'] = '#423';
+				wp_send_json_error( $return );
+				wp_die();
+			}
+
 			wc_collector_unset_sessions();
 			$return                 = array();
 			$return['redirect_url'] = wc_get_checkout_url();
@@ -152,6 +180,35 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 
 		// Check that update cart request was ok.
 		if ( is_wp_error( $collector_order_cart ) ) {
+
+			// Check if purchase was completed, if it was don't redirect customer.
+			if ( 900 === $collector_order_cart->get_error_code() ) {
+				if ( ! empty( $collector_order_cart->get_error_message( 'Purchase_Completed' ) ) || ! empty( $collector_order_cart->get_error_message( 'Purchase_Commitment_Found' ) ) ) {
+					$return                 = array();
+					$return['redirect_url'] = '#';
+					wp_send_json_error( $return );
+					wp_die();
+				}
+			}
+
+			// Check if somethings wrong with the content of the cart sent, if it was don't redirect customer.
+			if ( 400 === $collector_order_cart->get_error_code() ) {
+				if ( ! empty( $collector_order_cart->get_error_message( 'Duplicate_Articles' ) ) || ! empty( $collector_order_cart->get_error_message( 'Validation_Error' ) ) ) {
+					$return                 = array();
+					$return['redirect_url'] = '#';
+					wp_send_json_error( $return );
+					wp_die();
+				}
+			}
+
+			// Check if the resource is temporarily locked, if it was don't redirect customer.
+			if ( 423 === $collector_order_cart->get_error_code() ) {
+				$return                 = array();
+				$return['redirect_url'] = '#';
+				wp_send_json_error( $return );
+				wp_die();
+			}
+
 			wc_collector_unset_sessions();
 			$return                 = array();
 			$return['redirect_url'] = wc_get_checkout_url();

--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -69,11 +69,10 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 		} else {
 
 			// Get a new public token from Collector.
-			$init_checkout = new Collector_Checkout_Requests_Initialize_Checkout( $customer_type );
-			$request       = $init_checkout->request();
-			$decode        = json_decode( $request );
+			$init_checkout   = new Collector_Checkout_Requests_Initialize_Checkout( $customer_type );
+			$collector_order = $init_checkout->request();
 
-			if ( is_wp_error( $request ) || empty( $request ) ) {
+			if ( is_wp_error( $collector_order ) || empty( $collector_order ) ) {
 					$return = sprintf( '%s <a href="%s" class="button wc-forward">%s</a>', __( 'Could not connect to Collector. Error message: ', 'collector-checkout-for-woocommerce' ) . $request->get_error_message(), wc_get_checkout_url(), __( 'Try again', 'collector-checkout-for-woocommerce' ) );
 				wp_send_json_error( $return );
 				wp_die();
@@ -81,14 +80,14 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 			} else {
 
 				$return = array(
-					'publicToken'   => $decode->data->publicToken,
+					'publicToken'   => $collector_order['data']['publicToken'],
 					'test_mode'     => $test_mode,
 					'customer_type' => $customer_type,
 				);
 
 				// Set post metas so they can be used again later.
-				WC()->session->set( 'collector_public_token', $decode->data->publicToken );
-				WC()->session->set( 'collector_private_id', $decode->data->privateId );
+				WC()->session->set( 'collector_public_token', $collector_order['data']['publicToken'] );
+				WC()->session->set( 'collector_private_id', $collector_order['data']['privateId'] );
 				WC()->session->set( 'collector_customer_type', $customer_type );
 				WC()->session->set( 'collector_currency', get_woocommerce_currency() );
 
@@ -98,7 +97,7 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 					'session_id' => $collector_checkout_sessions->get_session_id(),
 				);
 				$args                        = array(
-					'private_id' => $decode->data->privateId,
+					'private_id' => $collector_order['data']['privateId'],
 					'data'       => $collector_data,
 				);
 				$result                      = Collector_Checkout_DB::create_data_entry( $args );

--- a/classes/requests/class-collector-checkout-requests.php
+++ b/classes/requests/class-collector-checkout-requests.php
@@ -70,6 +70,7 @@ class Collector_Checkout_Requests {
 			$data          = 'URL: ' . $request_url . ' - ' . wp_json_encode( $request_args );
 			$error_message = '';
 			// Get the error messages.
+			// @todo - remove this if?
 			if ( null !== $response['response'] ) {
 				$aco_error_code    = isset( $response['response']['code'] ) ? $response['response']['code'] . ' ' : '';
 				$aco_error_message = isset( $response['response']['message'] ) ? $response['response']['message'] . ' ' : '';
@@ -77,13 +78,14 @@ class Collector_Checkout_Requests {
 			}
 
 			if ( null !== json_decode( $response['body'], true ) ) {
-				$errors = json_decode( $response['body'], true );
-
-				foreach ( $errors as $key => $error ) {
-					$error_message .= $error['code'] . '. ' . $error['message'];
+				$response_body = json_decode( $response['body'], true );
+				$error         = new WP_Error();
+				$error->add( wp_remote_retrieve_response_code( $response ), $response_body['error']['message'] );
+				foreach ( $response_body['error']['errors'] as $key => $collector_error ) {
+					$error->add( $collector_error['reason'], $collector_error['message'] );
 				}
 			}
-			return new WP_Error( wp_remote_retrieve_response_code( $response ), $error_message, $data );
+			return $error;
 		}
 		return json_decode( wp_remote_retrieve_body( $response ), true );
 	}

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:     Collector Checkout for WooCommerce
  * Plugin URI:      https://krokedil.se/collector/
  * Description:     Extends WooCommerce. Provides a <a href="https://www.collector.se/" target="_blank">Collector Checkout</a> checkout for WooCommerce.
- * Version:         2.2.2
+ * Version:         2.2.3
  * Author:          Krokedil
  * Author URI:      https://krokedil.se/
  * Text Domain:     collector-checkout-for-woocommerce
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'COLLECTOR_BANK_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'COLLECTOR_BANK_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'COLLECTOR_BANK_VERSION', '2.2.2' );
+define( 'COLLECTOR_BANK_VERSION', '2.2.3' );
 define( 'COLLECTOR_DB_VERSION', '1' );
 
 if ( ! class_exists( 'Collector_Checkout' ) ) {

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -354,3 +354,34 @@ function wc_collector_verify_customer_data( $collector_order ) {
 	}
 	return $customer_information;
 }
+
+/**
+ * Finds an Order ID based on a private ID (the Collector session id during purchase).
+ *
+ * @param string $private_id Collector session id saved as _collector_private_id ID in WC order.
+ * @return int The ID of an order, or 0 if the order could not be found.
+ */
+function wc_collector_get_order_id_by_private_id( $private_id ) {
+	$query_args = array(
+		'fields'      => 'ids',
+		'post_type'   => wc_get_order_types(),
+		'post_status' => array_keys( wc_get_order_statuses() ),
+		'meta_key'    => '_collector_private_id', // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
+		'meta_value'  => sanitize_text_field( wp_unslash( $private_id ) ), // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
+		'date_query'  => array(
+			array(
+				'after' => '120 day ago',
+			),
+		),
+	);
+
+	$orders = get_posts( $query_args );
+
+	if ( $orders ) {
+		$order_id = $orders[0];
+	} else {
+		$order_id = 0;
+	}
+
+	return $order_id;
+}

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: collectorbank, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, collector, checkout
 Requires at least: 4.7
-Tested up to: 5.6.1
+Tested up to: 5.6.2
 Requires PHP: 5.6
 Stable tag: trunk
 WC requires at least: 4.0.0
@@ -39,6 +39,11 @@ For help setting up and configuring Collector Checkout for WooCommerce please re
 
 
 == CHANGELOG ==
+= 2021.02.25    - version 2.2.3 =
+* Tweak         - Improved error response handling in requests. Don't try to create a new Collector session if we get 900, 400 or 423 http responses during update requests.
+* Tweak         - Try to redirect to thankyou page if response is Purchase_Completed from Collector and we find a matching order in WooCommerce.
+* Fix           - Fix B2B / B2C switcher bug in checkout. 
+
 = 2021.02.22    - version 2.2.2 =
 * Fix           - Do not try to make a update fees request to Collector if not needed. Could cause multiple init requests and constant reloading of checkout page.
 


### PR DESCRIPTION
* Tweak - Improved error response handling in requests. Don't try to create a new Collector session if we get 900, 400 or 423 http responses during update requests.
* Tweak - Try to redirect to thankyou page if response is Purchase_Completed from Collector and we find a matching order in WooCommerce.
* Fix - Fix B2B / B2C switcher bug in checkout. 