### PR TITLE
Fix backward compatibility

### DIFF
--- a/classes/class-collector-checkout-post-checkout.php
+++ b/classes/class-collector-checkout-post-checkout.php
@@ -99,7 +99,7 @@ class Collector_Checkout_Post_Checkout {
 	 * Check for Collector Invoice Status Change (anti fraud system)
 	 **/
 	public function check_callback() {
-		if ( ! empty( $_SERVER['REQUEST_URI'] ) && str_contains( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), 'module/collectorcheckout/invoicestatus' ) ) {
+		if ( ! empty( $_SERVER['REQUEST_URI'] ) && false !== strpos( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), 'module/collectorcheckout/invoicestatus' ) ) {
 			$invoice_no     = filter_input( INPUT_GET, 'InvoiceNo', FILTER_SANITIZE_STRING );
 			$invoice_status = filter_input( INPUT_GET, 'InvoiceStatus', FILTER_SANITIZE_STRING );
 			if ( ! empty( $invoice_no ) && ! empty( $invoice_status ) ) {


### PR DESCRIPTION
str_contains (added in PHP 8) breaks backward-compatibility.

This has been tested with PHP 7.4 and 8.0.