### PR TITLE
Check if the shipping options exist before access

### DIFF
--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -703,9 +703,12 @@ function coc_get_shipping_data( $collector_order ) {
 		// Handle Walley Custom Delivery Adapter.
 		foreach ( $shipping['shipments'] as $shipment ) {
 			$cost = $shipment['shippingChoice']['fee'];
-			foreach ( $shipment['shippingChoice']['options'] as $option ) {
+			
+			$shipment_options = $shipment['shippingChoice']['options'] ?? array();
+			foreach ( $shipment_options as $option ) {
 				$cost += $option['fee'] ?? 0;
 			}
+
 			$shipping_data[] = array(
 				'label'        => $shipment['shippingChoice']['id'],
 				'shipping_id'  => $shipment['shippingChoice']['id'],


### PR DESCRIPTION
`PHP Warning:  foreach() argument must be of type array|object, null given in /var/www/html/wp-content/plugins/collector-checkout-for-woocommerce/includes/collector-checkout-for-woocommerce-functions.php on line 704`