### PR TITLE
Walley Delivery Module

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -398,12 +398,14 @@
     }
 
     function set_customer_data( data ) {
-        console.log( data );
+        console.log( 'set_customer_data', data );
         if (  null !== data.billing_country ) {
             // Billing fields.
             $( '#billing_postcode' ).val( ( ( data.billing_postcode ) ? data.billing_postcode : '' ) );
             $( '#billing_country' ).val( ( ( data.billing_country ) ? data.billing_country.toUpperCase() : '' ) );
             $( '#billing_email' ).val( ( ( data.billing_email ) ? data.billing_email : '' ) );
+            $( '#billing_address_1' ).val( ( ( data.billing_address ) ? data.billing_address : '' ) );
+            $( '#billing_city' ).val( ( ( data.billing_city ) ? data.billing_city : '' ) );
         }
         
         if ( null !== data.shipping_country ) {
@@ -412,6 +414,8 @@
             // Shipping fields.
             $( '#shipping_postcode' ).val( ( ( data.shipping_postcode ) ? data.shipping_postcode : '' ) );
             $( '#shipping_country' ).val( ( ( data.shipping_country ) ? data.shipping_country.toUpperCase() : '' ) );
+            $( '#shipping_address_1' ).val( ( ( data.shipping_address ) ? data.shipping_address : '' ) );
+            $( '#shipping_city' ).val( ( ( data.shipping_city ) ? data.shipping_city : '' ) );
         }
 
         // Trigger changes.

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -66,7 +66,6 @@
     
     // Customer updated - event triggered when customer changes address in Collector iframe
     document.addEventListener("collectorCheckoutCustomerUpdated", function(){
-        var url = window.location.href;
         // Check that this only happens in checkout page. Don't do it on thank you page
         if ( wc_collector_checkout.is_thank_you_page === 'no' ) {
             window.collector.checkout.api.suspend();

--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -287,10 +287,20 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 		$customer_data['billing_email']    = $collector_order['data']['customer']['email'];
 
 		if ( 'BusinessCustomer' === $collector_order['data']['customerType'] ) {
-			$customer_data['billing_postcode']  = $collector_order['data']['businessCustomer']['invoiceAddress']['postalCode'];
+			$customer_data['billing_city']     = $collector_order['data']['businessCustomer']['invoiceAddress']['city'];
+			$customer_data['billing_address']  = $collector_order['data']['businessCustomer']['invoiceAddress']['address'];
+			$customer_data['billing_postcode'] = $collector_order['data']['businessCustomer']['invoiceAddress']['postalCode'];
+
+			$customer_data['shipping_city']     = $collector_order['data']['businessCustomer']['deliveryAddress']['city'];
+			$customer_data['shipping_address']  = $collector_order['data']['businessCustomer']['deliveryAddress']['address'];
 			$customer_data['shipping_postcode'] = $collector_order['data']['businessCustomer']['deliveryAddress']['postalCode'];
 		} else {
-			$customer_data['billing_postcode']  = $collector_order['data']['customer']['billingAddress']['postalCode'];
+			$customer_data['billing_city']     = $collector_order['data']['customer']['deliveryAddress']['city'];
+			$customer_data['billing_address']  = $collector_order['data']['customer']['billingAddress']['address'];
+			$customer_data['billing_postcode'] = $collector_order['data']['customer']['billingAddress']['postalCode'];
+
+			$customer_data['shipping_city']     = $collector_order['data']['customer']['deliveryAddress']['city'];
+			$customer_data['shipping_address']  = $collector_order['data']['customer']['deliveryAddress']['address'];
 			$customer_data['shipping_postcode'] = $collector_order['data']['customer']['deliveryAddress']['postalCode'];
 		}
 
@@ -306,11 +316,16 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 				$update_needed = 'yes';
 			}
 			// Set customer data in Woo.
+			WC()->customer->set_billing_address( $customer_data['billing_address'] );
 			WC()->customer->set_billing_country( $customer_data['billing_country'] );
-			WC()->customer->set_shipping_country( $customer_data['shipping_country'] );
+			WC()->customer->set_billing_city( $customer_data['billing_city'] );
 			WC()->customer->set_billing_postcode( $customer_data['billing_postcode'] );
+			WC()->customer->set_shipping_country( $customer_data['shipping_country'] );
+			WC()->customer->set_shipping_city( $customer_data['shipping_city'] );
+			WC()->customer->set_shipping_address( $customer_data['shipping_address'] );
 			WC()->customer->set_shipping_postcode( $customer_data['shipping_postcode'] );
 			WC()->customer->save();
+
 			WC()->cart->calculate_totals();
 		}
 

--- a/classes/class-collector-checkout-api-callbacks.php
+++ b/classes/class-collector-checkout-api-callbacks.php
@@ -648,6 +648,11 @@ class Collector_Api_Callbacks {
 	 */
 	public function get_collector_fee_total() {
 		$fee_total_amount = 0;
+
+		if ( ! isset( $this->collector_order['data']['fees'] ) ) {
+			return 0;
+		}
+
 		// Loop all fees and them to the total.
 		foreach ( $this->collector_order['data']['fees'] as $cart_fee => $fee ) {
 			// Ignore shipping fees since they will be included by the shipping amount, but only if a shipping object exists under data.

--- a/classes/requests/helpers/class-collector-checkout-requests-cart.php
+++ b/classes/requests/helpers/class-collector-checkout-requests-cart.php
@@ -116,8 +116,17 @@ class Collector_Checkout_Requests_Cart {
 		);
 
 		// Get WooCommerce cart totals including tax.
-		$wc_total        = WC()->cart->get_total( 'total' ) - ( WC()->cart->get_shipping_total() + WC()->cart->get_shipping_tax() );
+		$wc_total        = WC()->cart->get_total( 'total' );
 		$collector_total = 0;
+
+		/**
+		 * If shipping is handled by WooCommerce, it will be passed separately in the fees.shipping object.
+		 * Since the $wc_total include the shipping cost, it must be subtracted so that both $wc_total and $collector_total
+		 * only include item cost.
+		 */
+		if ( WC()->cart->show_shipping() ) {
+			$wc_total -= WC()->cart->get_shipping_total() + WC()->cart->get_shipping_tax();
+		}
 
 		// Add all collector item amounts together.
 		foreach ( $collector_items as $collector_item ) {

--- a/classes/requests/helpers/class-collector-checkout-requests-cart.php
+++ b/classes/requests/helpers/class-collector-checkout-requests-cart.php
@@ -137,7 +137,7 @@ class Collector_Checkout_Requests_Cart {
 		$rounding_item['unitPrice'] = round( $wc_total - $collector_total, 2 );
 
 		// Add the rounding item to the collector items only if the price is not zero.
-		if ( ! empty( $rounding_item['unitPrice'] ) ) {
+		if ( ! empty( $rounding_item['unitPrice'] && abs( $rounding_item['unitPrice'] < 3 ) ) ) {
 			$collector_items[] = $rounding_item;
 		}
 	}

--- a/classes/requests/helpers/class-collector-checkout-requests-fees.php
+++ b/classes/requests/helpers/class-collector-checkout-requests-fees.php
@@ -77,7 +77,7 @@ class Collector_Checkout_Requests_Fees {
 		 */
 		$update_shipping = apply_filters( 'coc_update_shipping', ( 'no' === $this->delivery_module || 'v2' === $this->checkout_version ) ); // Filter on if we should update shipping with fees or not.
 		$shipping        = $this->get_shipping();
-		if ( $update_shipping && ! empty( $shipping ) ) {
+		if ( ( WC()->cart->show_shipping() && $update_shipping ) && ! empty( $shipping ) ) {
 			$fees['shipping'] = $shipping;
 		}
 

--- a/classes/requests/helpers/class-collector-checkout-requests-fees.php
+++ b/classes/requests/helpers/class-collector-checkout-requests-fees.php
@@ -72,13 +72,21 @@ class Collector_Checkout_Requests_Fees {
 		$fees = array();
 
 		/**
-		 * If a delivery module is not used, the shipping is handled in WooCommerce, and must be sent in the fee.shipping object.
+		 * If a delivery module is not used, the shipping is handled in WooCommerce, and must be sent in the fee.shipping object. Retrieves first available.
 		 * Note: if no shipping is available, fees.shipping is simply unset, NOT null.
 		 */
 		$update_shipping = apply_filters( 'coc_update_shipping', ( 'no' === $this->delivery_module || 'v2' === $this->checkout_version ) ); // Filter on if we should update shipping with fees or not.
 		$shipping        = $this->get_shipping();
 		if ( $update_shipping && ! empty( $shipping ) ) {
 			$fees['shipping'] = $shipping;
+		}
+
+		/**
+		 * If "Hide shipping cost until address is entered" is enabled, we don't want to send the shipping cost yet,
+		 * as this will cause a discrepancy between WooCommerce and Walley since the WooCommerce shipping cost is zero.
+		 */
+		if ( ! WC()->cart->show_shipping() ) {
+			unset( $fees['shipping'] );
 		}
 
 		if ( $this->invoice_fee_id ) {

--- a/classes/requests/helpers/class-collector-checkout-requests-fees.php
+++ b/classes/requests/helpers/class-collector-checkout-requests-fees.php
@@ -69,10 +69,15 @@ class Collector_Checkout_Requests_Fees {
 	 * @return array|string
 	 */
 	public function fees() {
-		$fees            = array();
+		$fees = array();
+
+		/**
+		 * If a delivery module is not used, the shipping is handled in WooCommerce, and must be sent in the fee.shipping object.
+		 * Note: if no shipping is available, fees.shipping is simply unset, NOT null.
+		 */
 		$update_shipping = apply_filters( 'coc_update_shipping', ( 'no' === $this->delivery_module || 'v2' === $this->checkout_version ) ); // Filter on if we should update shipping with fees or not.
-		if ( $update_shipping ) {
-			$shipping         = $this->get_shipping();
+		$shipping        = $this->get_shipping();
+		if ( $update_shipping && ! empty( $shipping ) ) {
 			$fees['shipping'] = $shipping;
 		}
 

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -73,7 +73,7 @@ function collector_wc_show_snippet() {
 				'private_id' => $collector_order['data']['privateId'],
 				'data'       => $collector_data,
 			);
-			$result                      = Collector_Checkout_DB::create_data_entry( $args );
+			Collector_Checkout_DB::create_data_entry( $args );
 
 			$public_token = $collector_order['data']['publicToken'];
 			$output       = array(
@@ -703,7 +703,7 @@ function coc_get_shipping_data( $collector_order ) {
 		// Handle Walley Custom Delivery Adapter.
 		foreach ( $shipping['shipments'] as $shipment ) {
 			$cost = $shipment['shippingChoice']['fee'];
-			
+
 			$shipment_options = $shipment['shippingChoice']['options'] ?? array();
 			foreach ( $shipment_options as $option ) {
 				$cost += $option['fee'] ?? 0;


### PR DESCRIPTION
1. There is an issue where if the setting "Hide shipping costs until an address is entered" (WooCommerce settings > Shipping > Shipping options > "Hide shipping costs until an address is entered"). WooCommerce does not detect an address change since not enough information is provided.

2. Since `$collector_total` only include the products, when comparing with `$wc_total`, it will be smaller, thus the shipping cost must be subtracted from `$wc_total`. The opposite may also be true if shipping is sent both in the `fees.shipping` and accounted for in `$wc_total`. This will happen when a shipping object is sent, while WC has not yet identified the customer's address.

3. If the "Walley Delivery Module" is enabled, the shipping option will not be available, only the default ones (if available). This will result in a discrepancy between WooCommerce that has a default shipping cost, and Walley that does not include a shipping cost. For this purpose, we want to WooCommerce to wait with calculating shipping until a shipping option from Walley is available.

This PR fixes the following symptoms:
- 400 error due to shipping.fee when delivery module is enabled.
- negative or positive rounding error that is equivalent to the shipping amount.
- the WC total in the order review does not match the total in the Walley form.