### PR TITLE
Check if session exists before access

### DIFF
--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -509,7 +509,7 @@ function wc_collector_get_default_customer_type() {
  */
 function wc_collector_get_selected_customer_type() {
 	$selected_customer_type = false;
-	if ( method_exists( WC()->session, 'get' ) ) {
+	if ( isset( WC()->session ) && method_exists( WC()->session, 'get' ) ) {
 		$selected_customer_type = WC()->session->get( 'collector_customer_type' );
 	}
 


### PR DESCRIPTION
`CRITICAL Uncaught TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given in /wp-content/plugins/collector-checkout-for-woocommerce/collector-checkout-for-woocommerce.php:509`