### PR TITLE
Develop delivery module setting

### DIFF
--- a/classes/requests/class-collector-checkout-requests-initialize-checkout.php
+++ b/classes/requests/class-collector-checkout-requests-initialize-checkout.php
@@ -163,13 +163,18 @@ class Collector_Checkout_Requests_Initialize_Checkout extends Collector_Checkout
 			'fees'             => ( null === $order_id ) ? $this->fees() : CCO_WC()->order_fees->get_order_fees( $order_id ),
 		);
 
+		$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
+
 		// Only send validationUri & profileName if this is a purchase from the checkout.
 		if ( null === $order_id ) {
 			if ( 'yes' === $this->activate_validation_callback ) {
 				$formatted_request_body['validationUri'] = $validation_uri;
 			}
 			if ( 'yes' === $this->delivery_module && 'v1' === $this->checkout_version ) {
-				$formatted_request_body['profileName'] = 'Shipping';
+				$formatted_request_body['profileName'] = $collector_settings[ 'collector_delivery_module_profile_' . strtolower( $this->country_code ) ];
+				if ( empty( $formatted_request_body['profileName'] ) ) {
+					$formatted_request_body['profileName'] = 'Shipping';
+				}
 			}
 
 			$formatted_request_body['redirectPageUri'] = add_query_arg(

--- a/classes/requests/class-collector-checkout-requests-initialize-checkout.php
+++ b/classes/requests/class-collector-checkout-requests-initialize-checkout.php
@@ -171,7 +171,7 @@ class Collector_Checkout_Requests_Initialize_Checkout extends Collector_Checkout
 				$formatted_request_body['validationUri'] = $validation_uri;
 			}
 			if ( 'yes' === $this->delivery_module && 'v1' === $this->checkout_version ) {
-				$formatted_request_body['profileName'] = $collector_settings[ 'collector_delivery_module_profile_' . strtolower( $this->country_code ) ];
+				$formatted_request_body['profileName'] = trim( $collector_settings[ 'collector_custom_profile_' . strtolower( $this->country_code ) ] );
 				if ( empty( $formatted_request_body['profileName'] ) ) {
 					$formatted_request_body['profileName'] = 'Shipping';
 				}

--- a/includes/collector-checkout-settings.php
+++ b/includes/collector-checkout-settings.php
@@ -67,7 +67,7 @@ $settings = array(
 	'collector_delivery_module_se'    => array(
 		'title'   => __( 'Walley nShift Delivery', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
-		'label'   => __( 'Active Walley nShift Delivery Sweden', 'collector-checkout-for-woocommerce' ),
+		'label'   => __( 'Activate Walley nShift Delivery Sweden', 'collector-checkout-for-woocommerce' ),
 		'default' => 'no',
 	),
 	'collector_custom_profile_se'     => array(
@@ -97,7 +97,7 @@ $settings = array(
 	'collector_delivery_module_no'    => array(
 		'title'   => __( 'Walley nShift Delivery', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
-		'label'   => __( 'Active Walley nShift Delivery Norway', 'collector-checkout-for-woocommerce' ),
+		'label'   => __( 'Activate Walley nShift Delivery Norway', 'collector-checkout-for-woocommerce' ),
 		'default' => 'no',
 	),
 	'collector_custom_profile_no'     => array(
@@ -127,7 +127,7 @@ $settings = array(
 	'collector_delivery_module_fi'    => array(
 		'title'   => __( 'Walley nShift Delivery', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
-		'label'   => __( 'Active Walley nShift Delivery Finland', 'collector-checkout-for-woocommerce' ),
+		'label'   => __( 'Activate Walley nShift Delivery Finland', 'collector-checkout-for-woocommerce' ),
 		'default' => 'no',
 	),
 	'collector_custom_profile_fi'     => array(
@@ -150,7 +150,7 @@ $settings = array(
 	'collector_delivery_module_dk'    => array(
 		'title'   => __( 'Walley nShift Delivery', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
-		'label'   => __( 'Active Walley nShift Delivery Denmark', 'collector-checkout-for-woocommerce' ),
+		'label'   => __( 'Activate Walley nShift Delivery Denmark', 'collector-checkout-for-woocommerce' ),
 		'default' => 'no',
 	),
 	'collector_custom_profile_dk'     => array(

--- a/includes/collector-checkout-settings.php
+++ b/includes/collector-checkout-settings.php
@@ -13,161 +13,157 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Settings for Collector Checkout
  */
 $settings = array(
-	'enabled'                              => array(
+	'enabled'                         => array(
 		'title'   => __( 'Enable/Disable', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
 		'label'   => __( 'Enable Walley Checkout (Collector)', 'collector-checkout-for-woocommerce' ),
 		'default' => 'no',
 	),
-	'title'                                => array(
+	'title'                           => array(
 		'title'       => __( 'Title', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'This is the title that the user sees on the checkout page for Walley Checkout (Collector).', 'collector-checkout-for-woocommerce' ),
 		'default'     => __( 'Walley Checkout', 'collector-checkout-for-woocommerce' ),
 	),
-	'collector_username'                   => array(
+	'collector_username'              => array(
 		'title'       => __( 'Username', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Username', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'collector_password'                   => array(
+	'collector_password'              => array(
 		'title'       => __( 'Password', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Password', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'collector_shared_key'                 => array(
+	'collector_shared_key'            => array(
 		'title'       => __( 'Shared Key', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Shared Key', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'se_settings_title'                    => array(
+	'se_settings_title'               => array(
 		'title' => __( 'Sweden', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
 	),
-	'collector_merchant_id_se_b2c'         => array(
+	'collector_merchant_id_se_b2c'    => array(
 		'title'       => __( 'Merchant ID Sweden B2C', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Merchant ID for B2C purchases in Sweden', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'collector_merchant_id_se_b2b'         => array(
+	'collector_merchant_id_se_b2b'    => array(
 		'title'       => __( 'Merchant ID Sweden B2B', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Merchant ID for B2B purchases in Sweden', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'collector_delivery_module_se'         => array(
-		'title'   => __( 'Shipping Module Sweden', 'collector-checkout-for-woocommerce' ),
+	'collector_delivery_module_se'    => array(
+		'title'   => __( 'Walley nShift Delivery', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
-		'label'   => __( 'Activate Shipping Module for Sweden', 'collector-checkout-for-woocommerce' ),
+		'label'   => __( 'Active Walley nShift Delivery Sweden', 'collector-checkout-for-woocommerce' ),
 		'default' => 'no',
 	),
-	'collector_delivery_module_profile_se' => array(
-		'title'       => __( 'Shipping Profile Sweden', 'collector-checkout-for-woocommerce' ),
+	'collector_custom_profile_se'     => array(
+		'title'       => __( 'Custom Profile Sweden', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( '', 'collector-checkout-for-woocommerce' ),
-		'label'       => __( 'Optional shipping module profile', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 	),
-	'no_settings_title'                    => array(
+	'no_settings_title'               => array(
 		'title' => __( 'Norway', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
 	),
-	'collector_merchant_id_no_b2c'         => array(
+	'collector_merchant_id_no_b2c'    => array(
 		'title'       => __( 'Merchant ID Norway B2C', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Merchant ID for B2C purchases in Norway', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'collector_merchant_id_no_b2b'         => array(
+	'collector_merchant_id_no_b2b'    => array(
 		'title'       => __( 'Merchant ID Norway B2B', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Merchant ID for B2B purchases in Norway', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'collector_delivery_module_no'         => array(
-		'title'   => __( 'Shipping Module Norway', 'collector-checkout-for-woocommerce' ),
+	'collector_delivery_module_no'    => array(
+		'title'   => __( 'Walley nShift Delivery', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
-		'label'   => __( 'Activate Shipping Module for Norway', 'collector-checkout-for-woocommerce' ),
+		'label'   => __( 'Active Walley nShift Delivery Norway', 'collector-checkout-for-woocommerce' ),
 		'default' => 'no',
 	),
-	'collector_delivery_module_profile_no' => array(
-		'title'       => __( 'Shipping Profile Norway', 'collector-checkout-for-woocommerce' ),
+	'collector_custom_profile_no'     => array(
+		'title'       => __( 'Custom Profile Norway', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( '', 'collector-checkout-for-woocommerce' ),
-		'label'       => __( 'Optional shipping module profile', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 	),
-	'fi_settings_title'                    => array(
+	'fi_settings_title'               => array(
 		'title' => __( 'Finland', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
 	),
-	'collector_merchant_id_fi_b2c'         => array(
+	'collector_merchant_id_fi_b2c'    => array(
 		'title'       => __( 'Merchant ID Finland B2C', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Merchant ID for B2C purchases in Finland', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'collector_merchant_id_fi_b2b'         => array(
+	'collector_merchant_id_fi_b2b'    => array(
 		'title'       => __( 'Merchant ID Finland B2B', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Merchant ID for B2B purchases in Finland', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'collector_delivery_module_fi'         => array(
-		'title'   => __( 'Shipping Module Finland', 'collector-checkout-for-woocommerce' ),
+	'collector_delivery_module_fi'    => array(
+		'title'   => __( 'Walley nShift Delivery', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
-		'label'   => __( 'Activate Shipping Module for Finland', 'collector-checkout-for-woocommerce' ),
+		'label'   => __( 'Active Walley nShift Delivery Finland', 'collector-checkout-for-woocommerce' ),
 		'default' => 'no',
 	),
-	'collector_delivery_module_profile_fi' => array(
-		'title'       => __( 'Shipping Profile Finland', 'collector-checkout-for-woocommerce' ),
+	'collector_custom_profile_fi'     => array(
+		'title'       => __( 'Custom Profile Finland', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( '', 'collector-checkout-for-woocommerce' ),
-		'label'       => __( 'Optional shipping module profile', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 	),
-	'dk_settings_title'                    => array(
+	'dk_settings_title'               => array(
 		'title' => __( 'Denmark', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
 	),
-	'collector_merchant_id_dk_b2c'         => array(
+	'collector_merchant_id_dk_b2c'    => array(
 		'title'       => __( 'Merchant ID Denmark B2C', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Merchant ID for B2C purchases in Denmark', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'collector_delivery_module_dk'         => array(
-		'title'   => __( 'Shipping Module Denmark', 'collector-checkout-for-woocommerce' ),
+	'collector_delivery_module_dk'    => array(
+		'title'   => __( 'Walley nShift Delivery', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
-		'label'   => __( 'Activate Shipping Module for Denmark', 'collector-checkout-for-woocommerce' ),
+		'label'   => __( 'Active Walley nShift Delivery Denmark', 'collector-checkout-for-woocommerce' ),
 		'default' => 'no',
 	),
-	'collector_delivery_module_profile_dk' => array(
-		'title'       => __( 'Shipping Profile Denmark', 'collector-checkout-for-woocommerce' ),
+	'collector_custom_profile_dk'     => array(
+		'title'       => __( 'Custom Profile Denmark', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( '', 'collector-checkout-for-woocommerce' ),
-		'label'       => __( 'Optional shipping module profile', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 	),
-	'checkout_settings_title'              => array(
+	'checkout_settings_title'         => array(
 		'title' => __( 'Checkout settings', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
 	),
-	'checkout_version'                     => array(
+	'checkout_version'                => array(
 		'title'       => __( 'Checkout version', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'select',
 		'description' => __( 'A brand new Checkout is available, project name Checkout 2.0. The current solution (referred as Checkout 1.0) will be deprecated during 2022.', 'collector-checkout-for-woocommerce' ),
@@ -177,7 +173,7 @@ $settings = array(
 		),
 		'default'     => 'v1',
 	),
-	'checkout_layout'                      => array(
+	'checkout_layout'                 => array(
 		'title'       => __( 'Checkout layout', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'select',
 		'options'     => array(
@@ -190,7 +186,7 @@ $settings = array(
 		'default'     => 'one_column_checkout',
 		'desc_tip'    => false,
 	),
-	'collector_invoice_fee'                => array(
+	'collector_invoice_fee'           => array(
 		'title'       => __( 'Invoice fee ID', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		/* Translators: link to docs */
@@ -198,7 +194,7 @@ $settings = array(
 		'default'     => '',
 		'desc_tip'    => false,
 	),
-	'collector_default_customer'           => array(
+	'collector_default_customer'      => array(
 		'title'       => __( 'Default customer', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'select',
 		'description' => __( 'Sets the default customer/checkout type for Walley Checkout (if offering both B2B & B2C)', 'collector-checkout-for-woocommerce' ),
@@ -208,14 +204,14 @@ $settings = array(
 		),
 		'default'     => 'b2c',
 	),
-	'checkout_button_color'                => array(
+	'checkout_button_color'           => array(
 		'title'       => __( 'Checkout button color', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'color',
 		'description' => __( 'Background color of call to action buttons in Walley Checkout.', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'activate_validation_callback'         => array(
+	'activate_validation_callback'    => array(
 		'title'       => __( 'Validation Callback', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'checkbox',
 		'label'       => __( 'Tick the checkbox to activate Walley Validation Callback.', 'collector-checkout-for-woocommerce' ),
@@ -223,7 +219,7 @@ $settings = array(
 		'description' => sprintf( __( 'Triggered by Collector when customer clicks the Complete purchase button in Walley Checkout. <a href="%s" target="_blank">Read more about validation callback.</a>', 'collector-checkout-for-woocommerce' ), 'https://docs.krokedil.com/walley-checkout-for-woocommerce/get-started/introduction/' ),
 		'default'     => 'yes',
 	),
-	'requires_electronic_id_fields'        => array(
+	'requires_electronic_id_fields'   => array(
 		'title'       => __( 'Electronic ID fields', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'checkbox',
 		'label'       => __( 'Tick the checkbox to activate Requires Electronic ID Fields settings in product pages.', 'collector-checkout-for-woocommerce' ),
@@ -231,39 +227,39 @@ $settings = array(
 		'description' => sprintf( __( '<a href="%s" target="_blank">Read more about this.</a>', 'collector-checkout-for-woocommerce' ), 'https://docs.krokedil.com/walley-checkout-for-woocommerce/get-started/introduction/' ),
 		'default'     => 'no',
 	),
-	'order_management_settings_title'      => array(
+	'order_management_settings_title' => array(
 		'title' => __( 'Order management settings', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
 	),
-	'manage_collector_orders'              => array(
+	'manage_collector_orders'         => array(
 		'title'   => __( 'Manage orders', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
 		'label'   => __( 'Enable WooCommerce to manage orders in Walley backend (when order status changes to Cancelled and Completed in WooCommerce).', 'collector-checkout-for-woocommerce' ),
 		'default' => 'yes',
 	),
-	'activate_individual_order_lines'      => array(
+	'activate_individual_order_lines' => array(
 		'title'   => __( 'Activate individual order lines', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
 		'label'   => __( 'If checked, each order line will be activated instead of the entire order.', 'collector-checkout-for-woocommerce' ),
 		'default' => 'no',
 	),
-	'display_invoice_no'                   => array(
+	'display_invoice_no'              => array(
 		'title'   => __( 'Invoice number on order page', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
 		'label'   => __( 'Display Walley Invoice Number after WooCommerce Order Number on WooCommerce order page (-> WooCommerce -> Orders).', 'collector-checkout-for-woocommerce' ),
 		'default' => 'yes',
 	),
-	'test_mode_settings_title'             => array(
+	'test_mode_settings_title'        => array(
 		'title' => __( 'Test Mode Settings', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
 	),
-	'test_mode'                            => array(
+	'test_mode'                       => array(
 		'title'   => __( 'Test mode', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
 		'label'   => __( 'Enable Test mode for Walley Checkout.', 'collector-checkout-for-woocommerce' ),
 		'default' => 'no',
 	),
-	'debug_mode'                           => array(
+	'debug_mode'                      => array(
 		'title'       => __( 'Debug', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'checkbox',
 		'label'       => __( 'Enable logging.', 'collector-checkout-for-woocommerce' ),

--- a/includes/collector-checkout-settings.php
+++ b/includes/collector-checkout-settings.php
@@ -13,133 +13,161 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Settings for Collector Checkout
  */
 $settings = array(
-	'enabled'                         => array(
+	'enabled'                              => array(
 		'title'   => __( 'Enable/Disable', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
 		'label'   => __( 'Enable Walley Checkout (Collector)', 'collector-checkout-for-woocommerce' ),
 		'default' => 'no',
 	),
-	'title'                           => array(
+	'title'                                => array(
 		'title'       => __( 'Title', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'This is the title that the user sees on the checkout page for Walley Checkout (Collector).', 'collector-checkout-for-woocommerce' ),
 		'default'     => __( 'Walley Checkout', 'collector-checkout-for-woocommerce' ),
 	),
-	'collector_username'              => array(
+	'collector_username'                   => array(
 		'title'       => __( 'Username', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Username', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'collector_password'              => array(
+	'collector_password'                   => array(
 		'title'       => __( 'Password', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Password', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'collector_shared_key'            => array(
+	'collector_shared_key'                 => array(
 		'title'       => __( 'Shared Key', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Shared Key', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'se_settings_title'               => array(
+	'se_settings_title'                    => array(
 		'title' => __( 'Sweden', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
 	),
-	'collector_merchant_id_se_b2c'    => array(
+	'collector_merchant_id_se_b2c'         => array(
 		'title'       => __( 'Merchant ID Sweden B2C', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Merchant ID for B2C purchases in Sweden', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'collector_merchant_id_se_b2b'    => array(
+	'collector_merchant_id_se_b2b'         => array(
 		'title'       => __( 'Merchant ID Sweden B2B', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Merchant ID for B2B purchases in Sweden', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'collector_delivery_module_se'    => array(
+	'collector_delivery_module_se'         => array(
 		'title'   => __( 'Shipping Module Sweden', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
 		'label'   => __( 'Activate Shipping Module for Sweden', 'collector-checkout-for-woocommerce' ),
 		'default' => 'no',
 	),
-	'no_settings_title'               => array(
+	'collector_delivery_module_profile_se' => array(
+		'title'       => __( 'Shipping Profile Sweden', 'collector-checkout-for-woocommerce' ),
+		'type'        => 'text',
+		'description' => __( '', 'collector-checkout-for-woocommerce' ),
+		'label'       => __( 'Optional shipping module profile', 'collector-checkout-for-woocommerce' ),
+		'default'     => '',
+	),
+	'no_settings_title'                    => array(
 		'title' => __( 'Norway', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
 	),
-	'collector_merchant_id_no_b2c'    => array(
+	'collector_merchant_id_no_b2c'         => array(
 		'title'       => __( 'Merchant ID Norway B2C', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Merchant ID for B2C purchases in Norway', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'collector_merchant_id_no_b2b'    => array(
+	'collector_merchant_id_no_b2b'         => array(
 		'title'       => __( 'Merchant ID Norway B2B', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Merchant ID for B2B purchases in Norway', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'collector_delivery_module_no'    => array(
+	'collector_delivery_module_no'         => array(
 		'title'   => __( 'Shipping Module Norway', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
 		'label'   => __( 'Activate Shipping Module for Norway', 'collector-checkout-for-woocommerce' ),
 		'default' => 'no',
 	),
-	'fi_settings_title'               => array(
+	'collector_delivery_module_profile_no' => array(
+		'title'       => __( 'Shipping Profile Norway', 'collector-checkout-for-woocommerce' ),
+		'type'        => 'text',
+		'description' => __( '', 'collector-checkout-for-woocommerce' ),
+		'label'       => __( 'Optional shipping module profile', 'collector-checkout-for-woocommerce' ),
+		'default'     => '',
+	),
+	'fi_settings_title'                    => array(
 		'title' => __( 'Finland', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
 	),
-	'collector_merchant_id_fi_b2c'    => array(
+	'collector_merchant_id_fi_b2c'         => array(
 		'title'       => __( 'Merchant ID Finland B2C', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Merchant ID for B2C purchases in Finland', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'collector_merchant_id_fi_b2b'    => array(
+	'collector_merchant_id_fi_b2b'         => array(
 		'title'       => __( 'Merchant ID Finland B2B', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Merchant ID for B2B purchases in Finland', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'collector_delivery_module_fi'    => array(
+	'collector_delivery_module_fi'         => array(
 		'title'   => __( 'Shipping Module Finland', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
 		'label'   => __( 'Activate Shipping Module for Finland', 'collector-checkout-for-woocommerce' ),
 		'default' => 'no',
 	),
-	'dk_settings_title'               => array(
+	'collector_delivery_module_profile_fi' => array(
+		'title'       => __( 'Shipping Profile Finland', 'collector-checkout-for-woocommerce' ),
+		'type'        => 'text',
+		'description' => __( '', 'collector-checkout-for-woocommerce' ),
+		'label'       => __( 'Optional shipping module profile', 'collector-checkout-for-woocommerce' ),
+		'default'     => '',
+	),
+	'dk_settings_title'                    => array(
 		'title' => __( 'Denmark', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
 	),
-	'collector_merchant_id_dk_b2c'    => array(
+	'collector_merchant_id_dk_b2c'         => array(
 		'title'       => __( 'Merchant ID Denmark B2C', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Merchant ID for B2C purchases in Denmark', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'collector_delivery_module_dk'    => array(
+	'collector_delivery_module_dk'         => array(
 		'title'   => __( 'Shipping Module Denmark', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
 		'label'   => __( 'Activate Shipping Module for Denmark', 'collector-checkout-for-woocommerce' ),
 		'default' => 'no',
 	),
-	'checkout_settings_title'         => array(
+	'collector_delivery_module_profile_dk' => array(
+		'title'       => __( 'Shipping Profile Denmark', 'collector-checkout-for-woocommerce' ),
+		'type'        => 'text',
+		'description' => __( '', 'collector-checkout-for-woocommerce' ),
+		'label'       => __( 'Optional shipping module profile', 'collector-checkout-for-woocommerce' ),
+		'default'     => '',
+	),
+	'checkout_settings_title'              => array(
 		'title' => __( 'Checkout settings', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
 	),
-	'checkout_version'                => array(
+	'checkout_version'                     => array(
 		'title'       => __( 'Checkout version', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'select',
 		'description' => __( 'A brand new Checkout is available, project name Checkout 2.0. The current solution (referred as Checkout 1.0) will be deprecated during 2022.', 'collector-checkout-for-woocommerce' ),
@@ -149,7 +177,7 @@ $settings = array(
 		),
 		'default'     => 'v1',
 	),
-	'checkout_layout'                 => array(
+	'checkout_layout'                      => array(
 		'title'       => __( 'Checkout layout', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'select',
 		'options'     => array(
@@ -162,7 +190,7 @@ $settings = array(
 		'default'     => 'one_column_checkout',
 		'desc_tip'    => false,
 	),
-	'collector_invoice_fee'           => array(
+	'collector_invoice_fee'                => array(
 		'title'       => __( 'Invoice fee ID', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		/* Translators: link to docs */
@@ -170,7 +198,7 @@ $settings = array(
 		'default'     => '',
 		'desc_tip'    => false,
 	),
-	'collector_default_customer'      => array(
+	'collector_default_customer'           => array(
 		'title'       => __( 'Default customer', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'select',
 		'description' => __( 'Sets the default customer/checkout type for Walley Checkout (if offering both B2B & B2C)', 'collector-checkout-for-woocommerce' ),
@@ -180,14 +208,14 @@ $settings = array(
 		),
 		'default'     => 'b2c',
 	),
-	'checkout_button_color'           => array(
+	'checkout_button_color'                => array(
 		'title'       => __( 'Checkout button color', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'color',
 		'description' => __( 'Background color of call to action buttons in Walley Checkout.', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
-	'activate_validation_callback'    => array(
+	'activate_validation_callback'         => array(
 		'title'       => __( 'Validation Callback', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'checkbox',
 		'label'       => __( 'Tick the checkbox to activate Walley Validation Callback.', 'collector-checkout-for-woocommerce' ),
@@ -195,7 +223,7 @@ $settings = array(
 		'description' => sprintf( __( 'Triggered by Collector when customer clicks the Complete purchase button in Walley Checkout. <a href="%s" target="_blank">Read more about validation callback.</a>', 'collector-checkout-for-woocommerce' ), 'https://docs.krokedil.com/walley-checkout-for-woocommerce/get-started/introduction/' ),
 		'default'     => 'yes',
 	),
-	'requires_electronic_id_fields'   => array(
+	'requires_electronic_id_fields'        => array(
 		'title'       => __( 'Electronic ID fields', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'checkbox',
 		'label'       => __( 'Tick the checkbox to activate Requires Electronic ID Fields settings in product pages.', 'collector-checkout-for-woocommerce' ),
@@ -203,39 +231,39 @@ $settings = array(
 		'description' => sprintf( __( '<a href="%s" target="_blank">Read more about this.</a>', 'collector-checkout-for-woocommerce' ), 'https://docs.krokedil.com/walley-checkout-for-woocommerce/get-started/introduction/' ),
 		'default'     => 'no',
 	),
-	'order_management_settings_title' => array(
+	'order_management_settings_title'      => array(
 		'title' => __( 'Order management settings', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
 	),
-	'manage_collector_orders'         => array(
+	'manage_collector_orders'              => array(
 		'title'   => __( 'Manage orders', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
 		'label'   => __( 'Enable WooCommerce to manage orders in Walley backend (when order status changes to Cancelled and Completed in WooCommerce).', 'collector-checkout-for-woocommerce' ),
 		'default' => 'yes',
 	),
-	'activate_individual_order_lines' => array(
+	'activate_individual_order_lines'      => array(
 		'title'   => __( 'Activate individual order lines', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
 		'label'   => __( 'If checked, each order line will be activated instead of the entire order.', 'collector-checkout-for-woocommerce' ),
 		'default' => 'no',
 	),
-	'display_invoice_no'              => array(
+	'display_invoice_no'                   => array(
 		'title'   => __( 'Invoice number on order page', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
 		'label'   => __( 'Display Walley Invoice Number after WooCommerce Order Number on WooCommerce order page (-> WooCommerce -> Orders).', 'collector-checkout-for-woocommerce' ),
 		'default' => 'yes',
 	),
-	'test_mode_settings_title'        => array(
+	'test_mode_settings_title'             => array(
 		'title' => __( 'Test Mode Settings', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
 	),
-	'test_mode'                       => array(
+	'test_mode'                            => array(
 		'title'   => __( 'Test mode', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'checkbox',
 		'label'   => __( 'Enable Test mode for Walley Checkout.', 'collector-checkout-for-woocommerce' ),
 		'default' => 'no',
 	),
-	'debug_mode'                      => array(
+	'debug_mode'                           => array(
 		'title'       => __( 'Debug', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'checkbox',
 		'label'       => __( 'Enable logging.', 'collector-checkout-for-woocommerce' ),


### PR DESCRIPTION
Relabels existing delivery module setting option, and adds a new custom profile setting option. If the delivery module is _enabled_ and profile name is empty, it will default to "Shipping" as profile name thus preserving current behavior. 

![image](https://user-images.githubusercontent.com/26507935/203954393-f8253131-a600-4901-a8e1-8026ec30b4c4.png)
