### PR TITLE
Send customer currency in validation url

### DIFF
--- a/classes/class-collector-checkout-api-callbacks.php
+++ b/classes/class-collector-checkout-api-callbacks.php
@@ -77,7 +77,9 @@ class Collector_Api_Callbacks {
 	public function validation_cb() {
 		$private_id    = filter_input( INPUT_GET, 'private-id', FILTER_SANITIZE_STRING );
 		$customer_type = filter_input( INPUT_GET, 'customer-type', FILTER_SANITIZE_STRING );
-		CCO_WC()->logger::log( 'Validation Callback hit. Private id: ' . wp_json_encode( $private_id ) . ' Customer type: ' . $customer_type );
+		$currency      = filter_input( INPUT_GET, 'customer-currency', FILTER_SANITIZE_STRING );
+
+		CCO_WC()->logger::log( 'Validation Callback hit. Private id: ' . wp_json_encode( $private_id ) . '. Customer type: ' . $customer_type . '. Customer currency: ' . $currency );
 
 		if ( empty( $private_id ) ) {
 			return;
@@ -85,7 +87,7 @@ class Collector_Api_Callbacks {
 		$collector_db_data   = get_collector_data_from_db( $private_id );
 		$this->db_session_id = $collector_db_data->session_id;
 
-		$response              = new Collector_Checkout_Requests_Get_Checkout_Information( $private_id, $customer_type );
+		$response              = new Collector_Checkout_Requests_Get_Checkout_Information( $private_id, $customer_type, $currency );
 		$this->collector_order = $response->request();
 
 		// Check if we have a session id.

--- a/classes/requests/class-collector-checkout-requests-initialize-checkout.php
+++ b/classes/requests/class-collector-checkout-requests-initialize-checkout.php
@@ -83,6 +83,7 @@ class Collector_Checkout_Requests_Initialize_Checkout extends Collector_Checkout
 		}
 		$this->customer_type                = $customer_type;
 		$this->country_code                 = $country_code;
+		$this->currency                     = get_woocommerce_currency();
 		$this->terms_page                   = esc_url( get_permalink( wc_get_page_id( 'terms' ) ) );
 		$this->activate_validation_callback = isset( $collector_settings['activate_validation_callback'] ) ? $collector_settings['activate_validation_callback'] : 'no';
 		$this->checkout_version             = isset( $collector_settings['checkout_version'] ) ? $collector_settings['checkout_version'] : 'v1';
@@ -138,9 +139,10 @@ class Collector_Checkout_Requests_Initialize_Checkout extends Collector_Checkout
 		// Set validation URI query args.
 		$validation_uri = add_query_arg(
 			array(
-				'private-id'    => '{checkout.id}',
-				'public-token'  => '{checkout.publictoken}',
-				'customer-type' => $this->customer_type,
+				'private-id'        => '{checkout.id}',
+				'public-token'      => '{checkout.publictoken}',
+				'customer-type'     => $this->customer_type,
+				'customer-currency' => $this->currency,
 			),
 			get_home_url() . '/wc-api/Collector_WC_Validation/'
 		);


### PR DESCRIPTION
Adds currency to validation url so correct store id easier can be used in GET session requests.