### PR TITLE
Order management rewite

### DIFF
--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -295,9 +295,11 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 		$payment_status  = $collector_order['data']['purchase']['result'];
 		$payment_method  = $collector_order['data']['purchase']['paymentName'];
 		$payment_id      = $collector_order['data']['purchase']['purchaseIdentifier'];
+		$walley_order_id = $collector_order['data']['order']['orderId'];
 
 		update_post_meta( $order_id, '_collector_payment_method', $payment_method );
 		update_post_meta( $order_id, '_collector_payment_id', $payment_id );
+		update_post_meta( $order_id, '_collector_order_id', sanitize_key( $walley_order_id ) );
 		wc_collector_save_shipping_reference_to_order( $order_id, $collector_order );
 
 		// Save shipping data.

--- a/classes/class-collector-checkout-post-checkout.php
+++ b/classes/class-collector-checkout-post-checkout.php
@@ -173,4 +173,3 @@ class Collector_Checkout_Post_Checkout {
 	}
 }
 
-new Collector_Checkout_Post_Checkout();

--- a/classes/class-collector-checkout-post-checkout.php
+++ b/classes/class-collector-checkout-post-checkout.php
@@ -173,3 +173,4 @@ class Collector_Checkout_Post_Checkout {
 	}
 }
 
+new Collector_Checkout_Post_Checkout();

--- a/classes/class-walley-checkout-api.php
+++ b/classes/class-walley-checkout-api.php
@@ -1,0 +1,97 @@
+<?php //phpcs:ignore
+/**
+ * Class for issuing API request.
+ *
+ * @package Collector_Checkout/Classes
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Walley_Checkout_API class.
+ *
+ * Class for handling Walley API requests.
+ */
+class Walley_Checkout_API {
+
+	/**
+	 * Returns a access token.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function get_access_token() {
+		$request  = new Walley_Checkout_Request_Access_Token( array() );
+		$response = $request->request();
+
+		return $this->check_for_api_error( $response );
+	}
+
+	/**
+	 * Get Walley order.
+	 *
+	 * @param string $walley_id The Walley transaction id.
+	 * @return array|WP_Error
+	 */
+	public function get_walley_order( $walley_id ) {
+		$args     = array( 'walley_id' => $walley_id );
+		$request  = new Walley_Checkout_Request_Get_Order( $args );
+		$response = $request->request();
+		return $this->check_for_api_error( $response );
+	}
+
+	/**
+	 * Capture Walley order.
+	 *
+	 * @param int $order_id The WooCommerce order id.
+	 * @return array|WP_Error
+	 */
+	public function capture_walley_order( $order_id ) {
+		$args     = array( 'order_id' => $order_id );
+		$request  = new Walley_Checkout_Request_Capture_Order( $args );
+		$response = $request->request();
+		return $this->check_for_api_error( $response );
+	}
+
+	/**
+	 * Part capture Walley order.
+	 *
+	 * @param int $order_id The WooCommerce order id.
+	 * @return array|WP_Error
+	 */
+	public function part_capture_walley_order( $order_id ) {
+		$args     = array( 'order_id' => $order_id );
+		$request  = new Walley_Checkout_Request_Part_Capture_Order( $args );
+		$response = $request->request();
+		return $this->check_for_api_error( $response );
+	}
+
+	/**
+	 * Cancel Walley order.
+	 *
+	 * @param int $order_id The WooCommerce order id.
+	 * @return array|WP_Error
+	 */
+	public function cancel_walley_order( $order_id ) {
+		$args     = array( 'order_id' => $order_id );
+		$request  = new Walley_Checkout_Request_Cancel_Order( $args );
+		$response = $request->request();
+		return $this->check_for_api_error( $response );
+	}
+
+	/**
+	 * Checks for WP Errors and returns either the response as array.
+	 *
+	 * @param array $response The response from the request.
+	 * @return array|WP_Error
+	 */
+	private function check_for_api_error( $response ) {
+		if ( is_wp_error( $response ) ) {
+			if ( ! is_admin() ) {
+				walley_print_error_message( $response );
+			}
+		}
+		return $response;
+	}
+}

--- a/classes/class-walley-checkout-api.php
+++ b/classes/class-walley-checkout-api.php
@@ -81,6 +81,41 @@ class Walley_Checkout_API {
 	}
 
 	/**
+	 * Refund Walley order.
+	 *
+	 * @param int $order_id The WooCommerce order id.
+	 * @return array|WP_Error
+	 */
+	public function refund_walley_order( $order_id, $amount = null, $reason = '' ) {
+
+		$query_args = array(
+			'fields'         => 'id=>parent',
+			'post_type'      => 'shop_order_refund',
+			'post_status'    => 'any',
+			'posts_per_page' => - 1,
+		);
+
+		$refunds         = get_posts( $query_args );
+		$refund_order_id = array_search( $order_id, $refunds, true );
+		if ( is_array( $refund_order_id ) ) {
+			foreach ( $refund_order_id as $key => $value ) {
+				$refund_order_id = $value;
+				break;
+			}
+		}
+
+		$args     = array(
+			'order_id'        => $order_id,
+			'refund_order_id' => $refund_order_id,
+			'amount'          => $amount,
+			'reason'          => $reason,
+		);
+		$request  = new Walley_Checkout_Request_Refund_Order( $args );
+		$response = $request->request();
+		return $this->check_for_api_error( $response );
+	}
+
+	/**
 	 * Checks for WP Errors and returns either the response as array.
 	 *
 	 * @param array $response The response from the request.

--- a/classes/class-walley-checkout-api.php
+++ b/classes/class-walley-checkout-api.php
@@ -83,7 +83,9 @@ class Walley_Checkout_API {
 	/**
 	 * Refund Walley order.
 	 *
-	 * @param int $order_id The WooCommerce order id.
+	 * @param int    $order_id The WooCommerce order id.
+	 * @param string $amount The refund amount.
+	 * @param string $reason The refund rason.
 	 * @return array|WP_Error
 	 */
 	public function refund_walley_order( $order_id, $amount = null, $reason = '' ) {
@@ -111,6 +113,29 @@ class Walley_Checkout_API {
 			'reason'          => $reason,
 		);
 		$request  = new Walley_Checkout_Request_Refund_Order( $args );
+		$response = $request->request();
+		return $this->check_for_api_error( $response );
+	}
+
+	/**
+	 * Refund Walley order by amount.
+	 *
+	 * @param int    $order_id The WooCommerce order id.
+	 * @param string $amount The refund amount.
+	 * @param string $reason The refund rason.
+	 * @return array|WP_Error
+	 */
+	public function refund_walley_order_by_amount( $order_id, $amount = null, $reason = '' ) {
+
+		$refund_order_id = Collector_Checkout_Create_Refund_Data::get_refunded_order_id( $order_id );
+
+		$args     = array(
+			'order_id'        => $order_id,
+			'refund_order_id' => $refund_order_id,
+			'amount'          => $amount,
+			'reason'          => $reason,
+		);
+		$request  = new Walley_Checkout_Request_Refund_Order_By_Amount( $args );
 		$response = $request->request();
 		return $this->check_for_api_error( $response );
 	}

--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -1,0 +1,310 @@
+<?php
+/**
+ * Class for order management.
+ *
+ * @package Collector_Checkout/Classes/
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Walley_Checkout_Order_Management
+ */
+class  Walley_Checkout_Order_Management {
+
+	/**
+	 * Class constructor
+	 */
+	public function __construct() {
+		$collector_settings                    = get_option( 'woocommerce_collector_checkout_settings' );
+		$this->manage_orders                   = $collector_settings['manage_collector_orders'];
+		$this->display_invoice_no              = $collector_settings['display_invoice_no'];
+		$this->activate_individual_order_lines = $collector_settings['activate_individual_order_lines'] ?? 'no';
+
+		if ( 'yes' === $this->manage_orders ) {
+			add_action( 'woocommerce_order_status_completed', array( $this, 'activate_walley_order' ) );
+			add_action( 'woocommerce_order_status_cancelled', array( $this, 'cancel_walley_order' ) );
+		}
+
+		if ( 'yes' === $this->manage_orders ) {
+			add_filter( 'woocommerce_order_number', array( $this, 'collector_order_number' ), 1000, 2 );
+		}
+
+		add_action( 'init', array( $this, 'check_callback' ), 20 );
+	}
+
+	/**
+	 *  Activate Walley order.
+	 *
+	 * @param int $order_id The WooCommerce order id.
+	 *
+	 * @return void
+	 */
+	public function activate_walley_order( $order_id ) {
+		$order = wc_get_order( $order_id );
+
+		// If this order wasn't created using collector_checkout or collector_invoice payment method, bail.
+		if ( ! in_array( $order->get_payment_method(), array( 'collector_checkout', 'collector_invoice' ), true ) ) {
+			return;
+		}
+
+		// Check if the order has been paid.
+		if ( empty( $order->get_date_paid() ) ) {
+			return;
+		}
+
+		if ( get_post_meta( $order_id, '_collector_order_activated', true ) ) {
+			$order->add_order_note( __( 'Could not activate Walley reservation, Walley reservation is already activated.', 'collector-checkout-for-woocommerce' ) );
+			return;
+		}
+
+		if ( empty( get_post_meta( $order_id, '_collector_order_id', true ) ) ) {
+			$order->add_order_note( __( 'Could not activate Walley reservation, Walley order ID is missing.', 'collector-checkout-for-woocommerce' ) );
+			return;
+		}
+
+		// Part activate or activate the entire order.
+		if ( 'yes' === $this->activate_individual_order_lines ) {
+			$response = CCO_WC()->api->part_capture_walley_order( $order_id );
+
+			if ( is_wp_error( $response ) ) {
+				// If error save error message.
+				$code          = $response->get_error_code();
+				$message       = $response->get_error_message();
+				$text          = __( 'Part activate Walley Checkout order error: ', 'collector-checkout-for-woocommerce' ) . '%s %s';
+				$formated_text = sprintf( $text, $code, $message );
+				$order->add_order_note( $formated_text );
+				$order->update_status( 'on-hold' );
+				return;
+			}
+
+			// Translators: Activated amount.
+			$order->add_order_note( sprintf( __( 'Order part activated with Walley Checkout. Activated amount %s', 'collector-checkout-for-woocommerce' ), wc_price( $order->get_total(), array( 'currency' => $order->get_order_currency() ) ) ) );
+			update_post_meta( $order_id, '_collector_order_activated', time() );
+			return;
+		} else {
+			$response = CCO_WC()->api->capture_walley_order( $order_id );
+
+			if ( is_wp_error( $response ) ) {
+				// If error save error message.
+				$code          = $response->get_error_code();
+				$message       = $response->get_error_message();
+				$text          = __( 'Activate Walley Checkout order error: ', 'collector-checkout-for-woocommerce' ) . '%s %s';
+				$formated_text = sprintf( $text, $code, $message );
+				$order->add_order_note( $formated_text );
+				$order->update_status( 'on-hold' );
+				return;
+			}
+
+			$note = __( 'Walley Checkout order activated.', 'collector-checkout-for-woocommerce' );
+			$order->add_order_note( $note );
+			update_post_meta( $order_id, '_collector_order_activated', time() );
+			return;
+		}
+	}
+
+	/**
+	 * Cancel the Collector order.
+	 *
+	 * @param int $order_id The WooCommerce order id.
+	 *
+	 * @return void
+	 */
+	public function cancel_walley_order( $order_id ) {
+		$order = wc_get_order( $order_id );
+
+		// If this order wasn't created using collector_checkout or collector_invoice payment method, bail.
+		if ( ! in_array( $order->get_payment_method(), array( 'collector_checkout', 'collector_invoice' ), true ) ) {
+			return;
+		}
+
+		// If the order has not been paid for, bail.
+		if ( empty( $order->get_date_paid() ) ) {
+			return;
+		}
+
+		// If this reservation was already cancelled, do nothing.
+		if ( get_post_meta( $order_id, '_collector_order_cancelled', true ) ) {
+			$order->add_order_note( __( 'Could not cancel Walley reservation, Walley reservation is already cancelled.', 'collector-checkout-for-woocommerce' ) );
+			return;
+		}
+
+		if ( empty( get_post_meta( $order_id, '_collector_order_id', true ) ) ) {
+			$order->add_order_note( __( 'Could not cancel Walley reservation, Walley order ID is missing.', 'collector-checkout-for-woocommerce' ) );
+			return;
+		}
+
+		// Check order status in Walley backoffice.
+		if ( ! $this->is_ok_to_cancel( $order_id ) ) {
+			return;
+		}
+
+		$response = CCO_WC()->api->cancel_walley_order( $order_id );
+
+		if ( is_wp_error( $response ) ) {
+			// If error save error message.
+			$code          = $response->get_error_code();
+			$message       = $response->get_error_message();
+			$text          = __( 'Cancel Walley Checkout order error: ', 'collector-checkout-for-woocommerce' ) . '%s %s';
+			$formated_text = sprintf( $text, $code, $message );
+			$order->add_order_note( $formated_text );
+			$order->update_status( 'on-hold' );
+			return;
+		}
+
+		$note = __( 'Walley Checkout order cancelled.', 'collector-checkout-for-woocommerce' );
+		$order->add_order_note( $note );
+		update_post_meta( $order_id, '_collector_order_cancelled', time() );
+	}
+
+	/**
+	 * Refunds the Dintero order that the WooCommerce order corresponds to.
+	 *
+	 * @param int    $order_id The WooCommerce order id.
+	 * @param string $amount The refund amount.
+	 * @param string $reason The reason for the refund.
+	 * @return boolean|null TRUE on success, FALSE on unrecoverable failure, and null if not relevant or valid.
+	 */
+	public function refund_walley_order( $order_id, $amount = null, $reason = '' ) {
+		$order = wc_get_order( $order_id );
+
+		// If this order wasn't created using collector_checkout or collector_invoice payment method, bail.
+		if ( ! in_array( $order->get_payment_method(), array( 'collector_checkout', 'collector_invoice' ), true ) ) {
+			return;
+		}
+
+		// If the order has not been paid for, bail.
+		if ( empty( $order->get_date_paid() ) ) {
+			return;
+		}
+
+		// If this reservation was already cancelled, do nothing.
+		if ( get_post_meta( $order_id, '_collector_order_cancelled', true ) ) {
+			$order->add_order_note( __( 'Could not refund Walley order, Walley reservation is cancelled.', 'collector-checkout-for-woocommerce' ) );
+			return new WP_Error( 'error', __( 'Could not refund Walley order, Walley reservation is cancelled.', 'collector-checkout-for-woocommerce' ) );
+		}
+
+		// If this reservation was not activated, do nothing.
+		if ( empty( get_post_meta( $order_id, '_collector_order_activated', true ) ) ) {
+			$order->add_order_note( __( 'There is nothing to refund. The order has not yet been captured in WooCommerce.', 'collector-checkout-for-woocommerce' ) );
+			return new WP_Error( 'error', __( 'There is nothing to refund. The order has not yet been captured in WooCommerce.', 'collector-checkout-for-woocommerce' ) );
+		}
+
+		if ( empty( get_post_meta( $order_id, '_collector_order_id', true ) ) ) {
+			$order->add_order_note( __( 'Could not refund Walley reservation, Walley order ID is missing.', 'collector-checkout-for-woocommerce' ) );
+			return new WP_Error( 'error', __( 'Could not refund Walley reservation, Walley order ID is missing.', 'collector-checkout-for-woocommerce' ) );
+		}
+
+		$response = CCO_WC()->api->refund_walley_order( $order_id, $amount, $reason );
+
+		if ( is_wp_error( $response ) ) {
+			// If error save error message.
+			$code          = $response->get_error_code();
+			$message       = $response->get_error_message();
+			$text          = __( 'Cancel Walley Checkout order error: ', 'collector-checkout-for-woocommerce' ) . '%s %s';
+			$formated_text = sprintf( $text, $code, $message );
+			$order->add_order_note( $formated_text );
+
+			return $response;
+		}
+		// Translators: Refunded amount.
+		$order->add_order_note( sprintf( __( 'Walley Checkout order refunded with %s.', 'collector-checkout-for-woocommerce' ), wc_price( $amount ) ) );
+		return true;
+	}
+
+	/**
+	 * Check if order is ok to cancel.
+	 *
+	 * @param int $order_id The WooCommerce order id.
+	 *
+	 * @return bool
+	 */
+	public function is_ok_to_cancel( $order_id ) {
+		$wc_order  = wc_get_order( $order_id );
+		$walley_id = get_post_meta( $order_id, '_collector_order_id', true );
+		$response  = CCO_WC()->api->get_walley_order( $walley_id );
+		if ( ! is_wp_error( $response ) ) {
+
+			if ( in_array( $response['data']['status'], array( 'NotActivated', 'PartActivated', 'Expired' ), true ) ) {
+				return true;
+			} else {
+				// Translators: Walley payment status.
+				$wc_order->add_order_note( sprintf( __( 'Cancel Walley order request will not be triggered. Order have status <i>%s</i> in Walley Merchant Hub.', 'dibs-easy-for-woocommerce' ), $response['data']['status'] ) );
+				return false;
+			}
+		}
+		// Translators: Request error message.
+		$wc_order->add_order_note( sprintf( __( 'Unable to get the Walley order. Error message: <i>%s</i>.', 'dibs-easy-for-woocommerce' ), $response->get_error_message() ) );
+		return false;
+	}
+
+	/**
+	 * Check for Collector Invoice Status Change (anti fraud system)
+	 **/
+	public function check_callback() {
+		if ( ! empty( $_SERVER['REQUEST_URI'] ) && false !== strpos( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), 'module/collectorcheckout/invoicestatus' ) ) {
+			$invoice_no     = filter_input( INPUT_GET, 'InvoiceNo', FILTER_SANITIZE_STRING );
+			$invoice_status = filter_input( INPUT_GET, 'InvoiceStatus', FILTER_SANITIZE_STRING );
+			if ( ! empty( $invoice_no ) && ! empty( $invoice_status ) ) {
+				CCO_WC()->logger::log( 'Collector Invoice Status Change callback hit' );
+				$collector_payment_id = $invoice_no;
+				$query_args           = array(
+					'post_type'   => wc_get_order_types(),
+					'post_status' => array_keys( wc_get_order_statuses() ),
+					'meta_key'    => '_collector_payment_id', // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
+					'meta_value'  => $collector_payment_id, // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
+				);
+				$orders               = get_posts( $query_args );
+				$order_id             = $orders[0]->ID;
+				$order                = wc_get_order( $order_id );
+
+				if ( is_object( $order ) ) {
+					// Add order note about the callback
+					// translators: Invoice status.
+					$order->add_order_note( sprintf( __( 'Invoice status callback from Walley. New Invoice status: %s', 'collector-checkout-for-woocommerce' ), $invoice_no ) );
+					// Set order status.
+					if ( '1' === $invoice_status ) {
+						$order->payment_complete( $collector_payment_id );
+					} elseif ( '5' === $invoice_status ) {
+						$order->update_status( 'failed' );
+					}
+					header( 'HTTP/1.1 200 Ok' );
+				} else {
+					$collector_info = sprintf( 'Invoice status callback from Collector but we could not find the corresponding order in WC. Collector InvoiceNo: %s InvoiceStatus: %s', $invoice_no, $invoice_status );
+					// TODO log function not found in Collector_Checkout!
+					CCO_WC()->logger::log( $collector_info );
+					header( 'HTTP/1.0 404 Not Found' );
+				}
+			} else {
+				CCO_WC()->logger::log( 'HTTP Request from Collector is missing parameters' );
+				header( 'HTTP/1.0 400 Bad Request' );
+			}
+			die();
+		}
+	}
+
+	/**
+	 * Display Collector payment id after WC order number on order overwiev page
+	 *
+	 * @param string   $order_number The WooCommerce order number.
+	 * @param WC_Order $order The WooCommerce order.
+	 **/
+	public function collector_order_number( $order_number, $order ) {
+		if ( is_admin() ) {
+			// Check if function get_current_screen() exist.
+			if ( ! function_exists( 'get_current_screen' ) ) {
+				return $order_number;
+			}
+
+			$current_screen = get_current_screen();
+			if ( is_object( $current_screen ) && 'edit-shop_order' === $current_screen->id ) {
+				$collector_payment_id = null !== get_post_meta( $order->get_id(), '_collector_payment_id', true ) ? get_post_meta( $order->get_id(), '_collector_payment_id', true ) : '';
+				//phpcs:ignore $collector_payment_id = get_post_meta( $order->get_id(), '_collector_payment_id', true );
+				if ( $collector_payment_id ) {
+					$order_number .= ' (' . $collector_payment_id . ')';
+				}
+			}
+		}
+		return $order_number;
+	}
+}

--- a/classes/requests/class-walley-checkout-request-get.php
+++ b/classes/requests/class-walley-checkout-request-get.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Base class for all GET requests.
+ *
+ * @package Collector_Checkout/Classes/Request
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ *  The main class for GET requests.
+ */
+abstract class Walley_Checkout_Request_Get extends Walley_Checkout_Request {
+
+	/**
+	 * Walley_Checkout_Request_Get constructor.
+	 *
+	 * @param  array $arguments  The request arguments.
+	 */
+	public function __construct( $arguments = array() ) {
+		parent::__construct( $arguments );
+		$this->method = 'GET';
+	}
+
+	/**
+	 * Build and return proper request arguments for this request type.
+	 *
+	 * @return array Request arguments
+	 */
+	protected function get_request_args() {
+		return array(
+			'headers'    => $this->get_request_headers(),
+			'user-agent' => $this->get_user_agent(),
+			'method'     => $this->method,
+			'timeout'    => apply_filters( 'walley_checkout_set_timeout', 10 ),
+		);
+	}
+}

--- a/classes/requests/class-walley-checkout-request-post.php
+++ b/classes/requests/class-walley-checkout-request-post.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Base class for all POST requests.
+ *
+ * @package Collector_Checkout/Classes/Request
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ *  The main class for POST requests.
+ */
+abstract class Walley_Checkout_Request_Post extends Walley_Checkout_Request {
+
+	/**
+	 * Walley_Checkout_Request_Post constructor.
+	 *
+	 * @param  array $arguments  The request arguments.
+	 */
+	public function __construct( $arguments = array() ) {
+		parent::__construct( $arguments );
+		$this->method = 'POST';
+	}
+
+	/**
+	 * Build and return proper request arguments for this request type.
+	 *
+	 * @return array Request arguments
+	 */
+	protected function get_request_args() {
+
+		if ( 'Access token' === $this->log_title ) {
+			$body = $this->get_body();
+		} else {
+			$body = wp_json_encode( apply_filters( 'walley_checkout_request_args', $this->get_body() ) );
+		}
+
+		return array(
+			'headers'    => $this->get_request_headers(),
+			'user-agent' => $this->get_user_agent(),
+			'method'     => $this->method,
+			'timeout'    => apply_filters( 'walley_checkout_set_timeout', 10 ),
+			'body'       => $body,
+		);
+	}
+
+	/**
+	 * Builds the request args for a POST request.
+	 *
+	 * @return array
+	 */
+	abstract protected function get_body();
+}

--- a/classes/requests/class-walley-checkout-request.php
+++ b/classes/requests/class-walley-checkout-request.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * Main request class
+ *
+ * @package Collector_Checkout/Classes/Requests
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Base class for all request classes.
+ */
+abstract class Walley_Checkout_Request {
+
+	/**
+	 * The request method.
+	 *
+	 * @var string
+	 */
+	protected $method;
+
+	/**
+	 * The request title.
+	 *
+	 * @var string
+	 */
+	protected $log_title;
+
+	/**
+	 * The Walley order id.
+	 *
+	 * @var string
+	 */
+	protected $walley_order_id;
+
+	/**
+	 * The request arguments.
+	 *
+	 * @var array
+	 */
+	protected $arguments;
+
+	/**
+	 * The plugin settings.
+	 *
+	 * @var array
+	 */
+	protected $settings;
+
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param array $arguments The request args.
+	 */
+	public function __construct( $arguments = array() ) {
+		$this->arguments = $arguments;
+		$this->load_settings();
+	}
+
+	/**
+	 * Loads the Walley Checkout settings and sets them to be used here.
+	 *
+	 * @return void
+	 */
+	protected function load_settings() {
+		$this->settings = get_option( 'woocommerce_collector_checkout_settings' );
+	}
+
+	/**
+	 * Get the API base URL.
+	 *
+	 * @return string
+	 */
+	protected function get_api_url_base() {
+		if ( 'yes' === $this->settings['test_mode'] ) {
+			return 'https://api.uat.walleydev.com';
+		}
+
+		return 'https://api.walleypay.com';
+	}
+
+	/**
+	 * Get the request headers.
+	 *
+	 * @return array
+	 */
+	protected function get_request_headers() {
+		return array(
+			'Content-type'  => 'application/json',
+			'Authorization' => $this->get_access_token(),
+		);
+	}
+
+	/**
+	 * Get the access token from Walley.
+	 *
+	 * @return string
+	 */
+	private function get_access_token() {
+		$access_token = get_transient( 'walley_checkout_access_token' );
+		if ( $access_token ) {
+			return $access_token;
+		}
+
+		$response = CCO_WC()->api->get_access_token();
+
+		if ( is_wp_error( $response ) ) {
+			return '';
+		}
+
+		$access_token = $response['token_type'] . ' ' . $response['access_token'];
+		set_transient( 'walley_checkout_access_token', $access_token, absint( $response['expires_in'] ) );
+		return $access_token;
+	}
+
+	/**
+	 * Get the user agent.
+	 *
+	 * @return string
+	 */
+	protected function get_user_agent() {
+		return apply_filters(
+			'http_headers_useragent',
+			'WordPress/' . get_bloginfo( 'version' ) . '; ' . get_bloginfo( 'url' )
+		) . ' - WooCommerce: ' . WC()->version . ' - Walley Checkout: ' . COLLECTOR_BANK_VERSION . ' - PHP Version: ' . phpversion() . ' - Krokedil';
+	}
+
+	/**
+	 * Get the request args.
+	 *
+	 * @return array
+	 */
+	abstract protected function get_request_args();
+
+	/**
+	 * Get the request url.
+	 *
+	 * @return string
+	 */
+	abstract protected function get_request_url();
+
+	/**
+	 * Make the request.
+	 *
+	 * @return object|WP_Error
+	 */
+	public function request() {
+		$url      = $this->get_request_url();
+		$args     = $this->get_request_args();
+		$response = wp_remote_request( $url, $args );
+		return $this->process_response( $response, $args, $url );
+	}
+
+	/**
+	 * Processes the response checking for errors.
+	 *
+	 * @param object|WP_Error $response The response from the request.
+	 * @param array           $request_args The request args.
+	 * @param string          $request_url The request url.
+	 * @return array|WP_Error
+	 */
+	protected function process_response( $response, $request_args, $request_url ) {
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		if ( $response_code < 200 || $response_code > 299 ) {
+			$data          = 'URL: ' . $request_url . ' - ' . wp_json_encode( $request_args );
+			$error_message = '';
+			// Get the error messages.
+			if ( null !== json_decode( $response['body'], true ) ) {
+				$errors = json_decode( $response['body'], true );
+
+				foreach ( $errors as $error ) {
+					$error_message .= ' ' . wp_json_encode( $error );
+				}
+			}
+
+			$error_message = empty( $error_message ) ? "API Error ${response_code}" : "API Error ${error_message}";
+			$return        = new WP_Error( $response_code, $error_message, $data );
+		} else {
+			$return = json_decode( wp_remote_retrieve_body( $response ), true );
+		}
+
+		$this->log_response( $response, $request_args, $request_url );
+		return $return;
+	}
+
+	/**
+	 * Logs the response from the request.
+	 *
+	 * @param array|WP_Error $response The response from the request.
+	 * @param array          $request_args The request args.
+	 * @param string         $request_url The request URL.
+	 *
+	 * @return void
+	 */
+	protected function log_response( $response, $request_args, $request_url ) {
+		$method = $this->method;
+		$title  = $this->log_title;
+		$code   = wp_remote_retrieve_response_code( $response );
+
+		$body     = json_decode( $response['body'], true );
+		$order_id = $body['paymentId'] ?? $body['payment']['paymentId'] ?? null;
+		$log      = Collector_Checkout_Logger::format_log( $order_id, $method, $title, $request_args, $request_url, $response, $code );
+		Collector_Checkout_Logger::log( $log );
+	}
+
+	/**
+	 * Get the api secret.
+	 *
+	 * @return string
+	 */
+	protected function get_client_id() {
+		return $this->settings['walley_api_client_id'];
+	}
+
+	/**
+	 * Get the api key.
+	 *
+	 * @return string
+	 */
+	protected function get_api_secret() {
+		return $this->settings['walley_api_secret'];
+	}
+
+	/**
+	 * Get the scope.
+	 *
+	 * @return string
+	 */
+	protected function get_scope() {
+		if ( 'yes' === $this->settings['test_mode'] ) {
+			return '705798e0-8cef-427c-ae00-6023deba29af/.default';
+		}
+		return 'a3f3019f-2be9-41cc-a254-7bb347238e89/.default';
+	}
+}

--- a/classes/requests/helpers/class-collector-checkout-create-refund-data.php
+++ b/classes/requests/helpers/class-collector-checkout-create-refund-data.php
@@ -299,5 +299,18 @@ class Collector_Checkout_Create_Refund_Data {
 		);
 	}
 
+	/**
+	 * Returns the id of the refunded order.
+	 *
+	 * @param int $order_id The WooCommerce order id.
+	 * @return string
+	 */
+	public static function get_refunded_order_id( $order_id ) {
+		$order = wc_get_order( $order_id );
+
+		/* Always retrieve the most recent (current) refund (index 0). */
+		return $order->get_refunds()[0]->get_id();
+	}
+
 
 }

--- a/classes/requests/helpers/class-collector-checkout-requests-helper-order-om.php
+++ b/classes/requests/helpers/class-collector-checkout-requests-helper-order-om.php
@@ -51,6 +51,28 @@ class Collector_Checkout_Requests_Helper_Order_Om {
 	}
 
 	/**
+	 * Formats the order lines for a refund request.
+	 *
+	 * @param int $order_id The WooCommerce Order ID.
+	 * @return array
+	 */
+	public static function get_refund_items( $order_id ) {
+		$order_lines  = self::get_order_lines( $order_id );
+		$return_lines = array();
+
+		foreach ( $order_lines as $order_line ) {
+			$return_lines[] = array(
+				'ArticleId'   => $order_line['ArticleId'],
+				'Description' => $order_line['Description'],
+				'Quantity'    => abs( $order_line['Quantity'] ),
+				'UnitPrice'   => $order_line['UnitPrice'],
+			);
+		}
+
+		return $return_lines;
+	}
+
+	/**
 	 * Compare and fix rounded total amounts in WooCommerce and Collector.
 	 *
 	 * @param array    $order_lines The cart order line items array.
@@ -160,10 +182,10 @@ class Collector_Checkout_Requests_Helper_Order_Om {
 		if ( isset( $collector_shipping_reference ) && ! empty( $collector_shipping_reference ) ) {
 			$shipping_reference = $collector_shipping_reference;
 		} else {
-			if ( null !== $shipping->get_instance_id() ) {
-				$shipping_reference = 'shipping|' . $shipping->get_method_id() . ':' . $shipping->get_instance_id();
+			if ( null !== $order_item->get_instance_id() ) {
+				$shipping_reference = 'shipping|' . $order_item->get_method_id() . ':' . $order_item->get_instance_id();
 			} else {
-				$shipping_reference = 'shipping|' . $shipping->get_method_id();
+				$shipping_reference = 'shipping|' . $order_item->get_method_id();
 			}
 		}
 

--- a/classes/requests/manage-orders/get/class-walley-checkout-request-get-order.php
+++ b/classes/requests/manage-orders/get/class-walley-checkout-request-get-order.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Class for the request to get an order.
+ *
+ * @package Collector_Checkout/Classes/Requests/GET
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Walley_Checkout_Request_Get_Order class.
+ */
+class Walley_Checkout_Request_Get_Order extends Walley_Checkout_Request_Get {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param array $arguments The request arguments.
+	 */
+	public function __construct( $arguments ) {
+		parent::__construct( $arguments );
+		$this->log_title = 'Get order';
+	}
+
+	/**
+	 * Get the request url.
+	 *
+	 * @return string
+	 */
+	protected function get_request_url() {
+		return $this->get_api_url_base() . "/manage/orders/{$this->arguments['walley_id']}";
+	}
+}

--- a/classes/requests/manage-orders/post/class-walley-checkout-request-cancel-order.php
+++ b/classes/requests/manage-orders/post/class-walley-checkout-request-cancel-order.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Class for the request to cancel an order.
+ *
+ * @package Collector_Checkout/Classes/Requests/POST
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Walley_Checkout_Request_Cancel_Order class.
+ */
+class Walley_Checkout_Request_Cancel_Order extends Walley_Checkout_Request_Post {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param array $arguments The request arguments.
+	 */
+	public function __construct( $arguments ) {
+		parent::__construct( $arguments );
+		$this->log_title = 'Cancel order';
+	}
+
+	/**
+	 * Get the request url.
+	 *
+	 * @return string
+	 */
+	protected function get_request_url() {
+		$walley_id = get_post_meta( $this->arguments['order_id'], '_collector_order_id', true );
+		return $this->get_api_url_base() . "/manage/orders/{$walley_id}/cancel";
+	}
+
+	/**
+	 * Get the body for the request.
+	 *
+	 * @return array
+	 */
+	protected function get_body() {
+		$order_id = $this->arguments['order_id'];
+		$order    = wc_get_order( $order_id );
+		$body     = array(
+			'amount' => $order->get_total(),
+		);
+
+		return apply_filters( 'coc_order_cancel_args', $body, $this->arguments['order_id'] );
+	}
+}

--- a/classes/requests/manage-orders/post/class-walley-checkout-request-capture-order.php
+++ b/classes/requests/manage-orders/post/class-walley-checkout-request-capture-order.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Class for the request to capoture an order.
+ *
+ * @package Collector_Checkout/Classes/Requests/POST
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Walley_Checkout_Request_Capture_Order class.
+ */
+class Walley_Checkout_Request_Capture_Order extends Walley_Checkout_Request_Post {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param array $arguments The request arguments.
+	 */
+	public function __construct( $arguments ) {
+		parent::__construct( $arguments );
+		$this->log_title = 'Capture order';
+	}
+
+	/**
+	 * Get the request url.
+	 *
+	 * @return string
+	 */
+	protected function get_request_url() {
+		$walley_id = get_post_meta( $this->arguments['order_id'], '_collector_order_id', true );
+		return $this->get_api_url_base() . "/manage/orders/{$walley_id}/capture";
+	}
+
+	/**
+	 * Get the body for the request.
+	 *
+	 * @return array
+	 */
+	protected function get_body() {
+		$order_id = $this->arguments['order_id'];
+		$order    = wc_get_order( $order_id );
+		$body     = array(
+			'amount' => $order->get_total(),
+		);
+
+		return apply_filters( 'coc_order_capture_args', $body, $this->arguments['order_id'] );
+	}
+}

--- a/classes/requests/manage-orders/post/class-walley-checkout-request-part-capture-order.php
+++ b/classes/requests/manage-orders/post/class-walley-checkout-request-part-capture-order.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Class for the request to capoture an order.
+ *
+ * @package Collector_Checkout/Classes/Requests/POST
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Walley_Checkout_Request_Part_Capture_Order class.
+ */
+class Walley_Checkout_Request_Part_Capture_Order extends Walley_Checkout_Request_Post {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param array $arguments The request arguments.
+	 */
+	public function __construct( $arguments ) {
+		parent::__construct( $arguments );
+		$this->log_title = 'Part capture order';
+	}
+
+	/**
+	 * Get the request url.
+	 *
+	 * @return string
+	 */
+	protected function get_request_url() {
+		$walley_id = get_post_meta( $this->arguments['order_id'], '_collector_order_id', true );
+		return $this->get_api_url_base() . "/manage/orders/{$walley_id}/capture";
+	}
+
+	/**
+	 * Get the body for the request.
+	 *
+	 * @return array
+	 */
+	protected function get_body() {
+		$order_id = $this->arguments['order_id'];
+		$order    = wc_get_order( $order_id );
+		$body     = array(
+			'amount' => $order->get_total(),
+			'items'  => Collector_Checkout_Requests_Helper_Order_Om::get_order_lines( $order_id ),
+		);
+
+		return apply_filters( 'coc_order_capture_args', $body, $this->arguments['order_id'] );
+	}
+}

--- a/classes/requests/manage-orders/post/class-walley-checkout-request-refund-order-by-amount.php
+++ b/classes/requests/manage-orders/post/class-walley-checkout-request-refund-order-by-amount.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Class for the request to refund an order by amount.
+ *
+ * @package Collector_Checkout/Classes/Requests/POST
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Walley_Checkout_Request_Refund_Order_By_Amount class.
+ */
+class Walley_Checkout_Request_Refund_Order_By_Amount extends Walley_Checkout_Request_Post {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param array $arguments The request arguments.
+	 */
+	public function __construct( $arguments ) {
+		parent::__construct( $arguments );
+		$this->log_title = 'Refund order by amount';
+	}
+
+	/**
+	 * Get the request url.
+	 *
+	 * @return string
+	 */
+	protected function get_request_url() {
+		$walley_id = get_post_meta( $this->arguments['order_id'], '_collector_order_id', true );
+		return $this->get_api_url_base() . "/manage/orders/{$walley_id}/refund";
+	}
+
+	/**
+	 * Get the body for the request.
+	 *
+	 * @return array
+	 */
+	protected function get_body() {
+		$refund_order_id = $this->arguments['refund_order_id'];
+		$refund_order    = wc_get_order( $refund_order_id );
+		$body            = array(
+			'amount'          => $this->arguments['amount'],
+			'description'     => $this->arguments['reason'],
+			'actionReference' => $this->arguments['refund_order_id'],
+		);
+
+		return apply_filters( 'coc_order_refund_by_amount_args', $body, $this->arguments['order_id'], $this->arguments['refund_order_id'] );
+	}
+}

--- a/classes/requests/manage-orders/post/class-walley-checkout-request-refund-order.php
+++ b/classes/requests/manage-orders/post/class-walley-checkout-request-refund-order.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Class for the request to refund an order.
+ *
+ * @package Collector_Checkout/Classes/Requests/POST
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Walley_Checkout_Request_Refund_Order class.
+ */
+class Walley_Checkout_Request_Refund_Order extends Walley_Checkout_Request_Post {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param array $arguments The request arguments.
+	 */
+	public function __construct( $arguments ) {
+		parent::__construct( $arguments );
+		$this->log_title = 'Refund order';
+	}
+
+	/**
+	 * Get the request url.
+	 *
+	 * @return string
+	 */
+	protected function get_request_url() {
+		$walley_id = get_post_meta( $this->arguments['order_id'], '_collector_order_id', true );
+		return $this->get_api_url_base() . "/manage/orders/{$walley_id}/refund";
+	}
+
+	/**
+	 * Get the body for the request.
+	 *
+	 * @return array
+	 */
+	protected function get_body() {
+		$refund_order_id = $this->arguments['refund_order_id'];
+		$refund_order    = wc_get_order( $refund_order_id );
+		$body            = array(
+			'amount' => $this->arguments['amount'],
+			'items'  => Collector_Checkout_Requests_Helper_Order_Om::get_refund_items( $refund_order_id ),
+		);
+
+		return apply_filters( 'coc_order_refund_args', $body, $this->arguments['order_id'], $this->arguments['refund_order_id'] );
+	}
+}

--- a/classes/requests/oauth2/class-walley-checkout-request-access-token.php
+++ b/classes/requests/oauth2/class-walley-checkout-request-access-token.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Class for the request to request an access token.
+ *
+ * @package Collector_Checkout/Classes/Requests/POST
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Walley_Checkout_Request_Access_Token class.
+ */
+class Walley_Checkout_Request_Access_Token extends Walley_Checkout_Request_Post {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param array $arguments The request arguments.
+	 */
+	public function __construct( $arguments ) {
+		parent::__construct( $arguments );
+		$this->log_title = 'Access token';
+	}
+
+	/**
+	 * Get the request url.
+	 *
+	 * @return string
+	 */
+	protected function get_request_url() {
+		return $this->get_api_url_base() . '/oauth2/v2.0/token';
+	}
+
+	/**
+	 * Gets the request headers.
+	 *
+	 * @return array
+	 */
+	protected function get_request_headers() {
+		return array(
+			'Content-Type' => 'application/x-www-form-urlencoded',
+		);
+	}
+
+	/**
+	 * Get the body for the request.
+	 *
+	 * @return array
+	 */
+	protected function get_body() {
+		$client_id     = rawurlencode( $this->get_client_id() );
+		$client_secret = rawurlencode( $this->get_api_secret() );
+		$scope         = rawurlencode( $this->get_scope() );
+		$fields        = "client_id=$client_id&client_secret=$client_secret&grant_type=client_credentials&scope=$scope";
+
+		return $fields;
+	}
+}

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -172,6 +172,9 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/soap/class-collector-checkout-soap-requests-credit-payment.php';
 				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/soap/class-collector-checkout-soap-requests-adjust-invoice.php';
 				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/soap/class-collector-checkout-soap-requests-part-credit-invoice.php';
+
+				// Set class variables related to old Payments/SOAP API.
+				$this->order_management = new Collector_Checkout_Post_Checkout();
 			}
 
 			// Functions.

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -89,6 +89,10 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 		 */
 		public function __construct() {
 
+			$collector_settings         = get_option( 'woocommerce_collector_checkout_settings', array() );
+			$this->walley_api_client_id = $collector_settings['walley_api_client_id'] ?? '';
+			$this->walley_api_secret    = $collector_settings['walley_api_secret'] ?? '';
+
 			// Initiate the gateway.
 			add_action( 'plugins_loaded', array( $this, 'init' ) );
 			// Load scripts.
@@ -120,7 +124,6 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 			// Include the Classes.
 			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-checkout-logger.php';
 			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-checkout-ajax-calls.php';
-			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-checkout-post-checkout.php';
 			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-checkout-admin-notices.php';
 			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-checkout-order-emails.php';
 			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-create-order-fallback.php';
@@ -135,6 +138,41 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-checkout-shipping-method.php';
 			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-checkout-delivery-module.php';
 			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-checkout-product-fields.php';
+
+			// Order management. SOAP will be deprecated.
+			if ( ! empty( $this->walley_api_client_id ) && ! empty( $this->walley_api_secret ) ) {
+
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-walley-checkout-api.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-walley-checkout-order-management.php';
+
+				// New OM class files.
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-walley-checkout-request.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-walley-checkout-request-get.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-walley-checkout-request-post.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/manage-orders/get/class-walley-checkout-request-get-order.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/manage-orders/post/class-walley-checkout-request-capture-order.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/manage-orders/post/class-walley-checkout-request-part-capture-order.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/manage-orders/post/class-walley-checkout-request-cancel-order.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/manage-orders/post/class-walley-checkout-request-refund-order.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/manage-orders/post/class-walley-checkout-request-refund-order-by-amount.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/oauth2/class-walley-checkout-request-access-token.php';
+
+				// Set class variables related to new Management API.
+				$this->api              = new Walley_Checkout_API();
+				$this->order_management = new Walley_Checkout_Order_Management();
+
+			} else {
+
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-checkout-post-checkout.php';
+
+				// Include the Soap Request Classes.
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/soap/class-collector-checkout-soap-requests-activate-invoice.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/soap/class-collector-checkout-soap-requests-part-activate-invoice.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/soap/class-collector-checkout-soap-requests-cancel-invoice.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/soap/class-collector-checkout-soap-requests-credit-payment.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/soap/class-collector-checkout-soap-requests-adjust-invoice.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/soap/class-collector-checkout-soap-requests-part-credit-invoice.php';
+			}
 
 			// Functions.
 			include_once COLLECTOR_BANK_PLUGIN_DIR . '/includes/collector-checkout-for-woocommerce-functions.php';
@@ -163,14 +201,6 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/helpers/class-collector-checkout-requests-helper-order-om.php';
 			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/helpers/class-collector-checkout-requests-helper-order-fees.php';
 
-			// Include the Soap Request Classes.
-			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/soap/class-collector-checkout-soap-requests-activate-invoice.php';
-			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/soap/class-collector-checkout-soap-requests-part-activate-invoice.php';
-			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/soap/class-collector-checkout-soap-requests-cancel-invoice.php';
-			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/soap/class-collector-checkout-soap-requests-credit-payment.php';
-			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/soap/class-collector-checkout-soap-requests-adjust-invoice.php';
-			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/soap/class-collector-checkout-soap-requests-part-credit-invoice.php';
-
 			// Set variables for shorthand access to classes.
 			$this->order_items = new Collector_Checkout_Requests_Helper_Order();
 			$this->order_fees  = new Collector_Checkout_Requests_Helper_Order_Fees();
@@ -187,8 +217,7 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 			add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'add_action_links' ) );
 
 			// Set class variables.
-			$this->logger           = new Collector_Checkout_Logger();
-			$this->order_management = new Collector_Checkout_Post_Checkout();
+			$this->logger = new Collector_Checkout_Logger();
 		}
 
 		/**

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -466,6 +466,7 @@ function wc_collector_confirm_order( $order_id, $private_id = null ) {
 	$payment_status  = $collector_order['data']['purchase']['result'];
 	$payment_method  = $collector_order['data']['purchase']['paymentName'];
 	$payment_id      = $collector_order['data']['purchase']['purchaseIdentifier'];
+	$walley_order_id = $collector_order['data']['order']['orderId'];
 
 	// Check if we need to update reference in collectors system.
 	if ( empty( $collector_order['data']['reference'] ) ) {
@@ -485,6 +486,7 @@ function wc_collector_confirm_order( $order_id, $private_id = null ) {
 
 	update_post_meta( $order_id, '_collector_payment_method', $payment_method );
 	update_post_meta( $order_id, '_collector_payment_id', $payment_id );
+	update_post_meta( $order_id, '_collector_order_id', sanitize_key( $walley_order_id ) );
 	wc_collector_save_shipping_reference_to_order( $order_id, $collector_order );
 
 	// Tie this order to a user if we have one.
@@ -727,4 +729,34 @@ function coc_get_shipping_data( $collector_order ) {
 	}
 
 	return $shipping_data;
+}
+
+/**
+ * Prints error message as notices.
+ *
+ * Sometimes an error message cannot be printed (e.g., in a cronjob environment) where there is
+ * no front end to display the error message, or otherwise irrelevant for a human. For that reason, we have to check if the print functions are undefined.
+ *
+ * @param WP_Error $wp_error A WordPress error object.
+ * @return void
+ */
+function walley_print_error_message( $wp_error ) {
+	if ( is_ajax() ) {
+		if ( function_exists( 'wc_add_notice' ) ) {
+			$print = 'wc_add_notice';
+		}
+	} else {
+		if ( function_exists( 'wc_print_notice' ) ) {
+			$print = 'wc_print_notice';
+		}
+	}
+
+	if ( ! isset( $print ) ) {
+		return;
+	}
+
+	foreach ( $wp_error->get_error_messages() as $error ) {
+		$message = is_array( $error ) ? implode( ' ', $error ) : $error;
+		$print( $message, 'error' );
+	}
 }

--- a/includes/collector-checkout-settings.php
+++ b/includes/collector-checkout-settings.php
@@ -25,6 +25,20 @@ $settings = array(
 		'description' => __( 'This is the title that the user sees on the checkout page for Walley Checkout (Collector).', 'collector-checkout-for-woocommerce' ),
 		'default'     => __( 'Walley Checkout', 'collector-checkout-for-woocommerce' ),
 	),
+	'walley_api_client_id'            => array(
+		'title'       => __( 'API Client ID', 'collector-checkout-for-woocommerce' ),
+		'type'        => 'text',
+		'description' => __( 'Enter your Walley Checkout API Client ID', 'collector-checkout-for-woocommerce' ),
+		'default'     => '',
+		'desc_tip'    => true,
+	),
+	'walley_api_secret'               => array(
+		'title'       => __( 'API Secret', 'collector-checkout-for-woocommerce' ),
+		'type'        => 'text',
+		'description' => __( 'Enter your Walley Checkout API Secret', 'collector-checkout-for-woocommerce' ),
+		'default'     => '',
+		'desc_tip'    => true,
+	),
 	'collector_username'              => array(
 		'title'       => __( 'Username', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',

--- a/includes/collector-checkout-settings.php
+++ b/includes/collector-checkout-settings.php
@@ -28,16 +28,16 @@ $settings = array(
 	'walley_api_client_id'            => array(
 		'title'       => __( 'API Client ID', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
-		'description' => __( 'Enter your Walley Checkout API Client ID', 'collector-checkout-for-woocommerce' ),
+		'description' => __( 'Enter your Walley Checkout API Client ID. Used for Walley\'s new Management API.', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
-		'desc_tip'    => true,
+		'desc_tip'    => false,
 	),
 	'walley_api_secret'               => array(
 		'title'       => __( 'API Secret', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
-		'description' => __( 'Enter your Walley Checkout API Secret', 'collector-checkout-for-woocommerce' ),
+		'description' => __( 'Enter your Walley Checkout API Secret. Used for Walley\'s new Management API.', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
-		'desc_tip'    => true,
+		'desc_tip'    => false,
 	),
 	'collector_username'              => array(
 		'title'       => __( 'Username', 'collector-checkout-for-woocommerce' ),

--- a/includes/collector-checkout-settings.php
+++ b/includes/collector-checkout-settings.php
@@ -25,31 +25,10 @@ $settings = array(
 		'description' => __( 'This is the title that the user sees on the checkout page for Walley Checkout (Collector).', 'collector-checkout-for-woocommerce' ),
 		'default'     => __( 'Walley Checkout', 'collector-checkout-for-woocommerce' ),
 	),
-	'walley_api_client_id'            => array(
-		'title'       => __( 'API Client ID', 'collector-checkout-for-woocommerce' ),
-		'type'        => 'text',
-		'description' => __( 'Enter your Walley Checkout API Client ID. Used for Walley\'s new Management API.', 'collector-checkout-for-woocommerce' ),
-		'default'     => '',
-		'desc_tip'    => false,
-	),
-	'walley_api_secret'               => array(
-		'title'       => __( 'API Secret', 'collector-checkout-for-woocommerce' ),
-		'type'        => 'text',
-		'description' => __( 'Enter your Walley Checkout API Secret. Used for Walley\'s new Management API.', 'collector-checkout-for-woocommerce' ),
-		'default'     => '',
-		'desc_tip'    => false,
-	),
 	'collector_username'              => array(
 		'title'       => __( 'Username', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Enter your Walley Checkout Username', 'collector-checkout-for-woocommerce' ),
-		'default'     => '',
-		'desc_tip'    => true,
-	),
-	'collector_password'              => array(
-		'title'       => __( 'Password', 'collector-checkout-for-woocommerce' ),
-		'type'        => 'text',
-		'description' => __( 'Enter your Walley Checkout Password', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),
@@ -59,6 +38,27 @@ $settings = array(
 		'description' => __( 'Enter your Walley Checkout Shared Key', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
+	),
+	'walley_api_client_id'            => array(
+		'title'       => __( 'API Client ID', 'collector-checkout-for-woocommerce' ),
+		'type'        => 'text',
+		'description' => __( 'Enter your Walley Checkout API Client ID. Used for Walley\'s new Management API. If entered this API will be used instead of the old SOAP based.', 'collector-checkout-for-woocommerce' ),
+		'default'     => '',
+		'desc_tip'    => false,
+	),
+	'walley_api_secret'               => array(
+		'title'       => __( 'API Secret', 'collector-checkout-for-woocommerce' ),
+		'type'        => 'text',
+		'description' => __( 'Enter your Walley Checkout API Secret. Used for Walley\'s new Management API. If entered this API will be used instead of the old SOAP based.', 'collector-checkout-for-woocommerce' ),
+		'default'     => '',
+		'desc_tip'    => false,
+	),
+	'collector_password'              => array(
+		'title'       => __( 'Password', 'collector-checkout-for-woocommerce' ),
+		'type'        => 'text',
+		'description' => __( 'Enter your Walley Checkout Password. Used for Walley\'s old SOAP based Payments API (for order management).', 'collector-checkout-for-woocommerce' ),
+		'default'     => '',
+		'desc_tip'    => false,
 	),
 	'se_settings_title'               => array(
 		'title' => __( 'Sweden', 'collector-checkout-for-woocommerce' ),
@@ -289,7 +289,7 @@ if ( version_compare( $wc_version, '3.4', '>=' ) ) {
 	$new_settings = array();
 	foreach ( $settings as $key => $value ) {
 		$new_settings[ $key ] = $value;
-		if ( 'collector_shared_key' === $key ) {
+		if ( 'collector_password' === $key ) {
 			$new_settings['display_privacy_policy_text'] = array(
 				'title'   => __( 'Display checkout privacy policy text', 'collector-checkout-for-woocommerce' ),
 				'label'   => __( 'Select if you want to show the <em>Checkout privacy policy</em> text on the checkout page, and where you want to display it.', 'collector-checkout-for-woocommerce' ),


### PR DESCRIPTION
Add support for Walley's new Management API. Currently supports
* Activate order
* Cancel order
* Refund order
* GET order

Also saves Walley order ID to Woo order. This is needed to be able to communicate with Walley with new Management API.