### PR TITLE
Checkout request rewrite

### DIFF
--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -639,6 +639,12 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 	public static function maybe_update_fees( $private_id, $customer_type ) {
 		// Use new or old API.
 		if ( self::use_new_api() ) {
+
+			// If Walley delivery module is used and there is no invoice fee - bail.
+			if ( empty( Walley_Checkout_Requests_Fees_Helper::fees() ) ) {
+				return;
+			}
+
 			$collector_order_fee = CCO_WC()->api->update_walley_fees(
 				array(
 					'private_id'    => $private_id,

--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -14,6 +14,24 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 
+	/**
+	 * Use new or old API.
+	 *
+	 * @var bool $walley_use_new_api
+	 */
+	public static $walley_use_new_api;
+
+	/**
+	 * Returns the *Singleton* instance of this class.
+	 *
+	 * @return bool.
+	 */
+	public static function use_new_api() {
+		if ( null === self::$walley_use_new_api ) {
+			self::$walley_use_new_api = walley_use_new_api();
+		}
+		return self::$walley_use_new_api;
+	}
 
 	/**
 	 * Hook in ajax handlers.
@@ -21,6 +39,7 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 	public static function init() {
 		self::add_ajax_events();
 	}
+
 	/**
 	 * Hook in methods - uses WordPress ajax handlers (admin-ajax).
 	 */
@@ -68,8 +87,12 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 		} else {
 
 			// Get a new public token from Collector.
-			$init_checkout   = new Collector_Checkout_Requests_Initialize_Checkout( $customer_type );
-			$collector_order = $init_checkout->request();
+			if ( self::use_new_api() ) {
+				$collector_order = CCO_WC()->api->initialize_walley_checkout( array( 'customer_type' => $customer_type ) );
+			} else {
+				$init_checkout   = new Collector_Checkout_Requests_Initialize_Checkout( $customer_type );
+				$collector_order = $init_checkout->request();
+			}
 
 			if ( is_wp_error( $collector_order ) || empty( $collector_order ) ) {
 				$return = sprintf( '%s <a href="%s" class="button wc-forward">%s</a>', __( 'Could not connect to Walley. Error message: ', 'collector-checkout-for-woocommerce' ) . $collector_order->get_error_message(), wc_get_checkout_url(), __( 'Try again', 'collector-checkout-for-woocommerce' ) );
@@ -119,134 +142,11 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 		$private_id    = WC()->session->get( 'collector_private_id' );
 		$customer_type = WC()->session->get( 'collector_customer_type' );
 
-		// start by updating our metadata if any
-		$metadata = apply_filters( 'coc_update_cart_metadata', array() );
-		if ( ! empty( $metadata ) ) {
-			$update_metadata         = new Collector_Checkout_Requests_Update_Metadata( $private_id, $customer_type, $metadata );
-			$collecor_order_metadata = $update_metadata->request();
-			// Check that everything went alright
-			if ( is_wp_error( $collecor_order_metadata ) ) {
-				// Check if purchase was completed, if it was don't redirect customer.
-				if ( 900 === $collecor_order_metadata->get_error_code() ) {
-					if ( ! empty( $collecor_order_metadata->get_error_message( 'Purchase_Completed' ) ) || ! empty( $collecor_order_metadata->get_error_message( 'Purchase_Commitment_Found' ) ) ) {
-						$return                 = array();
-						$return['redirect_url'] = '#';
-						wp_send_json_error( $return );
-					}
-				}
-				// Check if we had validation error
-				if ( 400 === $collecor_order_metadata->get_error_code() ) {
-					if ( ! empty( $collecor_order_metadata->get_error_message( 'Validation_Error' ) ) ) {
-						$return                 = array();
-						$return['redirect_url'] = '#';
-						wp_send_json_error( $return );
-					}
-				}
-				// Check if the resource is temporarily locked, if it was don't redirect customer.
-				if ( 423 === $collecor_order_metadata->get_error_code() ) {
-					$return                 = array();
-					$return['redirect_url'] = '#';
-					wp_send_json_error( $return );
-				}
-			}
-		}
+		self::maybe_update_metadata( $private_id, $customer_type );
 
-		$update_fees         = new Collector_Checkout_Requests_Update_Fees( $private_id, $customer_type );
-		$collector_order_fee = $update_fees->request();
+		self::maybe_update_fees( $private_id, $customer_type );
 
-		if ( is_checkout() ) {
-			$cart_item_total = Collector_Checkout_Requests_Cart::cart();
-
-			// Update checkout and annul payment method if the total cart item amount is 0.
-			if ( empty( $cart_item_total['items'] ) ) {
-				$return                 = array();
-				$return['redirect_url'] = wc_get_checkout_url();
-				wp_send_json_error( $return );
-			}
-		}
-
-		// Check that update fees request was ok.
-		if ( is_wp_error( $collector_order_fee ) ) {
-			// Check if purchase was completed, if it was don't redirect customer.
-			if ( 900 === $collector_order_fee->get_error_code() ) {
-				if ( ! empty( $collector_order_fee->get_error_message( 'Purchase_Completed' ) ) || ! empty( $collector_order_fee->get_error_message( 'Purchase_Commitment_Found' ) ) ) {
-					$return = array();
-					// Check if an order exist with this private id. If we find a match, redirect to thank you page.
-					$order_id = wc_collector_get_order_id_by_private_id( $private_id );
-					if ( ! empty( $order_id ) ) {
-						$order = wc_get_order( $order_id );
-						if ( is_object( $order ) ) {
-							$return['redirect_url'] = $order->get_checkout_order_received_url();
-						} else {
-							$return['redirect_url'] = '#900';
-						}
-					} else {
-						$return['redirect_url'] = '#900';
-					}
-					wp_send_json_error( $return );
-				}
-			}
-
-			// Check if somethings wrong with the content of the cart sent, if it was don't redirect customer.
-			if ( 400 === $collector_order_fee->get_error_code() ) {
-				if ( ! empty( $collector_order_fee->get_error_message( 'Duplicate_Articles' ) ) || ! empty( $collector_order_fee->get_error_message( 'Validation_Error' ) ) ) {
-					$return                 = array();
-					$return['redirect_url'] = '#400';
-					wp_send_json_error( $return );
-				}
-			}
-
-			// Check if the resource is temporarily locked, if it was don't redirect customer.
-			if ( 423 === $collector_order_fee->get_error_code() ) {
-				$return                 = array();
-				$return['redirect_url'] = '#423';
-				wp_send_json_error( $return );
-			}
-
-			wc_collector_unset_sessions();
-			$return                 = array();
-			$return['redirect_url'] = wc_get_checkout_url();
-			wp_send_json_error( $return );
-		}
-
-		$update_cart          = new Collector_Checkout_Requests_Update_Cart( $private_id, $customer_type );
-		$collector_order_cart = $update_cart->request();
-
-		// Check that update cart request was ok.
-		if ( is_wp_error( $collector_order_cart ) ) {
-
-			// Check if purchase was completed, if it was don't redirect customer.
-			if ( 900 === $collector_order_cart->get_error_code() ) {
-				if ( ! empty( $collector_order_cart->get_error_message( 'Purchase_Completed' ) ) || ! empty( $collector_order_cart->get_error_message( 'Purchase_Commitment_Found' ) ) ) {
-					$return                 = array();
-					$return['redirect_url'] = '#';
-					wp_send_json_error( $return );
-				}
-			}
-
-			// Check if somethings wrong with the content of the cart sent, if it was don't redirect customer.
-			if ( 400 === $collector_order_cart->get_error_code() ) {
-
-				if ( ! empty( $collector_order_cart->get_error_message( 'Duplicate_Articles' ) ) || ! empty( $collector_order_cart->get_error_message( 'Validation_Error' ) ) ) {
-
-					$return                 = array();
-					$return['redirect_url'] = '#';
-					wp_send_json_error( $return );
-				}
-			}
-
-			// Check if the resource is temporarily locked, if it was don't redirect customer.
-			if ( 423 === $collector_order_cart->get_error_code() ) {
-				$return                 = array();
-				$return['redirect_url'] = '#';
-				wp_send_json_error( $return );
-			}
-
-			wc_collector_unset_sessions();
-			$return                 = array();
-			$return['redirect_url'] = wc_get_checkout_url();
-			wp_send_json_error( $return );
-		}
+		self::maybe_update_cart( $private_id, $customer_type );
 
 		// Update database session id.
 		$collector_checkout_sessions = new Collector_Checkout_Sessions();
@@ -276,10 +176,21 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 		$update_needed = 'no';
 
 		// Get customer data from Collector.
-		$private_id      = WC()->session->get( 'collector_private_id' );
-		$customer_type   = WC()->session->get( 'collector_customer_type' );
-		$collector_order = new Collector_Checkout_Requests_Get_Checkout_Information( $private_id, $customer_type );
-		$collector_order = $collector_order->request();
+		$private_id    = WC()->session->get( 'collector_private_id' );
+		$customer_type = WC()->session->get( 'collector_customer_type' );
+
+		// Use new or old API.
+		if ( self::use_new_api() ) {
+			$collector_order = CCO_WC()->api->get_walley_checkout(
+				array(
+					'private_id'    => $private_id,
+					'customer_type' => $customer_type,
+				)
+			);
+		} else {
+			$collector_order = new Collector_Checkout_Requests_Get_Checkout_Information( $private_id, $customer_type );
+			$collector_order = $collector_order->request();
+		}
 
 		$customer_data                     = array();
 		$customer_data['billing_country']  = $collector_order['data']['countryCode'];
@@ -342,10 +253,21 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 
 		wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
 
-		$private_id      = WC()->session->get( 'collector_private_id' );
-		$customer_type   = WC()->session->get( 'collector_customer_type' );
-		$collector_order = new Collector_Checkout_Requests_Get_Checkout_Information( $private_id, $customer_type );
-		$collector_order = $collector_order->request();
+		$private_id    = WC()->session->get( 'collector_private_id' );
+		$customer_type = WC()->session->get( 'collector_customer_type' );
+
+		// Use new or old API.
+		if ( self::use_new_api() ) {
+			$collector_order = CCO_WC()->api->get_walley_checkout(
+				array(
+					'private_id'    => $private_id,
+					'customer_type' => $customer_type,
+				)
+			);
+		} else {
+			$collector_order = new Collector_Checkout_Requests_Get_Checkout_Information( $private_id, $customer_type );
+			$collector_order = $collector_order->request();
+		}
 
 		$shipping_data = coc_get_shipping_data( $collector_order );
 
@@ -441,8 +363,18 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 
 		CCO_WC()->logger::log( 'Payment complete triggered for private id ' . $private_id . '. Starting WooCommerce checkout form processing...' );
 
-		$customer_data   = new Collector_Checkout_Requests_Get_Checkout_Information( $private_id, $customer_type );
-		$collector_order = $customer_data->request();
+		// Use new or old API.
+		if ( self::use_new_api() ) {
+			$collector_order = CCO_WC()->api->get_walley_checkout(
+				array(
+					'private_id'    => $private_id,
+					'customer_type' => $customer_type,
+				)
+			);
+		} else {
+			$collector_order = new Collector_Checkout_Requests_Get_Checkout_Information( $private_id, $customer_type );
+			$collector_order = $collector_order->request();
+		}
 
 		if ( 'PurchaseCompleted' === $collector_order['data']['status'] ) {
 			// Save the payment method and payment id.
@@ -641,6 +573,197 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 		$redirect_url = $order->get_checkout_order_received_url();
 		$return       = array( 'redirect_url' => $redirect_url );
 		wp_send_json_success( $return );
+	}
+
+	/**
+	 * Maybe update metadata.
+	 *
+	 * @param string $private_id The Walley checkout session id.
+	 * @param string $customer_type The customer type (B2B|B2C).
+	 * @return void
+	 */
+	public static function maybe_update_metadata( $private_id, $customer_type ) {
+		// start by updating our metadata if any.
+		$metadata = apply_filters( 'coc_update_cart_metadata', array() );
+		if ( ! empty( $metadata ) ) {
+
+			// Use new or old API.
+			if ( self::use_new_api() ) {
+				$collecor_order_metadata = CCO_WC()->api->update_walley_metadata(
+					array(
+						'private_id'    => $private_id,
+						'customer_type' => $customer_type,
+						'metadata'      => $metadata,
+					)
+				);
+			} else {
+				$update_metadata         = new Collector_Checkout_Requests_Update_Metadata( $private_id, $customer_type, $metadata );
+				$collecor_order_metadata = $update_metadata->request();
+			}
+
+			// Check that everything went alright.
+			if ( is_wp_error( $collecor_order_metadata ) ) {
+				// Check if purchase was completed, if it was don't redirect customer.
+				if ( 900 === $collecor_order_metadata->get_error_code() ) {
+					if ( ! empty( $collecor_order_metadata->get_error_message( 'Purchase_Completed' ) ) || ! empty( $collecor_order_metadata->get_error_message( 'Purchase_Commitment_Found' ) ) ) {
+						$return                 = array();
+						$return['redirect_url'] = '#';
+						wp_send_json_error( $return );
+					}
+				}
+				// Check if we had validation error.
+				if ( 400 === $collecor_order_metadata->get_error_code() ) {
+					if ( ! empty( $collecor_order_metadata->get_error_message( 'Validation_Error' ) ) ) {
+						$return                 = array();
+						$return['redirect_url'] = '#';
+						wp_send_json_error( $return );
+					}
+				}
+				// Check if the resource is temporarily locked, if it was don't redirect customer.
+				if ( 423 === $collecor_order_metadata->get_error_code() ) {
+					$return                 = array();
+					$return['redirect_url'] = '#';
+					wp_send_json_error( $return );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Maybe update fees.
+	 *
+	 * @param string $private_id The Walley checkout session id.
+	 * @param string $customer_type The customer type (B2B|B2C).
+	 * @return void
+	 */
+	public static function maybe_update_fees( $private_id, $customer_type ) {
+		// Use new or old API.
+		if ( self::use_new_api() ) {
+			$collector_order_fee = CCO_WC()->api->update_walley_fees(
+				array(
+					'private_id'    => $private_id,
+					'customer_type' => $customer_type,
+				)
+			);
+		} else {
+			$update_fees         = new Collector_Checkout_Requests_Update_Fees( $private_id, $customer_type );
+			$collector_order_fee = $update_fees->request();
+		}
+
+		if ( is_checkout() ) {
+			$cart_item_total = Collector_Checkout_Requests_Cart::cart();
+
+			// Update checkout and annul payment method if the total cart item amount is 0.
+			if ( empty( $cart_item_total['items'] ) ) {
+				$return                 = array();
+				$return['redirect_url'] = wc_get_checkout_url();
+				wp_send_json_error( $return );
+			}
+		}
+
+		// Check that update fees request was ok.
+		if ( is_wp_error( $collector_order_fee ) ) {
+			// Check if purchase was completed, if it was don't redirect customer.
+			if ( 900 === $collector_order_fee->get_error_code() ) {
+				if ( ! empty( $collector_order_fee->get_error_message( 'Purchase_Completed' ) ) || ! empty( $collector_order_fee->get_error_message( 'Purchase_Commitment_Found' ) ) ) {
+					$return = array();
+					// Check if an order exist with this private id. If we find a match, redirect to thank you page.
+					$order_id = wc_collector_get_order_id_by_private_id( $private_id );
+					if ( ! empty( $order_id ) ) {
+						$order = wc_get_order( $order_id );
+						if ( is_object( $order ) ) {
+							$return['redirect_url'] = $order->get_checkout_order_received_url();
+						} else {
+							$return['redirect_url'] = '#900';
+						}
+					} else {
+						$return['redirect_url'] = '#900';
+					}
+					wp_send_json_error( $return );
+				}
+			}
+
+			// Check if somethings wrong with the content of the cart sent, if it was don't redirect customer.
+			if ( 400 === $collector_order_fee->get_error_code() ) {
+				if ( ! empty( $collector_order_fee->get_error_message( 'Duplicate_Articles' ) ) || ! empty( $collector_order_fee->get_error_message( 'Validation_Error' ) ) ) {
+					$return                 = array();
+					$return['redirect_url'] = '#400';
+					wp_send_json_error( $return );
+				}
+			}
+
+			// Check if the resource is temporarily locked, if it was don't redirect customer.
+			if ( 423 === $collector_order_fee->get_error_code() ) {
+				$return                 = array();
+				$return['redirect_url'] = '#423';
+				wp_send_json_error( $return );
+			}
+
+			wc_collector_unset_sessions();
+			$return                 = array();
+			$return['redirect_url'] = wc_get_checkout_url();
+			wp_send_json_error( $return );
+		}
+	}
+
+	/**
+	 * Maybe update cart.
+	 *
+	 * @param string $private_id The Walley checkout session id.
+	 * @param string $customer_type The customer type (B2B|B2C).
+	 * @return void
+	 */
+	public static function maybe_update_cart( $private_id, $customer_type ) {
+
+		// Use new or old API.
+		if ( self::use_new_api() ) {
+			$collector_order_cart = CCO_WC()->api->update_walley_cart(
+				array(
+					'private_id'    => $private_id,
+					'customer_type' => $customer_type,
+				)
+			);
+		} else {
+			$update_cart          = new Collector_Checkout_Requests_Update_Cart( $private_id, $customer_type );
+			$collector_order_cart = $update_cart->request();
+		}
+
+		// Check that update cart request was ok.
+		if ( is_wp_error( $collector_order_cart ) ) {
+
+			// Check if purchase was completed, if it was don't redirect customer.
+			if ( 900 === $collector_order_cart->get_error_code() ) {
+				if ( ! empty( $collector_order_cart->get_error_message( 'Purchase_Completed' ) ) || ! empty( $collector_order_cart->get_error_message( 'Purchase_Commitment_Found' ) ) ) {
+					$return                 = array();
+					$return['redirect_url'] = '#';
+					wp_send_json_error( $return );
+				}
+			}
+
+			// Check if somethings wrong with the content of the cart sent, if it was don't redirect customer.
+			if ( 400 === $collector_order_cart->get_error_code() ) {
+
+				if ( ! empty( $collector_order_cart->get_error_message( 'Duplicate_Articles' ) ) || ! empty( $collector_order_cart->get_error_message( 'Validation_Error' ) ) ) {
+
+					$return                 = array();
+					$return['redirect_url'] = '#';
+					wp_send_json_error( $return );
+				}
+			}
+
+			// Check if the resource is temporarily locked, if it was don't redirect customer.
+			if ( 423 === $collector_order_cart->get_error_code() ) {
+				$return                 = array();
+				$return['redirect_url'] = '#';
+				wp_send_json_error( $return );
+			}
+
+			wc_collector_unset_sessions();
+			$return                 = array();
+			$return['redirect_url'] = wc_get_checkout_url();
+			wp_send_json_error( $return );
+		}
+
 	}
 }
 Collector_Checkout_Ajax_Calls::init();

--- a/classes/class-collector-checkout-api-callbacks.php
+++ b/classes/class-collector-checkout-api-callbacks.php
@@ -87,8 +87,19 @@ class Collector_Api_Callbacks {
 		$collector_db_data   = get_collector_data_from_db( $private_id );
 		$this->db_session_id = $collector_db_data->session_id;
 
-		$response              = new Collector_Checkout_Requests_Get_Checkout_Information( $private_id, $customer_type, $currency );
-		$this->collector_order = $response->request();
+		// Use new or old API.
+		if ( walley_use_new_api() ) {
+			$this->collector_order = CCO_WC()->api->get_walley_checkout(
+				array(
+					'private_id'    => $private_id,
+					'customer_type' => $customer_type,
+					'currency'      => $currency,
+				)
+			);
+		} else {
+			$response              = new Collector_Checkout_Requests_Get_Checkout_Information( $private_id, $customer_type, $currency );
+			$this->collector_order = $response->request();
+		}
 
 		// Check if we have a session id.
 		$this->check_session_id();

--- a/classes/class-collector-checkout-confirmation.php
+++ b/classes/class-collector-checkout-confirmation.php
@@ -127,8 +127,19 @@ class Collector_Checkout_Confirmation {
 		$private_id    = WC()->session->get( 'collector_private_id' );
 		$customer_type = WC()->session->get( 'collector_customer_type' );
 
-		$customer_data   = new Collector_Checkout_Requests_Get_Checkout_Information( $private_id, $customer_type );
-		$collector_order = $customer_data->request();
+		// Use new or old API.
+		if ( walley_use_new_api() ) {
+			$collector_order = CCO_WC()->api->get_walley_checkout(
+				array(
+					'private_id'    => $private_id,
+					'customer_type' => $customer_type,
+				)
+			);
+		} else {
+			$customer_data   = new Collector_Checkout_Requests_Get_Checkout_Information( $private_id, $customer_type );
+			$collector_order = $customer_data->request();
+
+		}
 
 		if ( 'PurchaseCompleted' === $collector_order['data']['status'] ) {
 			// Save the payment method and payment id.

--- a/classes/class-walley-checkout-api.php
+++ b/classes/class-walley-checkout-api.php
@@ -29,6 +29,78 @@ class Walley_Checkout_API {
 	}
 
 	/**
+	 * Initialize Walley checkout.
+	 *
+	 * @param array $args Data passed to init request.
+	 * @return array|WP_Error
+	 */
+	public function initialize_walley_checkout( $args ) {
+		$request  = new Walley_Checkout_Request_Initialize_Checkout( $args );
+		$response = $request->request();
+		return $this->check_for_api_error( $response );
+	}
+
+	/**
+	 * Update Walley checkout cart.
+	 *
+	 * @param array $args Data passed to init request.
+	 * @return array|WP_Error
+	 */
+	public function update_walley_cart( $args ) {
+		$request  = new Walley_Checkout_Request_Update_Cart( $args );
+		$response = $request->request();
+		return $this->check_for_api_error( $response );
+	}
+
+	/**
+	 * Update Walley checkout fees.
+	 *
+	 * @param array $args Data passed to init request.
+	 * @return array|WP_Error
+	 */
+	public function update_walley_fees( $args ) {
+		$request  = new Walley_Checkout_Request_Update_Fees( $args );
+		$response = $request->request();
+		return $this->check_for_api_error( $response );
+	}
+
+	/**
+	 * Update Walley checkout metadata.
+	 *
+	 * @param array $args Data passed to init request.
+	 * @return array|WP_Error
+	 */
+	public function update_walley_metadata( $args ) {
+		$request  = new Walley_Checkout_Request_Update_Metadata( $args );
+		$response = $request->request();
+		return $this->check_for_api_error( $response );
+	}
+
+	/**
+	 * Get Walley checkout session.
+	 *
+	 * @param array $args Data passed to init request.
+	 * @return array|WP_Error
+	 */
+	public function get_walley_checkout( $args ) {
+		$request  = new Walley_Checkout_Request_Get_Checkout( $args );
+		$response = $request->request();
+		return $this->check_for_api_error( $response );
+	}
+
+	/**
+	 * Set order reference in Walley order.
+	 *
+	 * @param array $args Data passed to init request.
+	 * @return array|WP_Error
+	 */
+	public function set_order_reference_in_walley( $args ) {
+		$request  = new Walley_Checkout_Request_Set_Order_Reference( $args );
+		$response = $request->request();
+		return $this->check_for_api_error( $response );
+	}
+
+	/**
 	 * Get Walley order.
 	 *
 	 * @param string $walley_id The Walley transaction id.

--- a/classes/requests/checkouts/get/class-walley-checkout-request-get-checkout.php
+++ b/classes/requests/checkouts/get/class-walley-checkout-request-get-checkout.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Class for the request to get checkout session.
+ *
+ * @package Collector_Checkout/Classes/Requests/GET
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Walley_Checkout_Request_Get_Checkout class.
+ */
+class Walley_Checkout_Request_Get_Checkout extends Walley_Checkout_Request_Get {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param array $arguments The request arguments.
+	 */
+	public function __construct( $arguments ) {
+		parent::__construct( $arguments );
+		$this->log_title  = 'Get checkout';
+		$this->order_id   = $arguments['order_id'] ?? '';
+		$this->private_id = $arguments['private_id'] ?? '';
+		$this->set_environment_variables( $arguments );
+	}
+
+	/**
+	 * Get the request url.
+	 *
+	 * @return string
+	 */
+	protected function get_request_url() {
+		return $this->get_api_url_base() . "/checkouts/{$this->private_id}";
+	}
+}

--- a/classes/requests/checkouts/post/class-walley-checkout-request-initialize-checkout.php
+++ b/classes/requests/checkouts/post/class-walley-checkout-request-initialize-checkout.php
@@ -66,7 +66,7 @@ class Walley_Checkout_Request_Initialize_Checkout extends Walley_Checkout_Reques
 				get_home_url() . '/wc-api/Collector_Checkout_Gateway/'
 			),
 			'cart'             => empty( $this->order_id ) ? $this->cart() : CCO_WC()->order_items->get_order_lines( $this->order_id ),
-			'fees'             => empty( $this->order_id ) ? $this->fees() : CCO_WC()->order_fees->get_order_fees( $this->order_id ),
+			'fees'             => empty( $this->order_id ) ? Walley_Checkout_Requests_Fees_Helper::fees() : CCO_WC()->order_fees->get_order_fees( $this->order_id ),
 		);
 
 		// Only send validationUri & profileName if this is a purchase from the checkout.

--- a/classes/requests/checkouts/post/class-walley-checkout-request-initialize-checkout.php
+++ b/classes/requests/checkouts/post/class-walley-checkout-request-initialize-checkout.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Class for the request to initialize a checkout.
+ *
+ * @package Collector_Checkout/Classes/Requests/POST
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Walley_Checkout_Request_Initialize_Checkout class.
+ */
+class Walley_Checkout_Request_Initialize_Checkout extends Walley_Checkout_Request_Post {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param array $arguments The request arguments.
+	 */
+	public function __construct( $arguments ) {
+		parent::__construct( $arguments );
+		$this->log_title = 'Initialize checkout';
+		$this->order_id  = $arguments['order_id'] ?? '';
+		$this->set_environment_variables( $arguments );
+	}
+
+	/**
+	 * Get the request url.
+	 *
+	 * @return string
+	 */
+	protected function get_request_url() {
+		return $this->get_api_url_base() . '/checkouts';
+	}
+
+	/**
+	 * Get the body for the request.
+	 *
+	 * @return array
+	 */
+	protected function get_body() {
+
+		// Set validation URI query args.
+		$validation_uri = add_query_arg(
+			array(
+				'private-id'        => '{checkout.id}',
+				'public-token'      => '{checkout.publictoken}',
+				'customer-type'     => $this->customer_type,
+				'customer-currency' => $this->currency,
+			),
+			get_home_url() . '/wc-api/Collector_WC_Validation/'
+		);
+
+		$body = array(
+			'storeId'          => $this->store_id,
+			'countryCode'      => $this->country_code,
+			'reference'        => '',
+			'merchantTermsUri' => $this->terms_page,
+			'notificationUri'  => add_query_arg(
+				array(
+					'notification-callback' => '1',
+					'private-id'            => '{checkout.id}',
+					'public-token'          => '{checkout.publictoken}',
+					'customer-type'         => $this->customer_type,
+				),
+				get_home_url() . '/wc-api/Collector_Checkout_Gateway/'
+			),
+			'cart'             => empty( $this->order_id ) ? $this->cart() : CCO_WC()->order_items->get_order_lines( $this->order_id ),
+			'fees'             => empty( $this->order_id ) ? $this->fees() : CCO_WC()->order_fees->get_order_fees( $this->order_id ),
+		);
+
+		// Only send validationUri & profileName if this is a purchase from the checkout.
+		if ( empty( $this->order_id ) ) {
+			if ( 'yes' === $this->activate_validation_callback ) {
+				$body['validationUri'] = $validation_uri;
+			}
+			if ( 'yes' === $this->delivery_module && 'v1' === $this->checkout_version ) {
+				$body['profileName'] = trim( $this->settings[ 'collector_custom_profile_' . strtolower( $this->country_code ) ] );
+				if ( empty( $body['profileName'] ) ) {
+					$body['profileName'] = 'Shipping';
+				}
+			}
+
+			$body['redirectPageUri'] = add_query_arg(
+				array(
+					'payment_successful' => '1',
+					'public-token'       => '{checkout.publictoken}',
+				),
+				wc_get_checkout_url()
+			);
+
+			// Customer.
+			if ( WC()->customer->get_billing_email() && WC()->customer->get_billing_phone() ) {
+				$body['customer']['email']             = WC()->customer->get_billing_email();
+				$body['customer']['mobilePhoneNumber'] = WC()->customer->get_billing_phone();
+			}
+		} else {
+			$order                   = wc_get_order( $this->order_id );
+			$body['redirectPageUri'] = add_query_arg(
+				array(
+					'collector_confirm_order_pay' => '1',
+					'public-token'                => '{checkout.publictoken}',
+				),
+				$order->get_checkout_order_received_url()
+			);
+
+			// Customer.
+			if ( $order->get_billing_email() && $order->get_billing_phone() ) {
+				$body['customer']['email']             = $order->get_billing_email();
+				$body['customer']['mobilePhoneNumber'] = $order->get_billing_phone();
+			}
+		}
+
+		return apply_filters( 'coc_initialize_checkout_args', $body, $this->order_id );
+	}
+}

--- a/classes/requests/checkouts/put/class-walley-checkout-request-set-order-reference.php
+++ b/classes/requests/checkouts/put/class-walley-checkout-request-set-order-reference.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Class for the request to set order reference.
+ *
+ * @package Collector_Checkout/Classes/Requests/PUT
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Walley_Checkout_Request_Set_Order_Reference class.
+ */
+class Walley_Checkout_Request_Set_Order_Reference extends Walley_Checkout_Request_Put {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param array $arguments The request arguments.
+	 */
+	public function __construct( $arguments ) {
+		parent::__construct( $arguments );
+		$this->log_title  = 'Set order reference';
+		$this->order_id   = $arguments['order_id'] ?? '';
+		$this->private_id = $arguments['private_id'] ?? '';
+		$this->set_environment_variables( $arguments );
+	}
+
+	/**
+	 * Get the request url.
+	 *
+	 * @return string
+	 */
+	protected function get_request_url() {
+		return $this->get_api_url_base() . "/checkouts/{$this->private_id}/reference";
+	}
+
+	/**
+	 * Get the body for the request.
+	 *
+	 * @return array
+	 */
+	protected function get_body() {
+		$order             = wc_get_order( $this->order_id );
+		$body['Reference'] = $order->get_order_number();
+		return apply_filters( 'coc_set_order_reference_args', $body, $this->order_id );
+	}
+}

--- a/classes/requests/checkouts/put/class-walley-checkout-request-update-cart.php
+++ b/classes/requests/checkouts/put/class-walley-checkout-request-update-cart.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Class for the request to update cart.
+ *
+ * @package Collector_Checkout/Classes/Requests/PUT
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Walley_Checkout_Request_Update_Cart class.
+ */
+class Walley_Checkout_Request_Update_Cart extends Walley_Checkout_Request_Put {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param array $arguments The request arguments.
+	 */
+	public function __construct( $arguments ) {
+		parent::__construct( $arguments );
+		$this->log_title  = 'Update cart';
+		$this->order_id   = $arguments['order_id'] ?? '';
+		$this->private_id = $arguments['private_id'] ?? '';
+		$this->set_environment_variables( $arguments );
+	}
+
+	/**
+	 * Get the request url.
+	 *
+	 * @return string
+	 */
+	protected function get_request_url() {
+		return $this->get_api_url_base() . "/checkouts/{$this->private_id}/cart";
+	}
+
+	/**
+	 * Get the body for the request.
+	 *
+	 * @return array
+	 */
+	protected function get_body() {
+
+		$body = $this->cart();
+		return apply_filters( 'coc_update_cart_args', $body, $this->order_id );
+	}
+}

--- a/classes/requests/checkouts/put/class-walley-checkout-request-update-fees.php
+++ b/classes/requests/checkouts/put/class-walley-checkout-request-update-fees.php
@@ -41,7 +41,7 @@ class Walley_Checkout_Request_Update_Fees extends Walley_Checkout_Request_Put {
 	 */
 	protected function get_body() {
 
-		$fees = $this->fees();
+		$fees = Walley_Checkout_Requests_Fees_Helper::fees();
 		$body = array();
 
 		if ( isset( $fees['directinvoicenotification'] ) ) {

--- a/classes/requests/checkouts/put/class-walley-checkout-request-update-fees.php
+++ b/classes/requests/checkouts/put/class-walley-checkout-request-update-fees.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Class for the request to update fees.
+ *
+ * @package Collector_Checkout/Classes/Requests/PUT
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Walley_Checkout_Request_Update_Fees class.
+ */
+class Walley_Checkout_Request_Update_Fees extends Walley_Checkout_Request_Put {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param array $arguments The request arguments.
+	 */
+	public function __construct( $arguments ) {
+		parent::__construct( $arguments );
+		$this->log_title  = 'Update fees';
+		$this->order_id   = $arguments['order_id'] ?? '';
+		$this->private_id = $arguments['private_id'] ?? '';
+		$this->set_environment_variables( $arguments );
+	}
+
+	/**
+	 * Get the request url.
+	 *
+	 * @return string
+	 */
+	protected function get_request_url() {
+		return $this->get_api_url_base() . "/checkouts/{$this->private_id}/fees";
+	}
+
+	/**
+	 * Get the body for the request.
+	 *
+	 * @return array
+	 */
+	protected function get_body() {
+
+		$fees = $this->fees();
+		$body = array();
+
+		if ( isset( $fees['directinvoicenotification'] ) ) {
+			$body ['directinvoicenotification'] = $fees['directinvoicenotification'];
+		}
+
+		if ( isset( $fees['shipping'] ) && ! empty( $fees['shipping'] ) ) {
+			$body['shipping'] = $fees['shipping'];
+		}
+
+		if ( ! empty( $body ) ) {
+			return apply_filters( 'coc_update_fees_args', $body, $this->order_id );
+		} else {
+			return false;
+		}
+	}
+}

--- a/classes/requests/checkouts/put/class-walley-checkout-request-update-metadata.php
+++ b/classes/requests/checkouts/put/class-walley-checkout-request-update-metadata.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Class for the request to update metadata.
+ *
+ * @package Collector_Checkout/Classes/Requests/PUT
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Walley_Checkout_Request_Update_Metadata class.
+ */
+class Walley_Checkout_Request_Update_Metadata extends Walley_Checkout_Request_Put {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param array $arguments The request arguments.
+	 */
+	public function __construct( $arguments ) {
+		parent::__construct( $arguments );
+		$this->log_title  = 'Update metadata';
+		$this->order_id   = $arguments['order_id'] ?? '';
+		$this->metadata   = $arguments['metadata'] ?? '';
+		$this->private_id = $arguments['private_id'] ?? '';
+		$this->set_environment_variables( $arguments );
+	}
+
+	/**
+	 * Get the request url.
+	 *
+	 * @return string
+	 */
+	protected function get_request_url() {
+		return $this->get_api_url_base() . "/checkouts/{$this->private_id}/metadata";
+	}
+
+	/**
+	 * Get the body for the request.
+	 *
+	 * @return array
+	 */
+	protected function get_body() {
+
+		$body['metadata'] = $this->metadata;
+		return apply_filters( 'coc_update_metadata_args', $body, $this->order_id );
+	}
+}

--- a/classes/requests/class-walley-checkout-request-put.php
+++ b/classes/requests/class-walley-checkout-request-put.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Base class for all PUT requests.
+ *
+ * @package Collector_Checkout/Classes/Request
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ *  The main class for PUT requests.
+ */
+abstract class Walley_Checkout_Request_Put extends Walley_Checkout_Request {
+
+	/**
+	 * Walley_Checkout_Request_Put constructor.
+	 *
+	 * @param  array $arguments  The request arguments.
+	 */
+	public function __construct( $arguments = array() ) {
+		parent::__construct( $arguments );
+		$this->method = 'PUT';
+	}
+
+	/**
+	 * Build and return proper request arguments for this request type.
+	 *
+	 * @return array Request arguments
+	 */
+	protected function get_request_args() {
+
+		$body = wp_json_encode( apply_filters( 'walley_checkout_request_args', $this->get_body() ) );
+
+		return array(
+			'headers'    => $this->get_request_headers(),
+			'user-agent' => $this->get_user_agent(),
+			'method'     => $this->method,
+			'timeout'    => apply_filters( 'walley_checkout_set_timeout', 10 ),
+			'body'       => $body,
+		);
+	}
+
+	/**
+	 * Builds the request args for a PUT request.
+	 *
+	 * @return array
+	 */
+	abstract protected function get_body();
+}

--- a/classes/requests/class-walley-checkout-request.php
+++ b/classes/requests/class-walley-checkout-request.php
@@ -290,14 +290,4 @@ abstract class Walley_Checkout_Request {
 		$collector_checkout_requests_cart = new Collector_Checkout_Requests_Cart();
 		return $collector_checkout_requests_cart->cart();
 	}
-
-	/**
-	 * Gets fees.
-	 *
-	 * @return array|string
-	 */
-	protected function fees() {
-		$collector_checkout_requests_fees = new Collector_Checkout_Requests_Fees();
-		return $collector_checkout_requests_fees->fees();
-	}
 }

--- a/classes/requests/class-walley-checkout-request.php
+++ b/classes/requests/class-walley-checkout-request.php
@@ -64,7 +64,7 @@ abstract class Walley_Checkout_Request {
 	 * @return void
 	 */
 	protected function load_settings() {
-		$this->settings = get_option( 'woocommerce_collector_checkout_settings' );
+		$this->settings = get_option( 'woocommerce_collector_checkout_settings', array() );
 	}
 
 	/**
@@ -236,5 +236,68 @@ abstract class Walley_Checkout_Request {
 			return '705798e0-8cef-427c-ae00-6023deba29af/.default';
 		}
 		return 'a3f3019f-2be9-41cc-a254-7bb347238e89/.default';
+	}
+
+	/**
+	 * Set environment variables from settings depending on customer type and currency.
+	 *
+	 * @param array $arguments The current customer args.
+	 *
+	 * @return void
+	 */
+	public function set_environment_variables( $arguments = array() ) {
+		$this->customer_type = $arguments['customer_type'] ?? 'b2c';
+		$this->currency      = $arguments['currency'] ?? get_woocommerce_currency();
+		switch ( $this->currency ) {
+			case 'SEK':
+				$country_code          = 'SE';
+				$this->store_id        = $this->settings[ 'collector_merchant_id_se_' . $this->customer_type ];
+				$this->delivery_module = isset( $this->settings['collector_delivery_module_se'] ) ? $this->settings['collector_delivery_module_se'] : 'no';
+				break;
+			case 'NOK':
+				$country_code          = 'NO';
+				$this->store_id        = $this->settings[ 'collector_merchant_id_no_' . $this->customer_type ];
+				$this->delivery_module = isset( $this->settings['collector_delivery_module_no'] ) ? $this->settings['collector_delivery_module_no'] : 'no';
+				break;
+			case 'DKK':
+				$country_code          = 'DK';
+				$this->store_id        = $this->settings[ 'collector_merchant_id_dk_' . $this->customer_type ];
+				$this->delivery_module = isset( $this->settings['collector_delivery_module_dk'] ) ? $this->settings['collector_delivery_module_dk'] : 'no';
+				break;
+			case 'EUR':
+				$country_code          = 'FI';
+				$this->store_id        = $this->settings[ 'collector_merchant_id_fi_' . $this->customer_type ];
+				$this->delivery_module = isset( $this->settings['collector_delivery_module_fi'] ) ? $this->settings['collector_delivery_module_fi'] : 'no';
+				break;
+			default:
+				$country_code          = 'SE';
+				$this->store_id        = $this->settings[ 'collector_merchant_id_se_' . $this->customer_type ];
+				$this->delivery_module = isset( $this->settings['collector_delivery_module_se'] ) ? $this->settings['collector_delivery_module_se'] : 'no';
+				break;
+		}
+		$this->country_code                 = $country_code;
+		$this->terms_page                   = esc_url( get_permalink( wc_get_page_id( 'terms' ) ) );
+		$this->activate_validation_callback = isset( $this->settings['activate_validation_callback'] ) ? $this->settings['activate_validation_callback'] : 'no';
+		$this->checkout_version             = isset( $this->settings['checkout_version'] ) ? $this->settings['checkout_version'] : 'v1';
+	}
+
+	/**
+	 * Gets the WC cart.
+	 *
+	 * @return array
+	 */
+	protected function cart() {
+		$collector_checkout_requests_cart = new Collector_Checkout_Requests_Cart();
+		return $collector_checkout_requests_cart->cart();
+	}
+
+	/**
+	 * Gets fees.
+	 *
+	 * @return array|string
+	 */
+	protected function fees() {
+		$collector_checkout_requests_fees = new Collector_Checkout_Requests_Fees();
+		return $collector_checkout_requests_fees->fees();
 	}
 }

--- a/classes/requests/helpers/class-walley-checkout-requests-fees-helper.php
+++ b/classes/requests/helpers/class-walley-checkout-requests-fees-helper.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * The class represents helpers functions for requests fees.
+ *
+ * @package Collector_Checkout/Classes/Requests/Helpers
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Collector_Checkout_Requests_Fees.
+ */
+class Walley_Checkout_Requests_Fees_Helper {
+
+	/**
+	 * Invoice fee ID
+	 *
+	 * @var string
+	 */
+	public $invoice_fee_id = '';
+
+	/**
+	 * Price with tax included, based on store settings or an empty string if price calculation failed.
+	 *
+	 * @var float|string
+	 */
+	public $price = 0;
+
+	/**
+	 * Gets the invoice fee id (if set in settings).
+	 *
+	 * @return string
+	 */
+	public static function get_invoice_fee_id() {
+		$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
+		$invoice_fee_id     = $collector_settings['collector_invoice_fee'] ?? '';
+		return $invoice_fee_id;
+	}
+
+	/**
+	 * Gets the delivery module settings for the currency.
+	 *
+	 * @return string
+	 */
+	public static function get_delivery_module() {
+		$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
+		switch ( get_woocommerce_currency() ) {
+			case 'SEK':
+				$delivery_module = isset( $collector_settings['collector_delivery_module_se'] ) ? $collector_settings['collector_delivery_module_se'] : 'no';
+				break;
+			case 'NOK':
+				$delivery_module = isset( $collector_settings['collector_delivery_module_no'] ) ? $collector_settings['collector_delivery_module_no'] : 'no';
+				break;
+			case 'DKK':
+				$delivery_module = isset( $collector_settings['collector_delivery_module_dk'] ) ? $collector_settings['collector_delivery_module_dk'] : 'no';
+				break;
+			case 'EUR':
+				$delivery_module = isset( $collector_settings['collector_delivery_module_fi'] ) ? $collector_settings['collector_delivery_module_fi'] : 'no';
+				break;
+			default:
+				$delivery_module = isset( $collector_settings['collector_delivery_module_se'] ) ? $collector_settings['collector_delivery_module_se'] : 'no';
+				break;
+		}
+
+		return $delivery_module;
+	}
+
+	/**
+	 * Gets the fees.
+	 *
+	 * @return array|string
+	 */
+	public static function fees() {
+		$fees = array();
+
+		/**
+		 * If a delivery module is not used, the shipping is handled in WooCommerce, and must be sent in the fee.shipping object. Retrieves first available.
+		 * Note: if no shipping is available, fees.shipping is simply unset, NOT null.
+		 */
+		$update_shipping = apply_filters( 'coc_update_shipping', ( 'no' === self::get_delivery_module() ) ); // Filter on if we should update shipping with fees or not.
+		$shipping        = self::get_shipping();
+		if ( ( WC()->cart->show_shipping() && $update_shipping ) && ! empty( $shipping ) ) {
+			$fees['shipping'] = $shipping;
+		}
+
+		/**
+		 * If "Hide shipping cost until address is entered" is enabled, we don't want to send the shipping cost yet,
+		 * as this will cause a discrepancy between WooCommerce and Walley since the WooCommerce shipping cost is zero.
+		 */
+		if ( ! WC()->cart->show_shipping() ) {
+			unset( $fees['shipping'] );
+		}
+
+		if ( self::get_invoice_fee_id() ) {
+			$_product = wc_get_product( self::get_invoice_fee_id() );
+			if ( is_object( $_product ) ) {
+				$directinvoicenotification         = self::get_invoice_fee( $_product );
+				$fees['directinvoicenotification'] = $directinvoicenotification;
+			}
+		}
+
+		// Don't return an array if it's empty.
+		if ( empty( $fees ) ) {
+			$fees = '';
+		}
+
+		return $fees;
+
+	}
+
+	/**
+	 * Gets the shipping.
+	 *
+	 * @return array|void
+	 */
+	public static function get_shipping() {
+		if ( WC()->cart->needs_shipping() ) {
+			WC()->cart->calculate_shipping();
+			$packages        = WC()->shipping->get_packages();
+			$chosen_methods  = WC()->session->get( 'chosen_shipping_methods' );
+			$chosen_shipping = $chosen_methods[0];
+			foreach ( $packages as $i => $package ) {
+				foreach ( $package['rates'] as $method ) {
+					if ( $chosen_shipping === $method->id ) {
+						WC()->session->set( 'collector_chosen_shipping', $method->id );
+						if ( $method->cost > 0 ) {
+							$shipping_item = array(
+								'id'          => 'shipping|' . substr( $method->id, 0, 50 ),
+								'description' => $method->label,
+								'unitPrice'   => round( $method->cost + array_sum( $method->taxes ), 2 ),
+								'vat'         => round( array_sum( $method->taxes ) / $method->cost, 2 ) * 100,
+							);
+							return $shipping_item;
+						} else {
+							$shipping_item = array(
+								'id'          => 'shipping|' . $method->id,
+								'description' => $method->label,
+								'unitPrice'   => 0,
+								'vat'         => 0,
+							);
+							return $shipping_item;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Gets the invoice fee for the WooCommerce product.
+	 *
+	 * @param WC_Product $_product The WooCommerce product.
+	 *
+	 * @return array
+	 */
+	public static function get_invoice_fee( $_product ) {
+
+		$price = wc_get_price_including_tax( $_product );
+
+		$_tax      = new WC_Tax();
+		$tmp_rates = $_tax->get_base_tax_rates( $_product->get_tax_class() );
+		$_vat      = array_shift( $tmp_rates );// Get the rate.
+		// Check what kind of tax rate we have.
+		if ( $_product->is_taxable() && isset( $_vat['rate'] ) ) {
+			$vat_rate = round( $_vat['rate'] );
+		} else {
+			// if empty, set 0% as rate.
+			$vat_rate = 0;
+		}
+
+		return array(
+			'id'          => 'invoicefee|' . self::get_sku( $_product, $_product->get_id() ),
+			'description' => $_product->get_title(),
+			'unitPrice'   => round( $price, 2 ),
+			'vat'         => $vat_rate,
+		);
+	}
+
+	/**
+	 * Gets the product SKU.
+	 *
+	 * @param WC_Product $product WooCommerce product.
+	 * @param int        $product_id WooCommerce product ID.
+	 * @return string
+	 */
+	public static function get_sku( $product, $product_id ) {
+		if ( get_post_meta( $product_id, '_sku', true ) !== '' ) {
+			$part_number = $product->get_sku();
+		} else {
+			$part_number = $product->get_id();
+		}
+		return substr( $part_number, 0, 32 );
+	}
+}

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -215,6 +215,8 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/helpers/class-collector-checkout-requests-helper-order-om.php';
 			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/helpers/class-collector-checkout-requests-helper-order-fees.php';
 
+			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/helpers/class-walley-checkout-requests-fees-helper.php';
+
 			// Set variables for shorthand access to classes.
 			$this->order_items = new Collector_Checkout_Requests_Helper_Order();
 			$this->order_fees  = new Collector_Checkout_Requests_Helper_Order_Fees();

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -145,10 +145,21 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-walley-checkout-api.php';
 				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-walley-checkout-order-management.php';
 
-				// New OM class files.
+				// New request class files.
 				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-walley-checkout-request.php';
 				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-walley-checkout-request-get.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-walley-checkout-request-put.php';
 				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-walley-checkout-request-post.php';
+
+				// New Checkout request class files.
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/checkouts/get/class-walley-checkout-request-get-checkout.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/checkouts/post/class-walley-checkout-request-initialize-checkout.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/checkouts/put/class-walley-checkout-request-update-cart.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/checkouts/put/class-walley-checkout-request-update-fees.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/checkouts/put/class-walley-checkout-request-update-metadata.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/checkouts/put/class-walley-checkout-request-set-order-reference.php';
+
+				// New OM request class files.
 				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/manage-orders/get/class-walley-checkout-request-get-order.php';
 				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/manage-orders/post/class-walley-checkout-request-capture-order.php';
 				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/manage-orders/post/class-walley-checkout-request-part-capture-order.php';
@@ -164,6 +175,16 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 			} else {
 
 				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-checkout-post-checkout.php';
+
+				// Include the Checkout Request Classes.
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-collector-checkout-requests.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-collector-checkout-requests-initialize-checkout.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-collector-checkout-requests-update-fees.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-collector-checkout-requests-update-cart.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-collector-checkout-requests-update-metadata.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-collector-checkout-requests-get-checkout-information.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-collector-checkout-requests-update-reference.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-collector-checkout-requests-paylink.php';
 
 				// Include the Soap Request Classes.
 				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/soap/class-collector-checkout-soap-requests-activate-invoice.php';
@@ -183,16 +204,6 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 			// Include and add the Gateway.
 			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/class-collector-checkout-gateway.php';
 			add_filter( 'woocommerce_payment_gateways', array( $this, 'add_collector_checkout_gateway' ) );
-
-			// Include the Request Classes.
-			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-collector-checkout-requests.php';
-			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-collector-checkout-requests-initialize-checkout.php';
-			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-collector-checkout-requests-update-fees.php';
-			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-collector-checkout-requests-update-cart.php';
-			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-collector-checkout-requests-update-metadata.php';
-			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-collector-checkout-requests-get-checkout-information.php';
-			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-collector-checkout-requests-update-reference.php';
-			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/class-collector-checkout-requests-paylink.php';
 
 			// Include the Request Helpers.
 			include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/helpers/class-collector-checkout-requests-cart.php';

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -765,6 +765,11 @@ function walley_print_error_message( $wp_error ) {
 	}
 }
 
+/**
+ * Use new Walley API or not.
+ *
+ * @return bool
+ */
 function walley_use_new_api() {
 	$collector_settings   = get_option( 'woocommerce_collector_checkout_settings' );
 	$walley_api_client_id = $collector_settings['walley_api_client_id'] ?? '';


### PR DESCRIPTION
* Using Walley Checkouts new API for checkout requests.
* Using same logic as for the order management rewrite - if new API credentials are entered, use new API. Otherwise use old API.