### PR TITLE
Add support for customFields

### DIFF
--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -360,15 +360,10 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 
 					foreach ( $custom_field_group['fields'] as $custom_field ) {
 
-						switch ( $custom_field['value'] ) {
-							case 'true':
-								$value = 'yes';
-								break;
-							case false:
-								$value = 'no';
-								break;
-							default:
-								$value = $custom_field['value'];
+						$value = $custom_field['value'];
+						// If the returned value is true/false convert it to yes/no since it is easier to store as post meta value.
+						if ( is_bool( $value ) ) {
+							$value = $value ? 'yes' : 'no';
 						}
 						update_post_meta( $order_id, $custom_field['id'], sanitize_text_field( $value ) );
 					}

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -293,6 +293,9 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 
 		$this->process_collector_payment_in_order( $order_id );
 
+		// Let other plugins hook into this sequence.
+		do_action( 'walley_process_payment', $order_id, $collector_order );
+
 		CCO_WC()->logger::log( 'Process Collector Payment for private_id ' . $private_id . '. WC order ID ' . $order_id . '. Redirecting customer to ' . $this->get_return_url( $order ) );
 
 		return array(

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -346,6 +346,36 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 			WC()->session->__unset( 'collector_delivery_module_data' );
 		}
 
+		// Save customFields data.
+		if ( isset( $collector_order['data']['customFields'] ) ) {
+
+			// Save the entire customFields object as json in order.
+			if ( true === apply_filters( 'walley_save_custom_fields_raw_data', true ) ) {
+				update_post_meta( $order_id, '_collector_custom_fields', wp_json_encode( $collector_order['data']['customFields'] ) );
+			}
+
+			// Save each individual custom field as id:value.
+			if ( true === apply_filters( 'walley_save_individual_custom_field', true ) ) {
+				foreach ( $collector_order['data']['customFields'] as $custom_field_group ) {
+
+					foreach ( $custom_field_group['fields'] as $custom_field ) {
+
+						switch ( $custom_field['value'] ) {
+							case 'true':
+								$value = 'yes';
+								break;
+							case false:
+								$value = 'no';
+								break;
+							default:
+								$value = $custom_field['value'];
+						}
+						update_post_meta( $order_id, $custom_field['id'], sanitize_text_field( $value ) );
+					}
+				}
+			}
+		}
+
 		// Tie this order to a user if we have one.
 		if ( email_exists( $collector_order['data']['customer']['email'] ) ) {
 			$user    = get_user_by( 'email', $collector_order['data']['customer']['email'] );

--- a/classes/requests/checkouts/post/class-walley-checkout-request-initialize-checkout.php
+++ b/classes/requests/checkouts/post/class-walley-checkout-request-initialize-checkout.php
@@ -111,6 +111,12 @@ class Walley_Checkout_Request_Initialize_Checkout extends Walley_Checkout_Reques
 			}
 		}
 
+		// Custom fields.
+		$custom_fields = apply_filters( 'walley_custom_fields', array(), $this->order_id );
+		if ( ! empty( $custom_fields ) ) {
+			$body['customFields'] = $custom_fields;
+		}
+
 		return apply_filters( 'coc_initialize_checkout_args', $body, $this->order_id );
 	}
 }


### PR DESCRIPTION
Add support for customFields via walley_custom_fields filter. Also add hook walley_process_payment to be able to save customFields data to Woo order.