### PR TITLE
Develop fix after feedback

### DIFF
--- a/assets/js/walley-order-meta-box.js
+++ b/assets/js/walley-order-meta-box.js
@@ -23,6 +23,7 @@ jQuery(function ($) {
 					} else {
 						$('.sync-btn-walley').removeClass( 'disabled' );
 						$('.walley_sync_wrapper').append( '<div><i>' + data.data + '</i></div>' );
+						alert( data.data );
 					}
 				},
 				error: function (data) {

--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -70,7 +70,7 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 	 * @return void
 	 */
 	public static function get_public_token() {
-		$customer_type      = filter_input( INPUT_POST, 'customer_type', FILTER_SANITIZE_STRING );
+		$customer_type      = filter_input( INPUT_POST, 'customer_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$public_token       = WC()->session->get( 'collector_public_token' );
 		$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
 		$test_mode          = $collector_settings['test_mode'];
@@ -212,7 +212,7 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 	 * @return void
 	 */
 	public static function add_customer_order_note() {
-		$order_note = filter_input( INPUT_POST, 'order_note', FILTER_SANITIZE_STRING );
+		$order_note = filter_input( INPUT_POST, 'order_note', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		WC()->session->set( 'collector_customer_order_note', $order_note );
 
 		wp_send_json_success();
@@ -224,14 +224,14 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 	 * @return void
 	 */
 	public static function get_checkout_thank_you() {
-		$order_id           = filter_input( INPUT_POST, 'order_id', FILTER_SANITIZE_STRING );
-		$purchase_status    = filter_input( INPUT_POST, 'purchase_status', FILTER_SANITIZE_STRING );
+		$order_id           = filter_input( INPUT_POST, 'order_id', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$purchase_status    = filter_input( INPUT_POST, 'purchase_status', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
 		$test_mode          = $collector_settings['test_mode'];
 
 		// If something went wrong in get_customer_data() - display a "thank you page light".
 		if ( 'not-completed' === $purchase_status ) {
-			$public_token = filter_input( INPUT_POST, 'public_token', FILTER_SANITIZE_STRING );
+			$public_token = filter_input( INPUT_POST, 'public_token', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			if ( WC()->session->get( 'collector_customer_type' ) ) {
 				$customer_type = WC()->session->get( 'collector_customer_type' );
 			} else {

--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -533,6 +533,14 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 
 		if ( ! is_wp_error( $response ) ) {
 			$order->add_order_note( 'Wallley order successfully synced.' );
+			// Save received data to WP transient.
+			walley_save_order_data_to_transient(
+				array(
+					'order_id'     => $order_id,
+					'total_amount' => $order->get_total(),
+					'currency'     => $order->get_currency(),
+				)
+			);
 		} else {
 			// Translators: Request error message & request error code.
 			$order->add_order_note( sprintf( __( 'Could not update order lines in Walley. Error message: %1$s. Error code: %2$s</i>', 'collector-checkout-for-woocommerce' ), $response->get_error_message(), $response->get_error_code() ) );

--- a/classes/class-collector-checkout-api-callbacks.php
+++ b/classes/class-collector-checkout-api-callbacks.php
@@ -75,9 +75,9 @@ class Collector_Api_Callbacks {
 	 * Handles validation callbacks.
 	 */
 	public function validation_cb() {
-		$private_id    = filter_input( INPUT_GET, 'private-id', FILTER_SANITIZE_STRING );
-		$customer_type = filter_input( INPUT_GET, 'customer-type', FILTER_SANITIZE_STRING );
-		$currency      = filter_input( INPUT_GET, 'customer-currency', FILTER_SANITIZE_STRING );
+		$private_id    = filter_input( INPUT_GET, 'private-id', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$customer_type = filter_input( INPUT_GET, 'customer-type', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$currency      = filter_input( INPUT_GET, 'customer-currency', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		CCO_WC()->logger::log( 'Validation Callback hit. Private id: ' . wp_json_encode( $private_id ) . '. Customer type: ' . $customer_type . '. Customer currency: ' . $currency );
 

--- a/classes/class-collector-checkout-confirmation.php
+++ b/classes/class-collector-checkout-confirmation.php
@@ -64,7 +64,7 @@ class Collector_Checkout_Confirmation {
 		}
 
 		// Prevent duplicate orders if confirmation page is reloaded manually by customer.
-		$collector_public_token = filter_input( INPUT_GET, 'public-token', FILTER_SANITIZE_STRING );
+		$collector_public_token = filter_input( INPUT_GET, 'public-token', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$query                  = new WC_Order_Query(
 			array(
 				'limit'          => -1,
@@ -120,7 +120,7 @@ class Collector_Checkout_Confirmation {
 			return;
 		}
 
-		$collector_public_token = filter_input( INPUT_GET, 'public-token', FILTER_SANITIZE_STRING );
+		$collector_public_token = filter_input( INPUT_GET, 'public-token', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		echo '<div id="collector-confirm-loading"></div>';
 

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -82,9 +82,9 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 	 * Schedule order status check on notificationUri callback from Collector
 	 */
 	public function notification_listener() {
-		$private_id    = filter_input( INPUT_GET, 'private-id', FILTER_SANITIZE_STRING );
-		$public_token  = filter_input( INPUT_GET, 'public-token', FILTER_SANITIZE_STRING );
-		$customer_type = filter_input( INPUT_GET, 'customer-type', FILTER_SANITIZE_STRING );
+		$private_id    = filter_input( INPUT_GET, 'private-id', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$public_token  = filter_input( INPUT_GET, 'public-token', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$customer_type = filter_input( INPUT_GET, 'customer-type', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		CCO_WC()->logger::log( 'Notification Listener hit. Private id: ' . wp_json_encode( $private_id ) . '. Public token: ' . $public_token . '. Customer type: ' . $customer_type );
 
@@ -452,7 +452,7 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 			CCO_WC()->logger::log( 'Thankyou page rendered for order ID - ' . $order->get_id() );
 			return '<div class="collector-checkout-thankyou"></div>';
 		}
-		$purchase_status = filter_input( INPUT_GET, 'purchase-status', FILTER_SANITIZE_STRING );
+		$purchase_status = filter_input( INPUT_GET, 'purchase-status', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( 'not-completed' === $purchase_status ) {
 			// Unset Collector token and id.

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -335,6 +335,7 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 		update_post_meta( $order_id, '_collector_payment_method', $payment_method );
 		update_post_meta( $order_id, '_collector_payment_id', $payment_id );
 		update_post_meta( $order_id, '_collector_order_id', sanitize_key( $walley_order_id ) );
+		update_post_meta( $order_id, '_collector_original_order_total', $order->get_total() );
 		wc_collector_save_shipping_reference_to_order( $order_id, $collector_order );
 
 		// Save shipping data.

--- a/classes/class-collector-checkout-pay-for-order-confirmation.php
+++ b/classes/class-collector-checkout-pay-for-order-confirmation.php
@@ -48,9 +48,9 @@ class Collector_Checkout_Pay_For_Order_Confirmation {
 	 * Confirm order
 	 */
 	public function confirm_order_pay_order() {
-		$collector_confirm = filter_input( INPUT_GET, 'collector_confirm_order_pay', FILTER_SANITIZE_STRING );
-		$public_token      = filter_input( INPUT_GET, 'public-token', FILTER_SANITIZE_STRING );
-		$order_key         = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_STRING );
+		$collector_confirm = filter_input( INPUT_GET, 'collector_confirm_order_pay', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$public_token      = filter_input( INPUT_GET, 'public-token', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$order_key         = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		// Return if we dont have our parameters set.
 		if ( empty( $collector_confirm ) || empty( $public_token ) || empty( $order_key ) ) {

--- a/classes/class-collector-checkout-post-checkout.php
+++ b/classes/class-collector-checkout-post-checkout.php
@@ -107,8 +107,8 @@ class Collector_Checkout_Post_Checkout {
 	 **/
 	public function check_callback() {
 		if ( ! empty( $_SERVER['REQUEST_URI'] ) && false !== strpos( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), 'module/collectorcheckout/invoicestatus' ) ) {
-			$invoice_no     = filter_input( INPUT_GET, 'InvoiceNo', FILTER_SANITIZE_STRING );
-			$invoice_status = filter_input( INPUT_GET, 'InvoiceStatus', FILTER_SANITIZE_STRING );
+			$invoice_no     = filter_input( INPUT_GET, 'InvoiceNo', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+			$invoice_status = filter_input( INPUT_GET, 'InvoiceStatus', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			if ( ! empty( $invoice_no ) && ! empty( $invoice_status ) ) {
 				CCO_WC()->logger::log( 'Collector Invoice Status Change callback hit' );
 				$collector_payment_id = $invoice_no;

--- a/classes/class-collector-checkout-sessions.php
+++ b/classes/class-collector-checkout-sessions.php
@@ -65,7 +65,7 @@ class Collector_Checkout_Sessions {
 	 * @return void
 	 */
 	public function set_session_from_id() {
-		$private_id        = filter_input( INPUT_GET, 'private-id', FILTER_SANITIZE_STRING );
+		$private_id        = filter_input( INPUT_GET, 'private-id', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$collector_db_data = ! empty( $private_id ) ? get_collector_data_from_db( $private_id ) : null;
 		if ( isset( $collector_db_data->session_id ) ) {
 			$sessions_handler = new WC_Session_Handler();
@@ -92,7 +92,7 @@ class Collector_Checkout_Sessions {
 	 * @return void
 	 */
 	public function maybe_set_wc_cart( $cart ) {
-		$private_id        = filter_input( INPUT_GET, 'private-id', FILTER_SANITIZE_STRING );
+		$private_id        = filter_input( INPUT_GET, 'private-id', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$collector_db_data = ! empty( $private_id ) ? get_collector_data_from_db( $private_id ) : null;
 		if ( isset( $collector_db_data->session_id ) ) {
 			WC()->cart = $cart;

--- a/classes/class-collector-checkout-templates.php
+++ b/classes/class-collector-checkout-templates.php
@@ -109,7 +109,7 @@ class Collector_Checkout_Templates {
 			<?php do_action( 'woocommerce_checkout_billing' ); ?>
 			<?php do_action( 'woocommerce_checkout_shipping' ); ?>
 			<?php
-			$payment_successful = filter_input( INPUT_GET, 'payment_successful', FILTER_SANITIZE_STRING );
+			$payment_successful = filter_input( INPUT_GET, 'payment_successful', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			if ( ! empty( $payment_successful ) ) {//phpcs:ignore
 				// On confirmation page - render woocommerce_checkout_payment() to get the woocommerce-process-checkout-nonce correct.
 				woocommerce_checkout_payment();

--- a/classes/class-walley-checkout-assets.php
+++ b/classes/class-walley-checkout-assets.php
@@ -46,14 +46,14 @@ class Walley_Checkout_Assets {
 			} else {
 				$locale = 'sv-SE';
 			}
-			$public_token = filter_input( INPUT_GET, 'public-token', FILTER_SANITIZE_STRING );
+			$public_token = filter_input( INPUT_GET, 'public-token', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 			if ( WC()->session->get( 'collector_private_id' ) ) {
 				$checkout_initiated = 'yes';
 			} else {
 				$checkout_initiated = 'no';
 			}
-			$payment_successful = filter_input( INPUT_GET, 'payment_successful', FILTER_SANITIZE_STRING );
+			$payment_successful = filter_input( INPUT_GET, 'payment_successful', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			if ( empty( $payment_successful ) ) {
 				$payment_successful = '0';
 			} else {
@@ -61,13 +61,13 @@ class Walley_Checkout_Assets {
 			}
 			if ( is_wc_endpoint_url( 'order-received' ) ) {
 				$is_thank_you_page = 'yes';
-				$key               = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_STRING );
+				$key               = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 				if ( ! empty( $key ) ) {
 					$order_id = wc_get_order_id_by_order_key( sanitize_text_field( $key ) );
 				} else {
 					$order_id = '';
 				}
-				$purchase_status = filter_input( INPUT_GET, 'purchase-status', FILTER_SANITIZE_STRING );
+				$purchase_status = filter_input( INPUT_GET, 'purchase-status', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			} else {
 				$is_thank_you_page = 'no';
 				$order_id          = '';
@@ -135,7 +135,7 @@ class Walley_Checkout_Assets {
 
 		// Hide the Order overview data on thankyou page if it's a Collector Checkout purchase.
 		if ( is_wc_endpoint_url( 'order-received' ) ) {
-			$key = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_STRING );
+			$key = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			if ( ! empty( $key ) ) {
 				$order_id = wc_get_order_id_by_order_key( wc_clean( $key ) );
 				$order    = wc_get_order( $order_id );
@@ -160,7 +160,7 @@ class Walley_Checkout_Assets {
 			return;
 		}
 
-		$section = filter_input( INPUT_GET, 'section', FILTER_SANITIZE_STRING );
+		$section = filter_input( INPUT_GET, 'section', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( 'collector_checkout' !== $section ) {
 			return;
 		}

--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -81,6 +81,15 @@ class  Walley_Checkout_Order_Management {
 			// Translators: Activated amount.
 			$order->add_order_note( sprintf( __( 'Order part activated with Walley Checkout. Activated amount %s', 'collector-checkout-for-woocommerce' ), wc_price( $order->get_total(), array( 'currency' => $order->get_order_currency() ) ) ) );
 			update_post_meta( $order_id, '_collector_order_activated', time() );
+
+			// Save received data to WP transient.
+			walley_save_order_data_to_transient(
+				array(
+					'order_id'     => $order_id,
+					'total_amount' => $order->get_total(),
+					'currency'     => $order->get_currency(),
+				)
+			);
 			return;
 		} else {
 			$response = CCO_WC()->api->capture_walley_order( $order_id );
@@ -99,6 +108,15 @@ class  Walley_Checkout_Order_Management {
 			$note = __( 'Walley Checkout order activated.', 'collector-checkout-for-woocommerce' );
 			$order->add_order_note( $note );
 			update_post_meta( $order_id, '_collector_order_activated', time() );
+
+			// Save received data to WP transient.
+			walley_save_order_data_to_transient(
+				array(
+					'order_id'     => $order_id,
+					'total_amount' => $order->get_total(),
+					'currency'     => $order->get_currency(),
+				)
+			);
 			return;
 		}
 	}
@@ -155,6 +173,15 @@ class  Walley_Checkout_Order_Management {
 		$note = __( 'Walley Checkout order cancelled.', 'collector-checkout-for-woocommerce' );
 		$order->add_order_note( $note );
 		update_post_meta( $order_id, '_collector_order_cancelled', time() );
+
+		// Save received data to WP transient.
+		walley_save_order_data_to_transient(
+			array(
+				'order_id'     => $order_id,
+				'total_amount' => $order->get_total(),
+				'currency'     => $order->get_currency(),
+			)
+		);
 	}
 
 	/**
@@ -211,6 +238,15 @@ class  Walley_Checkout_Order_Management {
 
 			return $response;
 		}
+
+		// Save received data to WP transient.
+		walley_save_order_data_to_transient(
+			array(
+				'order_id' => $order_id,
+				'currency' => $order->get_currency(),
+			)
+		);
+
 		// Translators: Refunded amount.
 		$order->add_order_note( sprintf( __( 'Walley Checkout order refunded with %s.', 'collector-checkout-for-woocommerce' ), wc_price( $amount ) ) );
 		return true;

--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -79,7 +79,7 @@ class  Walley_Checkout_Order_Management {
 			}
 
 			// Translators: Activated amount.
-			$order->add_order_note( sprintf( __( 'Order part activated with Walley Checkout. Activated amount %s', 'collector-checkout-for-woocommerce' ), wc_price( $order->get_total(), array( 'currency' => $order->get_order_currency() ) ) ) );
+			$order->add_order_note( sprintf( __( 'Order part activated with Walley Checkout. Activated amount %s', 'collector-checkout-for-woocommerce' ), wc_price( $order->get_total(), array( 'currency' => $order->get_currency() ) ) ) );
 			update_post_meta( $order_id, '_collector_order_activated', time() );
 
 			// Save received data to WP transient.

--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -327,8 +327,8 @@ class  Walley_Checkout_Order_Management {
 	 **/
 	public function check_callback() {
 		if ( ! empty( $_SERVER['REQUEST_URI'] ) && false !== strpos( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), 'module/collectorcheckout/invoicestatus' ) ) {
-			$invoice_no     = filter_input( INPUT_GET, 'InvoiceNo', FILTER_SANITIZE_STRING );
-			$invoice_status = filter_input( INPUT_GET, 'InvoiceStatus', FILTER_SANITIZE_STRING );
+			$invoice_no     = filter_input( INPUT_GET, 'InvoiceNo', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+			$invoice_status = filter_input( INPUT_GET, 'InvoiceStatus', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			if ( ! empty( $invoice_no ) && ! empty( $invoice_status ) ) {
 				CCO_WC()->logger::log( 'Collector Invoice Status Change callback hit' );
 				$collector_payment_id = $invoice_no;

--- a/classes/requests/helpers/class-collector-checkout-requests-helper-order-om.php
+++ b/classes/requests/helpers/class-collector-checkout-requests-helper-order-om.php
@@ -46,7 +46,7 @@ class Collector_Checkout_Requests_Helper_Order_Om {
 			}
 		}
 
-		self::rounding_fee( $order_lines, $order );
+		// self::rounding_fee( $order_lines, $order );
 		return $order_lines;
 	}
 

--- a/classes/requests/manage-orders/post/class-walley-checkout-request-reauthorize-order.php
+++ b/classes/requests/manage-orders/post/class-walley-checkout-request-reauthorize-order.php
@@ -47,4 +47,25 @@ class Walley_Checkout_Request_Reauthorize_Order extends Walley_Checkout_Request_
 
 		return apply_filters( 'coc_order_reauthorize_args', $body, $this->arguments['order_id'] );
 	}
+
+	/**
+	 * Processes the response checking for errors.
+	 *
+	 * @param object|WP_Error $response The response from the request.
+	 * @param array           $request_args The request args.
+	 * @param string          $request_url The request url.
+	 * @return array|WP_Error
+	 */
+	protected function process_response( $response, $request_args, $request_url ) {
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		parent::process_response( $response, $request_args, $request_url );
+
+		return array(
+			'status' => wp_remote_retrieve_response_code( $response ),
+			'header' => wp_remote_retrieve_header( $response, 'location' ),
+		);
+	}
 }

--- a/classes/requests/soap/class-collector-checkout-soap-requests-part-activate-invoice.php
+++ b/classes/requests/soap/class-collector-checkout-soap-requests-part-activate-invoice.php
@@ -165,7 +165,7 @@ class Collector_Checkout_SOAP_Requests_Part_Activate_Invoice {
 			}
 
 			// translators: 1. Due date.
-			$order->add_order_note( sprintf( __( 'Order part activated with Walley Checkout. Activated amount %s', 'collector-checkout-for-woocommerce' ), wc_price( $request->TotalAmount, array( 'currency' => $order->get_order_currency() ) ), $due_date ) );
+			$order->add_order_note( sprintf( __( 'Order part activated with Walley Checkout. Activated amount %s', 'collector-checkout-for-woocommerce' ), wc_price( $request->TotalAmount, array( 'currency' => $order->get_currency() ) ), $due_date ) );
 			update_post_meta( $order_id, '_collector_order_activated', time() );
 
 			$log = CCO_WC()->logger::format_log( $order_id, 'SOAP', 'CCO Part Activate order ', $args, '', wp_json_encode( $request ), '' );

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -843,3 +843,18 @@ function walley_use_new_api() {
 		return false;
 	}
 }
+
+/**
+ * Save Walley order data to transient in WordPress.
+ *
+ * @param array $walley_order the returned Walley order data.
+ * @return void
+ */
+function walley_save_order_data_to_transient( $walley_order ) {
+	$walley_order_status_data = array(
+		'status'       => $walley_order['status'] ?? '',
+		'total_amount' => $walley_order['total_amount'] ?? '',
+		'currency'     => $walley_order['currency'] ?? '',
+	);
+	set_transient( "walley_order_status_{$walley_order['order_id']}", $walley_order_status_data, 30 );
+}

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -258,8 +258,8 @@ function wc_collector_add_invoice_fee_to_order( $order_id, $product_id ) {
  * @return boolean
  */
 function is_collector_confirmation() {
-	$payment_successful = filter_input( INPUT_GET, 'payment_successful', FILTER_SANITIZE_STRING );
-	$public_token       = filter_input( INPUT_GET, 'payment_successful', FILTER_SANITIZE_STRING );
+	$payment_successful = filter_input( INPUT_GET, 'payment_successful', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+	$public_token       = filter_input( INPUT_GET, 'payment_successful', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 	if ( '1' === $payment_successful && ! empty( $public_token ) ) {
 		return true;
 	}

--- a/templates/walley-checkout-meta-box.php
+++ b/templates/walley-checkout-meta-box.php
@@ -18,7 +18,7 @@ if ( 'yes' !== $manage_orders ) {
 if ( in_array( $walley_order_status, array( 'NotActivated', 'PartActivated' ), true ) ) {
 	?>
 	<div class="walley_sync_wrapper">
-		<button class="button-primary sync-btn-walley"><?php esc_html_e( 'Sync order to Walley', 'collector-checkout-for-woocommerce' ); ?></button>
+		<button class="button-secondary sync-btn-walley"><?php esc_html_e( 'Update order to Walley', 'collector-checkout-for-woocommerce' ); ?></button>
 	</div>
 	<?php
 }


### PR DESCRIPTION
* [Store current Walley order data in transient (stored for 30 seconds) so we don't display wrong info in Walley metabox. This can happen since it takes a couple of seconds before current status is updated in the GET order request](https://github.com/krokedil/collector-checkout-for-woocommerce/commit/02da23254c5cd8dce3a07ef263b945798c639720).
* [Don't do any rounding order line logic in order management](https://github.com/krokedil/collector-checkout-for-woocommerce/commit/2c261f606f89ffda9bfeeb24835d6e20107f4fb2).
* [Change button color + tweak button text for reauthorize requests](https://github.com/krokedil/collector-checkout-for-woocommerce/commit/bce525f0ccbadd2dbb5cbf03bccc077afdf66b42)