### PR TITLE
Version 3.5.4

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -125,14 +125,14 @@
 
 	// Suspend Walley Checkout during WooCommerce checkout update.
     $(document).on('update_checkout', function () {
-        if ("collector_checkout" === $("input[name='payment_method']:checked").val() && checkout_initiated == 'yes') {
+        if ("collector_checkout" === $("input[name='payment_method']:checked").val() ) {
             window.collector.checkout.api.suspend();
         }
     });
     
     // Resume Walley checkout when updated_checkout is triggered by Woo.
     $(document).on('updated_checkout', function () {
-        if ("collector_checkout" === $("input[name='payment_method']:checked").val() && 'yes' === checkout_initiated && wc_collector_checkout.payment_successful == 0 ) {
+        if ("collector_checkout" === $("input[name='payment_method']:checked").val() && wc_collector_checkout.payment_successful == 0 ) {
             console.log('walley updated_checkout');
             window.collector.checkout.api.resume();
             // Display shipping price if Delivery module is active.

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -8,14 +8,14 @@
  * Plugin Name:     Walley Checkout for WooCommerce
  * Plugin URI:      https://krokedil.se/collector/
  * Description:     Extends WooCommerce. Provides a <a href="https://www.collector.se/" target="_blank">Walley Checkout</a> checkout for WooCommerce.
- * Version:         3.5.2
+ * Version:         3.5.3
  * Author:          Krokedil
  * Author URI:      https://krokedil.se/
  * Text Domain:     collector-checkout-for-woocommerce
  * Domain Path:     /languages
  *
  * WC requires at least: 5.0.0
- * WC tested up to: 7.5.1
+ * WC tested up to: 7.6.0
  *
  * Copyright:       © 2017-2023 Krokedil.
  * License:         GNU General Public License v3.0
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'COLLECTOR_BANK_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'COLLECTOR_BANK_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'COLLECTOR_BANK_VERSION', '3.5.2' );
+define( 'COLLECTOR_BANK_VERSION', '3.5.3' );
 define( 'COLLECTOR_DB_VERSION', '1' );
 
 if ( ! class_exists( 'Collector_Checkout' ) ) {

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:     Walley Checkout for WooCommerce
  * Plugin URI:      https://krokedil.se/collector/
  * Description:     Extends WooCommerce. Provides a <a href="https://www.collector.se/" target="_blank">Walley Checkout</a> checkout for WooCommerce.
- * Version:         3.5.3
+ * Version:         3.5.4
  * Author:          Krokedil
  * Author URI:      https://krokedil.se/
  * Text Domain:     collector-checkout-for-woocommerce
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'COLLECTOR_BANK_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'COLLECTOR_BANK_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'COLLECTOR_BANK_VERSION', '3.5.3' );
+define( 'COLLECTOR_BANK_VERSION', '3.5.4' );
 define( 'COLLECTOR_DB_VERSION', '1' );
 
 if ( ! class_exists( 'Collector_Checkout' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,9 +4,9 @@ Tags: ecommerce, e-commerce, woocommerce, collector, checkout, walley
 Requires at least: 5.0
 Tested up to: 6.2
 Requires PHP: 7.2
-Stable tag: 3.5.2
+Stable tag: 3.5.3
 WC requires at least: 5.0.0
-WC tested up to: 7.5.1
+WC tested up to: 7.6.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -39,6 +39,9 @@ For help setting up and configuring Walley Checkout for WooCommerce please refer
 
 
 == CHANGELOG ==
+= 2023.04.20    - version 3.5.3 =
+* Fix           - Solve error with update order reference request that in some cases could happen when using new Walley API.
+
 = 2023.04.11    - version 3.5.2 =
 * Fix           - Do not add rounding order line if diff is 0.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, e-commerce, woocommerce, collector, checkout, walley
 Requires at least: 5.0
 Tested up to: 6.2
 Requires PHP: 7.2
-Stable tag: 3.5.3
+Stable tag: 3.5.4
 WC requires at least: 5.0.0
 WC tested up to: 7.6.0
 License: GPLv3
@@ -39,6 +39,9 @@ For help setting up and configuring Walley Checkout for WooCommerce please refer
 
 
 == CHANGELOG ==
+= 2023.04.26    - version 3.5.4 =
+* Fix           - Remove checkout_initiated check in Walley js file used in checkout. This prevents potential issue where Walley Checkout isn't suspended when update request is sent to Walley.
+
 = 2023.04.20    - version 3.5.3 =
 * Fix           - Solve error with update order reference request that in some cases could happen when using new Walley API.
 


### PR DESCRIPTION
* Fix - Remove checkout_initiated check in Walley js file used in checkout. This prevents potential issue where Walley Checkout isn't suspended when update request is sent to Walley.