### PR TITLE
Update checkout request endpoint

### DIFF
--- a/classes/class-walley-checkout-api.php
+++ b/classes/class-walley-checkout-api.php
@@ -41,6 +41,18 @@ class Walley_Checkout_API {
 	}
 
 	/**
+	 * Update Walley checkout.
+	 *
+	 * @param array $args Data passed to init request.
+	 * @return array|WP_Error
+	 */
+	public function update_walley_checkout( $args ) {
+		$request  = new Walley_Checkout_Request_Update_Checkout( $args );
+		$response = $request->request();
+		return $this->check_for_api_error( $response );
+	}
+
+	/**
 	 * Update Walley checkout cart.
 	 *
 	 * @param array $args Data passed to init request.

--- a/classes/class-walley-checkout.php
+++ b/classes/class-walley-checkout.php
@@ -204,6 +204,7 @@ class Walley_Checkout {
 
 			// New API.
 			if ( walley_use_new_api() ) {
+				// In new API this is now handled via the update checkout endpoint (that takes care of update cart, fees & metadata).
 				return;
 			}
 
@@ -244,6 +245,7 @@ class Walley_Checkout {
 
 		// New API.
 		if ( walley_use_new_api() ) {
+			// In new API this is now handled via the update checkout endpoint (that takes care of update cart, fees & metadata).
 			return;
 		}
 

--- a/classes/class-walley-checkout.php
+++ b/classes/class-walley-checkout.php
@@ -193,8 +193,6 @@ class Walley_Checkout {
 	/**
 	 * Maybe update metadata.
 	 *
-	 * @todo Remove this after confirmed with Redlight Media.
-	 *
 	 * @param string $private_id The Walley checkout session id.
 	 * @param string $customer_type The customer type (B2B|B2C).
 	 * @return void
@@ -204,19 +202,14 @@ class Walley_Checkout {
 		$metadata = apply_filters( 'coc_update_cart_metadata', array() );
 		if ( ! empty( $metadata ) ) {
 
-			// Use new or old API.
+			// New API.
 			if ( walley_use_new_api() ) {
-				$collecor_order_metadata = CCO_WC()->api->update_walley_metadata(
-					array(
-						'private_id'    => $private_id,
-						'customer_type' => $customer_type,
-						'metadata'      => $metadata,
-					)
-				);
-			} else {
-				$update_metadata         = new Collector_Checkout_Requests_Update_Metadata( $private_id, $customer_type, $metadata );
-				$collecor_order_metadata = $update_metadata->request();
+				return;
 			}
+
+			// Old API.
+			$update_metadata         = new Collector_Checkout_Requests_Update_Metadata( $private_id, $customer_type, $metadata );
+			$collecor_order_metadata = $update_metadata->request();
 
 			// Check that everything went alright.
 			if ( is_wp_error( $collecor_order_metadata ) ) {

--- a/classes/class-walley-checkout.php
+++ b/classes/class-walley-checkout.php
@@ -193,6 +193,8 @@ class Walley_Checkout {
 	/**
 	 * Maybe update metadata.
 	 *
+	 * @todo Remove this after confirmed with Redlight Media.
+	 *
 	 * @param string $private_id The Walley checkout session id.
 	 * @param string $customer_type The customer type (B2B|B2C).
 	 * @return void
@@ -246,24 +248,15 @@ class Walley_Checkout {
 	 * @return void
 	 */
 	public static function maybe_update_fees( $private_id, $customer_type ) {
-		// Use new or old API.
+
+		// New API.
 		if ( walley_use_new_api() ) {
-
-			// If Walley delivery module is used and there is no invoice fee - bail.
-			if ( empty( Walley_Checkout_Requests_Fees_Helper::fees() ) ) {
-				return;
-			}
-
-			$collector_order_fee = CCO_WC()->api->update_walley_fees(
-				array(
-					'private_id'    => $private_id,
-					'customer_type' => $customer_type,
-				)
-			);
-		} else {
-			$update_fees         = new Collector_Checkout_Requests_Update_Fees( $private_id, $customer_type );
-			$collector_order_fee = $update_fees->request();
+			return;
 		}
+
+		// Old API.
+		$update_fees         = new Collector_Checkout_Requests_Update_Fees( $private_id, $customer_type );
+		$collector_order_fee = $update_fees->request();
 
 		if ( is_checkout() ) {
 			$cart_item_total = Collector_Checkout_Requests_Cart::cart();
@@ -311,14 +304,17 @@ class Walley_Checkout {
 	public static function maybe_update_cart( $private_id, $customer_type ) {
 
 		// Use new or old API.
+
 		if ( walley_use_new_api() ) {
-			$collector_order_cart = CCO_WC()->api->update_walley_cart(
+			// New API - update entire checkout.
+			$collector_order_cart = CCO_WC()->api->update_walley_checkout(
 				array(
 					'private_id'    => $private_id,
 					'customer_type' => $customer_type,
 				)
 			);
 		} else {
+			// Old API update the cart.
 			$update_cart          = new Collector_Checkout_Requests_Update_Cart( $private_id, $customer_type );
 			$collector_order_cart = $update_cart->request();
 		}

--- a/classes/requests/checkouts/put/class-walley-checkout-request-update-checkout.php
+++ b/classes/requests/checkouts/put/class-walley-checkout-request-update-checkout.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Class for the request to update checkout.
+ *
+ * @package Collector_Checkout/Classes/Requests/PUT
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Walley_Checkout_Request_Update_Checkout class.
+ */
+class Walley_Checkout_Request_Update_Checkout extends Walley_Checkout_Request_Put {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param array $arguments The request arguments.
+	 */
+	public function __construct( $arguments ) {
+		parent::__construct( $arguments );
+		$this->log_title  = 'Update checkout';
+		$this->order_id   = $arguments['order_id'] ?? '';
+		$this->private_id = $arguments['private_id'] ?? '';
+		$this->set_environment_variables( $arguments );
+	}
+
+	/**
+	 * Get the request url.
+	 *
+	 * @return string
+	 */
+	protected function get_request_url() {
+		return $this->get_api_url_base() . "/checkouts/{$this->private_id}/";
+	}
+
+	/**
+	 * Get the body for the request.
+	 *
+	 * @return array
+	 */
+	protected function get_body() {
+
+		$body = array(
+			'cart' => empty( $this->order_id ) ? $this->cart()['items'] : CCO_WC()->order_items->get_order_lines( $this->order_id )['items'],
+			'fees' => empty( $this->order_id ) ? Walley_Checkout_Requests_Fees_Helper::fees() : CCO_WC()->order_fees->get_order_fees( $this->order_id ),
+		);
+
+		// Maybe add shipping classes.
+		if ( ! empty( walley_get_cart_shipping_classes() ) ) {
+			$body['shippingProperties'] = walley_get_cart_shipping_classes();
+		}
+
+		// Maybe add free shipping coupon.
+		if ( ! empty( walley_cart_contain_free_shipping_coupon() ) ) {
+			$body['shippingProperties']['free_shipping'] = true;
+		}
+
+		return apply_filters( 'walley_update_checkout_args', $body, $this->order_id );
+	}
+}

--- a/classes/requests/checkouts/put/class-walley-checkout-request-update-checkout.php
+++ b/classes/requests/checkouts/put/class-walley-checkout-request-update-checkout.php
@@ -40,11 +40,24 @@ class Walley_Checkout_Request_Update_Checkout extends Walley_Checkout_Request_Pu
 	 * @return array
 	 */
 	protected function get_body() {
+		$cart      = apply_filters( 'walley_update_cart_args', empty( $this->order_id ) ? $this->cart()['items'] : CCO_WC()->order_items->get_order_lines( $this->order_id )['items'], $this->order_id );
+		$fees      = apply_filters( 'walley_update_fees_args', empty( $this->order_id ) ? Walley_Checkout_Requests_Fees_Helper::fees() : CCO_WC()->order_fees->get_order_fees( $this->order_id ), $this->order_id );
+		$meta_data = apply_filters( 'walley_update_metadata_args', array(), $this->order_id );
 
+		// Add cart data.
 		$body = array(
-			'cart' => empty( $this->order_id ) ? $this->cart()['items'] : CCO_WC()->order_items->get_order_lines( $this->order_id )['items'],
-			'fees' => empty( $this->order_id ) ? Walley_Checkout_Requests_Fees_Helper::fees() : CCO_WC()->order_fees->get_order_fees( $this->order_id ),
+			'cart' => $cart,
 		);
+
+		// Maybe add fees.
+		if ( ! empty( $fees ) ) {
+			$body['fees'] = $fees;
+		}
+
+		// Maybe add metadata.
+		if ( ! empty( $meta_data ) ) {
+			$body['metadata'] = $meta_data;
+		}
 
 		// Maybe add shipping classes.
 		if ( ! empty( walley_get_cart_shipping_classes() ) ) {

--- a/classes/requests/helpers/class-collector-checkout-requests-helper-order-om.php
+++ b/classes/requests/helpers/class-collector-checkout-requests-helper-order-om.php
@@ -304,7 +304,6 @@ class Collector_Checkout_Requests_Helper_Order_Om {
 		$order_lines  = self::get_order_lines( $order_id );
 
 		foreach ( $order_lines as $order_line ) {
-			error_log( 'orderrad: ' . var_export( floatval( $order_line['UnitPrice'] ) * $order_line['Quantity'], true ) . '. Unit price: ' . $order_line['UnitPrice'] );
 			$total_amount += floatval( $order_line['UnitPrice'] ) * $order_line['Quantity'];
 
 		}

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -156,9 +156,10 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 				// New Checkout request class files.
 				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/checkouts/get/class-walley-checkout-request-get-checkout.php';
 				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/checkouts/post/class-walley-checkout-request-initialize-checkout.php';
-				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/checkouts/put/class-walley-checkout-request-update-cart.php';
-				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/checkouts/put/class-walley-checkout-request-update-fees.php';
-				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/checkouts/put/class-walley-checkout-request-update-metadata.php';
+				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/checkouts/put/class-walley-checkout-request-update-checkout.php';
+				// include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/checkouts/put/class-walley-checkout-request-update-cart.php';
+				// include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/checkouts/put/class-walley-checkout-request-update-fees.php';
+				// include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/checkouts/put/class-walley-checkout-request-update-metadata.php';
 				include_once COLLECTOR_BANK_PLUGIN_DIR . '/classes/requests/checkouts/put/class-walley-checkout-request-set-order-reference.php';
 
 				// New OM request class files.

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:     Walley Checkout for WooCommerce
  * Plugin URI:      https://krokedil.se/collector/
  * Description:     Extends WooCommerce. Provides a <a href="https://www.collector.se/" target="_blank">Walley Checkout</a> checkout for WooCommerce.
- * Version:         3.6.0-beta7
+ * Version:         3.6.0-beta8
  * Author:          Krokedil
  * Author URI:      https://krokedil.se/
  * Text Domain:     collector-checkout-for-woocommerce
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'COLLECTOR_BANK_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'COLLECTOR_BANK_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'COLLECTOR_BANK_VERSION', '3.6.0-beta7' );
+define( 'COLLECTOR_BANK_VERSION', '3.6.0-beta8' );
 define( 'COLLECTOR_DB_VERSION', '1' );
 
 if ( ! class_exists( 'Collector_Checkout' ) ) {

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -986,3 +986,35 @@ function walley_get_shipping_reference_from_delivery_module_data( $order_id ) {
 	$shipping_reference      = $collector_delivery_data['shippingFeeId'] ?? '';
 	return $shipping_reference;
 }
+
+/**
+ * Maybe adds the free shipping tag.
+ *
+ * @return bool
+ */
+function walley_cart_contain_free_shipping_coupon() {
+	foreach ( WC()->cart->get_applied_coupons() as $coupon_code ) {
+		$coupon = new WC_Coupon( $coupon_code );
+		if ( $coupon->get_free_shipping() ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Get cart shipping classes.
+ *
+ * @return array
+ */
+function walley_get_cart_shipping_classes() {
+	$shipping_classes = array();
+	// Check all cart items.
+	foreach ( WC()->cart->get_cart() as $cart_item ) {
+
+		if ( ! empty( $cart_item['data']->get_shipping_class() ) ) {
+			$shipping_classes[ $cart_item['data']->get_shipping_class() ] = true;
+		}
+	}
+	return $shipping_classes;
+}


### PR DESCRIPTION
* Adds new "update checkout" endpoint (for new API), to replace "update cart", "update fees" & "update metadata" endpoints.
* Adds` -> shippingProperties -> free_shipping=true` in create and update request if free shipping coupon is included in cart. To handle delivery module logic better.
* Adds product shipping classes to `shippingProperties` in create and update requests. To handle delivery module logic better.
* Adds filter walley_update_checkout_args to be able to filter update request data.