### PR TITLE
Version 4.0.3

### DIFF
--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -254,6 +254,20 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 			);
 		}
 
+		$order         = wc_get_order( $order_id );
+		$shipping_cost = $walley_order['data']['fees']['shipping']['unitPrice'] ?? 0;
+		$cart_cost     = $walley_order['data']['cart']['totalAmount']; // Uses the same "major units" similar to WC_Order->get_total().
+		$total_amount  = $shipping_cost + $cart_cost;
+
+		if ( abs( $total_amount - $order->get_total() ) > 3 ) {
+			$message = __( 'It seems like the WooCommerce and Walley total amount differs. Please, try again.', 'collector-checkout-for-woocommerce' );
+
+			return array(
+				'result'  => 'error',
+				'message' => $message,
+			);
+		}
+
 		$walley_extra_fields = $this->save_walley_extra_fields( $order_id, $walley_order );
 
 		$walley_shipping = $this->save_walley_purchase_and_shipping_data( $order_id, $walley_order );

--- a/classes/class-walley-checkout-session.php
+++ b/classes/class-walley-checkout-session.php
@@ -26,12 +26,14 @@ class Walley_Checkout_Session {
 		$customer_address['shipping_country'] = $walley_order['data']['countryCode'] ?? '';
 
 		if ( 'BusinessCustomer' === $walley_order['data']['customerType'] ) {
+			$customer_address['billing_company']    = $walley_order['data']['businessCustomer']['invoiceAddress']['companyName'] ?? '';
 			$customer_address['billing_first_name'] = $walley_order['data']['businessCustomer']['firstName'] ?? '';
 			$customer_address['billing_last_name']  = $walley_order['data']['businessCustomer']['lastName'] ?? '';
 			$customer_address['billing_city']       = $walley_order['data']['businessCustomer']['invoiceAddress']['city'] ?? '';
 			$customer_address['billing_address_1']  = $walley_order['data']['businessCustomer']['invoiceAddress']['address'] ?? '';
 			$customer_address['billing_postcode']   = $walley_order['data']['businessCustomer']['invoiceAddress']['postalCode'] ?? '';
 
+			$customer_address['shipping_company']    = $walley_order['data']['businessCustomer']['deliveryAddress']['companyName'] ?? '';
 			$customer_address['shipping_first_name'] = $walley_order['data']['businessCustomer']['firstName'] ?? '';
 			$customer_address['shipping_last_name']  = $walley_order['data']['businessCustomer']['lastName'] ?? '';
 			$customer_address['shipping_city']       = $walley_order['data']['businessCustomer']['deliveryAddress']['city'] ?? '';

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:     Walley Checkout for WooCommerce
  * Plugin URI:      https://krokedil.se/collector/
  * Description:     Extends WooCommerce. Provides a <a href="https://www.collector.se/" target="_blank">Walley Checkout</a> checkout for WooCommerce.
- * Version:         4.0.2
+ * Version:         4.0.3
  * Author:          Krokedil
  * Author URI:      https://krokedil.se/
  * Text Domain:     collector-checkout-for-woocommerce
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'COLLECTOR_BANK_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'COLLECTOR_BANK_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'COLLECTOR_BANK_VERSION', '4.0.2' );
+define( 'COLLECTOR_BANK_VERSION', '4.0.3' );
 define( 'COLLECTOR_DB_VERSION', '1' );
 
 if ( ! class_exists( 'Collector_Checkout' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, e-commerce, woocommerce, collector, checkout, walley
 Requires at least: 5.0
 Tested up to: 6.3
 Requires PHP: 7.3
-Stable tag: 4.0.2
+Stable tag: 4.0.3
 WC requires at least: 6.0.0
 WC tested up to: 8.0.2
 License: GPLv3
@@ -39,6 +39,10 @@ For help setting up and configuring Walley Checkout for WooCommerce please refer
 
 
 == CHANGELOG ==
+= 2023.08.31    - version 4.0.3 =
+* Fix           - Adds cart total comparison between WooCommerce & Walley when order is created in Woo, before customer can complete payment.
+* Fix           - Add billing and shipping company name in get_customer_address so Woo checkout form is populated correctly before placing Woo order.
+
 = 2023.08.31    - version 4.0.2 =
 * Tweak         - GitHub deployment to wordpress.org logic tweak.
 * Tweak         - Small front-end logging improvement.


### PR DESCRIPTION
* Fix - Adds cart total comparison between WooCommerce & Walley when order is created in Woo, before customer can complete payment.
* Fix - Add billing and shipping company name in get_customer_address so Woo checkout form is populated correctly before placing Woo order.