### PR TITLE
Version 4.0.4

### DIFF
--- a/assets/js/walley-checkout-for-woocommerce.js
+++ b/assets/js/walley-checkout-for-woocommerce.js
@@ -39,8 +39,6 @@ jQuery( function( $ ) {
 					walleyCheckoutWc.logToFile( 'onBeforePayment from Walley triggered' );
 					let placeOrder = await walleyCheckoutWc.placeWalleyOrder();
 	
-					 console.log('Async test', placeOrder);
-	
 					if( 'success' === placeOrder.result ) {
 						console.log('onBeforePayment success');
 						return Promise.resolve();
@@ -303,10 +301,10 @@ jQuery( function( $ ) {
 		placeWalleyOrder: async function() {
 			var walleyOrder = await walleyCheckoutWc.getWalleyOrder();
 			if( walleyOrder.success ) {
-				console.log('placeWalleyOrder if');
+				console.log('getWalleyOrder success');
 				walleyOrder = walleyCheckoutWc.submitOrder();
 			} else {
-				console.log('placeWalleyOrder else');
+				console.log('getWalleyOrder no success');
 			}
 			return walleyOrder;
 		},

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -8,14 +8,14 @@
  * Plugin Name:     Walley Checkout for WooCommerce
  * Plugin URI:      https://krokedil.se/collector/
  * Description:     Extends WooCommerce. Provides a <a href="https://www.collector.se/" target="_blank">Walley Checkout</a> checkout for WooCommerce.
- * Version:         4.0.3
+ * Version:         4.0.4
  * Author:          Krokedil
  * Author URI:      https://krokedil.se/
  * Text Domain:     collector-checkout-for-woocommerce
  * Domain Path:     /languages
  *
  * WC requires at least: 6.0.0
- * WC tested up to: 8.0.2
+ * WC tested up to: 8.0.3
  *
  * Copyright:       © 2017-2023 Krokedil.
  * License:         GNU General Public License v3.0
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'COLLECTOR_BANK_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'COLLECTOR_BANK_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'COLLECTOR_BANK_VERSION', '4.0.3' );
+define( 'COLLECTOR_BANK_VERSION', '4.0.4' );
 define( 'COLLECTOR_DB_VERSION', '1' );
 
 if ( ! class_exists( 'Collector_Checkout' ) ) {

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -398,13 +398,6 @@ function wc_collector_confirm_order( $order_id, $private_id = null ) {
 	update_post_meta( $order_id, '_collector_order_id', sanitize_key( $walley_order_id ) );
 	wc_collector_save_shipping_reference_to_order( $order_id, $collector_order );
 
-	// Tie this order to a user if we have one.
-	if ( email_exists( $collector_order['data']['customer']['email'] ) ) {
-		$user    = get_user_by( 'email', $collector_order['data']['customer']['email'] );
-		$user_id = $user->ID;
-		update_post_meta( $order_id, '_customer_user', $user_id );
-	}
-
 	if ( 'Preliminary' === $payment_status || 'Completed' === $payment_status ) {
 		$order->payment_complete( $payment_id );
 	} elseif ( 'Signing' === $payment_status ) {
@@ -817,13 +810,6 @@ function walley_confirm_order( $order_id, $private_id = null ) {
 	if ( isset( $collector_order['data']['shipping'] ) ) {
 		update_post_meta( $order_id, '_collector_delivery_module_data', wp_json_encode( $collector_order['data']['shipping'], JSON_UNESCAPED_UNICODE ) );
 		update_post_meta( $order_id, '_collector_delivery_module_reference', $collector_order['data']['shipping']['pendingShipment']['id'] );
-	}
-
-	// Tie this order to a user if we have one.
-	if ( email_exists( $collector_order['data']['customer']['email'] ) ) {
-		$user    = get_user_by( 'email', $collector_order['data']['customer']['email'] );
-		$user_id = $user->ID;
-		update_post_meta( $order_id, '_customer_user', $user_id );
 	}
 
 	if ( 'Preliminary' === $payment_status || 'Completed' === $payment_status ) {

--- a/readme.txt
+++ b/readme.txt
@@ -2,11 +2,11 @@
 Contributors: collectorbank, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, collector, checkout, walley
 Requires at least: 5.0
-Tested up to: 6.3
+Tested up to: 6.3.1
 Requires PHP: 7.3
-Stable tag: 4.0.3
+Stable tag: 4.0.4
 WC requires at least: 6.0.0
-WC tested up to: 8.0.2
+WC tested up to: 8.0.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -39,6 +39,11 @@ For help setting up and configuring Walley Checkout for WooCommerce please refer
 
 
 == CHANGELOG ==
+= 2023.09.01    - version 4.0.4 =
+* Tweak         - Do not save _customer_user to order. From WC 8.0 this can result in non logged in users see a login prompt instead of the order received page.
+* Fix           - Improve cart total comparison logic in process_payment sequence.
+* Fix           - Improve error notice displayed in checkout if process_payment fails.
+
 = 2023.08.31    - version 4.0.3 =
 * Fix           - Adds cart total comparison between WooCommerce & Walley when order is created in Woo, before customer can complete payment.
 * Fix           - Add billing and shipping company name in get_customer_address so Woo checkout form is populated correctly before placing Woo order.


### PR DESCRIPTION
* Tweak - Do not save _customer_user to order. From WC 8.0 this can result in non logged in users see a login prompt instead of the order received page.
* Fix - Improve cart total comparison logic in process_payment sequence.
* Fix - Improve error notice displayed in checkout if process_payment fails.