### PR TITLE
Use wc_collector_get_order_id_by_private_id function to query ordersin callback logic

### DIFF
--- a/classes/class-collector-checkout-api-callbacks.php
+++ b/classes/class-collector-checkout-api-callbacks.php
@@ -71,9 +71,9 @@ class Collector_Api_Callbacks {
 
 				// Maybe abort the callback (if the order already has been processed in Woo).
 				if ( ! empty( $order->get_date_paid() ) ) {
-					CCO_WC()->logger::log( 'Aborting API callback. Order ' . $order->get_order_number() . '(order ID ' . $order_id_match . ', Private ID ' . $private_id . ') already processed.' );
+					CCO_WC()->logger::log( 'Aborting API callback. Order ' . $order->get_order_number() . '(order ID ' . $order_id . ', Private ID ' . $private_id . ') already processed.' );
 				} else {
-					CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . '(order ID ' . $order_id_match . ', Private ID ' . $private_id . ') during checkout process. Setting order status to Processing/Completed in API callback.' );
+					CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . '(order ID ' . $order_id . ', Private ID ' . $private_id . ') during checkout process. Setting order status to Processing/Completed in API callback.' );
 					// translators: Walley private ID.
 					$note = sprintf( __( 'Order status not set correctly during checkout process. Confirming purchase via callback from Walley.', 'collector-checkout-for-woocommerce' ), $private_id );
 					$order->add_order_note( $note );
@@ -81,7 +81,7 @@ class Collector_Api_Callbacks {
 				}
 			} else {
 				// No order, why?
-				CCO_WC()->logger::log( 'API-callback executed. Private id ' . $private_id . '. already exist in order ID ' . $order_id_match . '. But we could not instantiate an order object' );
+				CCO_WC()->logger::log( 'API-callback executed. Private id ' . $private_id . '. already exist in order ID ' . $order_id . '. But we could not instantiate an order object' );
 			}
 		} else {
 			// No order found - create a new.

--- a/classes/class-collector-checkout-api-callbacks.php
+++ b/classes/class-collector-checkout-api-callbacks.php
@@ -60,31 +60,12 @@ class Collector_Api_Callbacks {
 	 */
 	public function collector_check_for_order_callback( $private_id, $public_token, $customer_type = 'b2c' ) {
 		CCO_WC()->logger::log( 'Check for order in API-callback. Private id: ' . $private_id . '. Public token: ' . $public_token );
-		$query          = new WC_Order_Query(
-			array(
-				'limit'          => -1,
-				'orderby'        => 'date',
-				'order'          => 'ASC',
-				'return'         => 'ids',
-				'payment_method' => 'collector_checkout',
-				'date_created'   => '>' . ( time() - MONTH_IN_SECONDS ),
-			)
-		);
-		$orders         = $query->get_orders();
-		$order_id_match = '';
-		foreach ( $orders as $order_id ) {
 
-			$order_private_id = get_post_meta( $order_id, '_collector_private_id', true );
-
-			if ( $order_private_id === $private_id ) {
-				$order_id_match = $order_id;
-				break;
-			}
-		}
+		$order_id = wc_collector_get_order_id_by_private_id( $private_id );
 
 		// Did we get a match?
-		if ( $order_id_match ) {
-			$order = wc_get_order( $order_id_match );
+		if ( ! empty( $order_id ) ) {
+			$order = wc_get_order( $order_id );
 
 			if ( $order ) {
 

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -276,6 +276,8 @@ function wc_collector_get_order_id_by_private_id( $private_id = null ) {
 		'post_status' => array_keys( wc_get_order_statuses() ),
 		'meta_key'    => '_collector_private_id', // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
 		'meta_value'  => sanitize_text_field( wp_unslash( $private_id ) ), // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
+		'orderby'     => 'date',
+		'order'       => 'DESC',
 		'date_query'  => array(
 			array(
 				'after' => '120 day ago',


### PR DESCRIPTION
Avoid issues when multiple WC orders are created during one payment session.