### PR TITLE
Version 4.0.7

### DIFF
--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:     Walley Checkout for WooCommerce
  * Plugin URI:      https://krokedil.se/collector/
  * Description:     Extends WooCommerce. Provides a <a href="https://www.collector.se/" target="_blank">Walley Checkout</a> checkout for WooCommerce.
- * Version:         4.0.5
+ * Version:         4.0.6
  * Author:          Krokedil
  * Author URI:      https://krokedil.se/
  * Text Domain:     collector-checkout-for-woocommerce
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'COLLECTOR_BANK_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'COLLECTOR_BANK_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'COLLECTOR_BANK_VERSION', '4.0.5' );
+define( 'COLLECTOR_BANK_VERSION', '4.0.6' );
 define( 'COLLECTOR_DB_VERSION', '1' );
 
 if ( ! class_exists( 'Collector_Checkout' ) ) {

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:     Walley Checkout for WooCommerce
  * Plugin URI:      https://krokedil.se/collector/
  * Description:     Extends WooCommerce. Provides a <a href="https://www.collector.se/" target="_blank">Walley Checkout</a> checkout for WooCommerce.
- * Version:         4.0.6
+ * Version:         4.0.7
  * Author:          Krokedil
  * Author URI:      https://krokedil.se/
  * Text Domain:     collector-checkout-for-woocommerce
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'COLLECTOR_BANK_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'COLLECTOR_BANK_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'COLLECTOR_BANK_VERSION', '4.0.6' );
+define( 'COLLECTOR_BANK_VERSION', '4.0.7' );
 define( 'COLLECTOR_DB_VERSION', '1' );
 
 if ( ! class_exists( 'Collector_Checkout' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, e-commerce, woocommerce, collector, checkout, walley
 Requires at least: 5.0
 Tested up to: 6.3.1
 Requires PHP: 7.3
-Stable tag: 4.0.5
+Stable tag: 4.0.6
 WC requires at least: 6.0.0
 WC tested up to: 8.0.3
 License: GPLv3
@@ -39,6 +39,9 @@ For help setting up and configuring Walley Checkout for WooCommerce please refer
 
 
 == CHANGELOG ==
+= 2023.09.11    - version 4.0.6 =
+* Fix           - Improve query when trying to get WC order in callback logic. Avoids issues when multiple WC orders are created during one payment session.
+
 = 2023.09.06    - version 4.0.5 =
 * Tweak         - Save Custom Fields data to WooCommerce order also during confirm order step (when payment is done).
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, e-commerce, woocommerce, collector, checkout, walley
 Requires at least: 5.0
 Tested up to: 6.3.1
 Requires PHP: 7.3
-Stable tag: 4.0.6
+Stable tag: 4.0.7
 WC requires at least: 6.0.0
 WC tested up to: 8.0.3
 License: GPLv3
@@ -39,6 +39,9 @@ For help setting up and configuring Walley Checkout for WooCommerce please refer
 
 
 == CHANGELOG ==
+= 2023.09.20    - version 4.0.7 =
+* Fix           - Due to a change introduced in WooCommerce version 8.1, the "thank you" snippet wouldn't be rendered as expected. This has now been fixed.
+
 = 2023.09.11    - version 4.0.6 =
 * Fix           - Improve query when trying to get WC order in callback logic. Avoids issues when multiple WC orders are created during one payment session.
 


### PR DESCRIPTION
* Fix           - Due to a change introduced in WooCommerce version 8.1, the "thank you" snippet wouldn't be rendered as expected. This has now been fixed.