### PR TITLE
Version 4.0.10

### DIFF
--- a/assets/js/walley-checkout-for-woocommerce.js
+++ b/assets/js/walley-checkout-for-woocommerce.js
@@ -39,12 +39,12 @@ jQuery( function( $ ) {
 
 					// Setup a timeout that will be used if the onBeforePaymentHandler takes too long to return a rejected promise.
 					const timeout = new Promise((resolve, reject) => {
-						setTimeout(() => {
-							reject({
-								"title": "Place WooCommerce order issue.",
-								"message": "Timeout"
-							});
-						}, 9500); // 9.5 seconds
+					setTimeout(() => {
+						reject({
+							title: "Place WooCommerce order issue.",
+							message: "Timeout",
+						});
+						}, 29000); // 29 seconds
 					});
 
 					try {

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:     Walley Checkout for WooCommerce
  * Plugin URI:      https://krokedil.se/produkt/walley-checkout/
  * Description:     Extends WooCommerce. Provides a <a href="https://www.walley.se/foretag/checkout/" target="_blank">Walley Checkout</a> checkout for WooCommerce.
- * Version:         4.0.9
+ * Version:         4.0.10
  * Author:          Krokedil
  * Author URI:      https://krokedil.se/
  * Text Domain:     collector-checkout-for-woocommerce
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'COLLECTOR_BANK_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'COLLECTOR_BANK_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'COLLECTOR_BANK_VERSION', '4.0.9' );
+define( 'COLLECTOR_BANK_VERSION', '4.0.10' );
 define( 'COLLECTOR_DB_VERSION', '1' );
 
 if ( ! class_exists( 'Collector_Checkout' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, e-commerce, woocommerce, collector, checkout, walley
 Requires at least: 5.0
 Tested up to: 6.4.1
 Requires PHP: 7.3
-Stable tag: 4.0.9
+Stable tag: 4.0.10
 WC requires at least: 6.0.0
 WC tested up to: 8.3.0
 License: GPLv3
@@ -39,6 +39,9 @@ For help setting up and configuring Walley Checkout for WooCommerce please refer
 
 
 == CHANGELOG ==
+= 2023.12.14    - version 4.0.10 =
+* Enhancement   - Increased the timeout for placing a WooCommerce order to 29 seconds from 9.5 to match Walleys updated timeout of 30 seconds.
+
 = 2023.11.21    - version 4.0.9 =
 * Enhancement   - Ensures logging of any error messages generated during the checkout process.
 * Enhancement   - Adds a timeout to the order placement to prevent the checkout from locking.


### PR DESCRIPTION
* Enhancement - Increased the timeout for placing a WooCommerce order to 29 seconds from 9.5 to match Walleys updated timeout of 30 seconds.