### PR TITLE
Complete digital orders on callback, and lower callback scheduled time to 30sec

### DIFF
--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -105,7 +105,7 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 		);
 
 		if ( empty( $scheduled_actions ) ) {
-			as_schedule_single_action( time() + 120, 'collector_check_for_order', array( $private_id, $public_token, $customer_type ) );
+			as_schedule_single_action( time() + 30, 'collector_check_for_order', array( $private_id, $public_token, $customer_type ) );
 			header( 'HTTP/1.1 200 OK' );
 		} else {
 			CCO_WC()->logger::log( 'collector_check_for_order callback already scheduled. ' . wp_json_encode( $scheduled_actions ) ); // Input var okay.

--- a/classes/class-walley-checkout-confirmation.php
+++ b/classes/class-walley-checkout-confirmation.php
@@ -63,6 +63,18 @@ class Walley_Checkout_Confirmation {
 			return;
 		}
 
+		$order = wc_get_order( $order_id );
+
+		// If the order does not need processing, set the status to on-hold, and redirect.
+		// This is to prevent an error from attempting to complete an order before it has been moved to the order management api in Walley.
+		if ( ! $order->needs_processing() ) {
+			$order->update_meta_data( '_walley_pending_callback', 'yes' );
+			$order->update_status( 'on-hold', __( 'The order has been completed, but awaiting callback from Walley to confirm the order.', 'collector-checkout-for-woocommerce' ) );
+			$order->save();
+			wp_safe_redirect( $order->get_checkout_order_received_url() );
+			exit;
+		}
+
 		$result = walley_confirm_order( $order_id );
 
 		if ( $result ) {
@@ -70,7 +82,6 @@ class Walley_Checkout_Confirmation {
 			CCO_WC()->logger::log( "Order ID $order_id confirmed on the confirmation page. Walley payment ID: $walley_payment_id." );
 		}
 
-		$order = wc_get_order( $order_id );
 		wp_safe_redirect( $order->get_checkout_order_received_url() );
 		exit;
 	}

--- a/classes/class-walley-checkout-confirmation.php
+++ b/classes/class-walley-checkout-confirmation.php
@@ -69,7 +69,7 @@ class Walley_Checkout_Confirmation {
 		// This is to prevent an error from attempting to complete an order before it has been moved to the order management api in Walley.
 		if ( ! $order->needs_processing() ) {
 			$order->update_meta_data( '_walley_pending_callback', 'yes' );
-			$order->update_status( 'on-hold', __( 'The order has been completed, but awaiting callback from Walley to confirm the order.', 'collector-checkout-for-woocommerce' ) );
+			$order->update_status( 'on-hold', __( 'The payment has been completed, but awaiting callback from Walley to confirm the order.', 'collector-checkout-for-woocommerce' ) );
 			$order->save();
 			wp_safe_redirect( $order->get_checkout_order_received_url() );
 			exit;


### PR DESCRIPTION
Lets the callback complete any purchases that don't require processing, instead of doing it in the initial order confirmation.
This is required since Walley does not move the order over to the order management API for up to 10seconds after order completion.

Also lowers the scheduled time for the callback processing to 30 seconds into the future, instead of 120 seconds.