### PR TITLE
Display on checkout page the reason for timeout error

### DIFF
--- a/assets/js/walley-checkout-for-woocommerce.js
+++ b/assets/js/walley-checkout-for-woocommerce.js
@@ -63,12 +63,15 @@ jQuery( function( $ ) {
 					} catch (error) {
 						clearTimeout(timeout);
 						const message  = error.message.replace(/<\/?[^>]+(>|$)/g, "").replace(/(\t|\n)/gm, "") ?? 'Unknown error.';
+						const title = error.title.replace(/<\/?[^>]+(>|$)/g, "").replace(/(\t|\n)/gm, "") ?? '';
 
-						walleyCheckoutWc.failOrder( null, message );
+						// Do not modify the original message as it will be sent separately to Walley.
+						const message_to_customer = (title) ? `${message}: ${title}` : message;
+						walleyCheckoutWc.failOrder( null, message_to_customer );
 
 						return Promise.reject(
 							{
-								"title": "Place WooCommerce order issue.",
+								"title": title,
 								"message": message
 							}
 						);


### PR DESCRIPTION
When a timeout error happens, the error message only contains the word "Timeout" without explanation.

- use the `title` to explain the reason for the error message.
- do not modify the `message` variable as it is used internally by Walley. 