### PR TITLE
Reject when place order fails and properly display error message

### DIFF
--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -364,6 +364,16 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 	 * @return string
 	 */
 	public function collector_thankyou_order_received_text( $text, $order ) {
+		// The $order might be FALSE. This can happen if the customer visits the order received page directly and the order does not exist or if the order number and/or the key is invalid.
+		if ( empty( $order ) ) {
+			return $text;
+		}
+
+		// Check if the payment method is Collector since the hook 'woocommerce_thankyou_order_received_text' is triggered for all payment methods.
+		if ( 'collector_checkout' !== $order->get_payment_method() ) {
+			return $text;
+		}
+
 		$html_snippet = '<div class="collector-checkout-thankyou"></div>';
 
 		// Only print the snippet if the order was not upsold. If it has, the iframe wont show the same order amount as the WC order.

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -377,7 +377,7 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 		$html_snippet = '<div class="collector-checkout-thankyou"></div>';
 
 		// Only print the snippet if the order was not upsold. If it has, the iframe wont show the same order amount as the WC order.
-		$upsell_uuids    = $order->get_meta( '_ppu_upsell_ids', true );
+		$upsell_uuids    = $order->get_meta( '_ppu_upsell_ids' );
 		$has_been_upsold = ! empty( $upsell_uuids );
 
 		if ( $has_been_upsold ) {
@@ -385,27 +385,22 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 			return $text;
 		}
 
-		if ( is_object( $order ) && 'collector_checkout' === $order->get_payment_method() ) {
-			CCO_WC()->logger::log( 'Thankyou page rendered for order ID - ' . $order->get_id() );
-
-			// Starting WC 8.1 the HTML snippet will be escaped, we now have to echo it directly,
-			// and return an empty string to overwrite the default $text string.
-			echo wp_kses_post( $html_snippet );
-			return '';
-		}
-
+		// Maybe render simplified thankyou page.
 		$purchase_status = filter_input( INPUT_GET, 'purchase-status', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( 'not-completed' === $purchase_status ) {
 			// Unset Collector token and id.
 			wc_collector_unset_sessions();
 			WC()->cart->empty_cart();
-			CCO_WC()->logger::log( 'Rendering simplified thankyou page (only display Collector thank you iframe).' );
 
-			echo wp_kses_post( $html_snippet );
-			return '';
+			CCO_WC()->logger::log( 'Rendering simplified thankyou page (only display Collector thank you iframe).' );
+		} else {
+			CCO_WC()->logger::log( 'Thankyou page rendered for order ID - ' . $order->get_id() );
 		}
 
-		return $text;
+		// Starting WC 8.1 the HTML snippet will be escaped, we now have to echo it directly.
+		echo wp_kses_post( $html_snippet );
+		// And return an empty string to overwrite the default $text string.
+		return '';
 	}
 
 	/**

--- a/classes/class-walley-part-payment-widget.php
+++ b/classes/class-walley-part-payment-widget.php
@@ -217,7 +217,7 @@ class Walley_Part_Payment_Widget {
 
 		// If the product is a variable product, get the min price.
 		if ( $product->is_type( 'variable' ) ) {
-			return $product->get_variation_price( 'min' ) * 100;
+			return floatval( $product->get_variation_price( 'min' ) ) * 100;
 		}
 
 		// Else return the price.


### PR DESCRIPTION
Although placeWalleyOrder throws an error, the handler function will never reject with an error, but rather resolve without any error. This means, the timeout will always win the race, resulting in the vague "timeout error".

- reject the promise when placeWalleyOrder fails
- extract the error message from the HTML, and properly render it on the checkout page as list elements

**changelog**
- reject when place order fails and properly display error message
- only check the purchase-status if the payment method is collector checkout
- resolve "Uncaught Error: Call to a member function get_meta() on bool"
- resolve "Unsupported operand types: string * int"