### PR TITLE
Add compatibility with WooCommerce's HPOS

### DIFF
--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -277,7 +277,7 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 		$purchase_status    = filter_input( INPUT_POST, 'purchase_status', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
 		$test_mode          = $collector_settings['test_mode'];
-		// $order				= wc_get_order( $order_id );
+		$order              = wc_get_order( $order_id );
 
 		// If something went wrong in get_customer_data() - display a "thank you page light".
 		if ( 'not-completed' === $purchase_status ) {
@@ -288,11 +288,8 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 				$customer_type = 'b2c';
 			}
 		} else {
-			$public_token  = get_post_meta( $order_id, '_collector_public_token', true );
-			$customer_type = get_post_meta( $order_id, '_collector_customer_type', true );
-
-			// $public_token  = $order->get_meta( '_collector_public_token', true );
-			// $customer_type = $order->get_meta('_collector_customer_type', true );
+			$public_token  = $order->get_meta( '_collector_public_token' );
+			$customer_type = $order->get_meta( '_collector_customer_type' );
 		}
 
 		$return = array(
@@ -347,7 +344,7 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 			} elseif ( 201 === $response['status'] ) {
 				// This should not happen as long as we do not allow a order total amount that is higher than the original order amount.
 				$order->add_order_note( __( 'Walley order sync started. Waiting for reauthorize response.', 'collector-checkout-for-woocommerce' ) );
-				$order->update_meta_data('_walley_reauthorize_data', wp_json_encode( $response['header'] ));
+				$order->update_meta_data( '_walley_reauthorize_data', wp_json_encode( $response['header'] ) );
 				$order->save();
 			} else {
 				// Translators: Request response http status.

--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -277,6 +277,7 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 		$purchase_status    = filter_input( INPUT_POST, 'purchase_status', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
 		$test_mode          = $collector_settings['test_mode'];
+		// $order				= wc_get_order( $order_id );
 
 		// If something went wrong in get_customer_data() - display a "thank you page light".
 		if ( 'not-completed' === $purchase_status ) {
@@ -289,6 +290,9 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 		} else {
 			$public_token  = get_post_meta( $order_id, '_collector_public_token', true );
 			$customer_type = get_post_meta( $order_id, '_collector_customer_type', true );
+
+			// $public_token  = $order->get_meta( '_collector_public_token', true );
+			// $customer_type = $order->get_meta('_collector_customer_type', true );
 		}
 
 		$return = array(
@@ -321,9 +325,9 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 			wp_die();
 		}
 
-		if ( floatval( $order->get_total() ) > floatval( get_post_meta( $order_id, '_collector_original_order_total', true ) ) ) {
-			// Translators: Original order amount.
-			$message = sprintf( __( 'Updated total amount sent to Walley can not be higher than the original order amount (%1$s).', 'collector-checkout-for-woocommerce' ), get_post_meta( $order_id, '_collector_original_order_total', true ) );
+		if ( floatval( $order->get_total() ) > floatval( $order->get_meta( '_collector_original_order_total', true ) ) ) {
+				// Translators: Original order amount.
+			$message = sprintf( __( 'Updated total amount sent to Walley can not be higher than the original order amount (%1$s).', 'collector-checkout-for-woocommerce' ), $order->get_meta( '_collector_original_order_total', true ) );
 			$order->add_order_note( $message );
 			wp_send_json_error( $message );
 			wp_die();
@@ -343,7 +347,8 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 			} elseif ( 201 === $response['status'] ) {
 				// This should not happen as long as we do not allow a order total amount that is higher than the original order amount.
 				$order->add_order_note( __( 'Walley order sync started. Waiting for reauthorize response.', 'collector-checkout-for-woocommerce' ) );
-				update_post_meta( $order_id, '_walley_reauthorize_data', wp_json_encode( $response['header'] ) );
+				$order->update_meta_data('_walley_reauthorize_data', wp_json_encode( $response['header'] ));
+				$order->save();
 			} else {
 				// Translators: Request response http status.
 				$order->add_order_note( sprintf( __( 'Walley order sync started. Unknown http status response. Status: %1$s.', 'collector-checkout-for-woocommerce' ), $response['status'] ) );

--- a/classes/class-collector-checkout-api-callbacks.php
+++ b/classes/class-collector-checkout-api-callbacks.php
@@ -61,33 +61,24 @@ class Collector_Api_Callbacks {
 	public function collector_check_for_order_callback( $private_id, $public_token, $customer_type = 'b2c' ) {
 		CCO_WC()->logger::log( 'Check for order in API-callback. Private id: ' . $private_id . '. Public token: ' . $public_token );
 
-		$order_id = wc_collector_get_order_id_by_private_id( $private_id );
+		$order = wc_collector_get_order_by_private_id( $private_id );
 
 		// Did we get a match?
-		if ( ! empty( $order_id ) ) {
-			$order = wc_get_order( $order_id );
-
-			if ( $order ) {
-
-				// Maybe abort the callback (if the order already has been processed in Woo).
-				if ( ! empty( $order->get_date_paid() ) ) {
-					CCO_WC()->logger::log( 'Aborting API callback. Order ' . $order->get_order_number() . '(order ID ' . $order_id . ', Private ID ' . $private_id . ') already processed.' );
-				} else {
-					CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . '(order ID ' . $order_id . ', Private ID ' . $private_id . ') during checkout process. Setting order status to Processing/Completed in API callback.' );
-					// translators: Walley private ID.
-					$note = sprintf( __( 'Order status not set correctly during checkout process. Confirming purchase via callback from Walley.', 'collector-checkout-for-woocommerce' ), $private_id );
-					$order->add_order_note( $note );
-					walley_confirm_order( $order_id, $private_id );
-				}
+		if ( ! empty( $order ) ) {
+			// Maybe abort the callback (if the order already has been processed in Woo).
+			if ( ! empty( $order->get_date_paid() ) ) {
+				CCO_WC()->logger::log( 'Aborting API callback. Order ' . $order->get_order_number() . '(order ID ' . $order->get_id() . ', Private ID ' . $private_id . ') already processed.' );
 			} else {
-				// No order, why?
-				CCO_WC()->logger::log( 'API-callback executed. Private id ' . $private_id . '. already exist in order ID ' . $order_id . '. But we could not instantiate an order object' );
+				CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . '(order ID ' . $order->get_id() . ', Private ID ' . $private_id . ') during checkout process. Setting order status to Processing/Completed in API callback.' );
+				// translators: Walley private ID.
+				$note = sprintf( __( 'Order status not set correctly during checkout process. Confirming purchase via callback from Walley.', 'collector-checkout-for-woocommerce' ), $private_id );
+				$order->add_order_note( $note );
+				walley_confirm_order( $order, $private_id );
 			}
 		} else {
 			// No order found - create a new.
 			CCO_WC()->logger::log( 'API-callback executed. We could NOT find Private id ' . $private_id . '(with public token ' . $public_token . ' & customer type ' . $customer_type . '). Aborting process.' );
 		}
-
 	}
 
 	/**

--- a/classes/class-collector-checkout-api-callbacks.php
+++ b/classes/class-collector-checkout-api-callbacks.php
@@ -152,7 +152,8 @@ class Collector_Api_Callbacks {
 			CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to Processing/Completed.' );
 		} elseif ( 'Signing' === $collector_order['data']['purchase']['result'] ) {
 			$order->add_order_note( __( 'Order is waiting for electronic signing by customer. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $collector_order['data']['purchase']['purchaseIdentifier'] );
-			update_post_meta( $order->get_id(), '_transaction_id', $collector_order['data']['purchase']['purchaseIdentifier'] );
+			$order->update_meta_data( '_transaction_id', $collector_order['data']['purchase']['purchaseIdentifier'] );
+			$order->save();
 			$order->update_status( 'on-hold' );
 			CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to On hold.' );
 		} else {

--- a/classes/class-collector-checkout-delivery-module.php
+++ b/classes/class-collector-checkout-delivery-module.php
@@ -47,8 +47,7 @@ class Collector_Delivery_Module {
 	 * @return mixed Prints the html displayed in order admin.
 	 */
 	public function admin_order_meta( $order ) {
-		$order_id                = $order->get_id();
-		$collector_delivery_data = json_decode( get_post_meta( $order_id, '_collector_delivery_module_data', true ), true );
+		$collector_delivery_data = json_decode( $order->get_meta( '_collector_delivery_module_data', true ), true );
 
 		if ( ! empty( $collector_delivery_data ) ) {
 			$pickup_service = isset( $collector_delivery_data['carrierName'] ) ? $collector_delivery_data['carrierName'] : '';

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -161,32 +161,33 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 	 * Check if this gateway is enabled and available in the user's country
 	 */
 	public function is_available() {
-		if ( 'yes' === $this->enabled ) {
-
-			if ( is_checkout() ) {
-				$cart_item_total = Collector_Checkout_Requests_Cart::cart();
-
-				// Update checkout and annul payment method if the total cart item amount is 0.
-				if ( empty( $cart_item_total['items'] ) ) {
-					return false;
-				}
-			}
-
-			if ( ! is_admin() ) {
-				$currency = get_woocommerce_currency();
-				// Currency check.
-				if ( ! in_array( $currency, array( 'NOK', 'SEK', 'DKK', 'EUR' ), true ) ) {
-					return false;
-				}
-
-				// If there are no available customer types, return false.
-				if ( ! wc_collector_get_available_customer_types() ) {
-					return false;
-				}
-			}
-			return true;
+		if ( 'yes' !== $this->enabled ) {
+			return false;
 		}
-		return false;
+
+		if ( is_checkout() ) {
+			$cart_item_total = Collector_Checkout_Requests_Cart::cart();
+
+			// Update checkout and annul payment method if the total cart item amount is 0.
+			if ( empty( $cart_item_total['items'] ) ) {
+				return false;
+			}
+		}
+
+		if ( ! is_admin() ) {
+			$currency = get_woocommerce_currency();
+			// Currency check.
+			if ( ! in_array( $currency, array( 'NOK', 'SEK', 'DKK', 'EUR' ), true ) ) {
+				return false;
+			}
+
+			// If there are no available customer types, return false.
+			if ( ! wc_collector_get_available_customer_types() ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -215,7 +215,7 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 	 */
 	public function process_payment( $order_id, $retry = false ) {
 
-		$order		   = wc_get_order( $order_id );
+		$order         = wc_get_order( $order_id );
 		$customer_type = WC()->session->get( 'collector_customer_type' );
 		$private_id    = WC()->session->get( 'collector_private_id' );
 		$order->update_meta_data( '_collector_customer_type', $customer_type );
@@ -262,8 +262,8 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 		}
 
 		// Save data to order.
-		$walley_extra_fields = walley_save_custom_fields( $order_id, $walley_order );
-		$walley_shipping     = $this->save_walley_purchase_and_shipping_data( $order_id, $walley_order );
+		walley_save_custom_fields( $order_id, $walley_order );
+		$this->save_walley_purchase_and_shipping_data( $order_id, $walley_order );
 
 		return array(
 			'result' => 'success',
@@ -318,7 +318,6 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 
 	public function save_walley_purchase_and_shipping_data( $order_id, $walley_order ) {
 		$order               = wc_get_order( $order_id );
-		$payment_status      = $walley_order['data']['purchase']['result'] ?? '';
 		$payment_method      = $walley_order['data']['purchase']['paymentName'] ?? '';
 		$payment_id          = $walley_order['data']['purchase']['purchaseIdentifier'] ?? '';
 		$walley_order_id     = $walley_order['data']['order']['orderId'] ?? '';

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -245,7 +245,6 @@ class Collector_Checkout_Gateway extends WC_Payment_Gateway {
 			);
 		}
 
-		$order = wc_get_order( $order_id );
 		// $shipping_cost                 = $walley_order['data']['fees']['shipping']['unitPrice'] ?? 0; // Shipping.
 		$shipping_cost = $walley_order['data']['fees']['shipping']['unitPrice'] ?? $walley_order['data']['shipping']['shippingFee'] ?? 0;
 		$cart_cost     = $walley_order['data']['cart']['totalAmount']; // Cart.

--- a/classes/class-collector-checkout-order-emails.php
+++ b/classes/class-collector-checkout-order-emails.php
@@ -37,12 +37,11 @@ class Collector_Checkout_Order_Emails {
 	 * @return void
 	 */
 	public function email_extra_information( $order, $sent_to_admin, $plain_text = false ) {
-		$order_id     = $order->get_id();
-		$gateway_used = get_post_meta( $order_id, '_payment_method', true );
+		$gateway_used = $order->get_meta( '_payment_method', true );
 		if ( 'collector_checkout' === $gateway_used ) {
 			$payment_details = '';
-			$payment_id      = get_post_meta( $order_id, '_collector_payment_id', true );
-			$payment_type    = wc_collector_get_payment_method_name( get_post_meta( $order_id, '_collector_payment_method', true ) );
+			$payment_id      = $order->get_meta( '_collector_payment_id', true );
+			$payment_type    = wc_collector_get_payment_method_name( $order->get_meta( '_collector_payment_method', true ) );
 			$order_date      = wc_format_datetime( $order->get_date_created() );
 
 			echo '<h2>' . esc_html__( 'Walley details', 'collector-checkout-for-woocommerce' ) . '</h2>';

--- a/classes/class-collector-checkout-order-emails.php
+++ b/classes/class-collector-checkout-order-emails.php
@@ -37,12 +37,11 @@ class Collector_Checkout_Order_Emails {
 	 * @return void
 	 */
 	public function email_extra_information( $order, $sent_to_admin, $plain_text = false ) {
-		$gateway_used = $order->get_meta( '_payment_method', true );
+		$gateway_used = $order->get_payment_method();
 		if ( 'collector_checkout' === $gateway_used ) {
 			$payment_details = '';
 			$payment_id      = $order->get_meta( '_collector_payment_id', true );
 			$payment_type    = wc_collector_get_payment_method_name( $order->get_meta( '_collector_payment_method', true ) );
-			$order_date      = wc_format_datetime( $order->get_date_created() );
 
 			echo '<h2>' . esc_html__( 'Walley details', 'collector-checkout-for-woocommerce' ) . '</h2>';
 			if ( $payment_id ) {

--- a/classes/class-collector-checkout-pay-for-order-confirmation.php
+++ b/classes/class-collector-checkout-pay-for-order-confirmation.php
@@ -52,7 +52,7 @@ class Collector_Checkout_Pay_For_Order_Confirmation {
 		$public_token      = filter_input( INPUT_GET, 'public-token', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$order_key         = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
-		// Return if we dont have our parameters set.
+		// Return if we don't have our parameters set.
 		if ( empty( $collector_confirm ) || empty( $public_token ) || empty( $order_key ) ) {
 			return;
 		}
@@ -71,9 +71,8 @@ class Collector_Checkout_Pay_For_Order_Confirmation {
 			return;
 		}
 
-		wc_collector_confirm_order( $order_id );
+		wc_collector_confirm_order( $order );
 	}
-
 }
 
 Collector_Checkout_Pay_For_Order_Confirmation::get_instance();

--- a/classes/class-collector-checkout-post-checkout.php
+++ b/classes/class-collector-checkout-post-checkout.php
@@ -56,7 +56,7 @@ class Collector_Checkout_Post_Checkout {
 			return;
 		}
 
-		if ( get_post_meta( $order_id, '_collector_order_activated', true ) ) {
+		if ( $order->get_meta( '_collector_order_activated', true ) ) {
 			$order->add_order_note( __( 'Could not activate Walley reservation, Walley reservation is already activated.', 'collector-checkout-for-woocommerce' ) );
 			return;
 		}
@@ -93,7 +93,7 @@ class Collector_Checkout_Post_Checkout {
 		}
 
 		// If this reservation was already cancelled, do nothing.
-		if ( get_post_meta( $order_id, '_collector_order_cancelled', true ) ) {
+		if ( $order->get_meta( '_collector_order_cancelled', true ) ) {
 			$order->add_order_note( __( 'Could not cancel Walley reservation, Walley reservation is already cancelled.', 'collector-checkout-for-woocommerce' ) );
 			return;
 		}
@@ -162,8 +162,7 @@ class Collector_Checkout_Post_Checkout {
 
 			$current_screen = get_current_screen();
 			if ( is_object( $current_screen ) && 'edit-shop_order' === $current_screen->id ) {
-				$collector_payment_id = null !== get_post_meta( $order->get_id(), '_collector_payment_id', true ) ? get_post_meta( $order->get_id(), '_collector_payment_id', true ) : '';
-				//phpcs:ignore $collector_payment_id = get_post_meta( $order->get_id(), '_collector_payment_id', true );
+				$collector_payment_id = null !== $order->get_meta( '_collector_payment_id', true ) ? $order->get_meta( '_collector_payment_id', true ) : '';
 				if ( $collector_payment_id ) {
 					$order_number .= ' (' . $collector_payment_id . ')';
 				}

--- a/classes/class-walley-checkout-api.php
+++ b/classes/class-walley-checkout-api.php
@@ -186,26 +186,12 @@ class Walley_Checkout_API {
 	 * @return array|WP_Error
 	 */
 	public function refund_walley_order( $order_id, $amount = null, $reason = '' ) {
-
-		$query_args = array(
-			'fields'         => 'id=>parent',
-			'post_type'      => 'shop_order_refund',
-			'post_status'    => 'any',
-			'posts_per_page' => - 1,
-		);
-
-		$refunds         = get_posts( $query_args );
-		$refund_order_id = array_search( $order_id, $refunds, true );
-		if ( is_array( $refund_order_id ) ) {
-			foreach ( $refund_order_id as $key => $value ) {
-				$refund_order_id = $value;
-				break;
-			}
-		}
+		$order        = wc_get_order( $order_id );
+		$refund_order = $order->get_refunds()[0];
 
 		$args     = array(
 			'order_id'        => $order_id,
-			'refund_order_id' => $refund_order_id,
+			'refund_order_id' => $refund_order->get_id(),
 			'amount'          => $amount,
 			'reason'          => $reason,
 		);

--- a/classes/class-walley-checkout-api.php
+++ b/classes/class-walley-checkout-api.php
@@ -119,6 +119,11 @@ class Walley_Checkout_API {
 	 * @return array|WP_Error
 	 */
 	public function get_walley_order( $walley_id ) {
+		// If the walley ID is missing, the request will still be successful as Walley will return the 10 most recent transactions which is not the desired behavior.
+		if ( empty( $walley_id ) ) {
+			return new WP_Error( 'walley_get_order_error', __( 'Walley order id is missing.', 'collector-checkout-for-woocommerce' ) );
+		}
+
 		$args     = array( 'walley_id' => $walley_id );
 		$request  = new Walley_Checkout_Request_Get_Order( $args );
 		$response = $request->request();

--- a/classes/class-walley-checkout-assets.php
+++ b/classes/class-walley-checkout-assets.php
@@ -248,14 +248,7 @@ class Walley_Checkout_Assets {
 	 * @param string $hook The current hook/settings page.
 	 */
 	public function enqueue_admin_metabox_scripts( $hook ) {
-
-		global $post;
-
-		if ( empty( $post ) ) {
-			return;
-		}
-
-		if ( get_post_type( $post ) !== 'shop_order' ) {
+		if ( ! walley_is_order_page() ) {
 			return;
 		}
 
@@ -270,7 +263,7 @@ class Walley_Checkout_Assets {
 			array(
 				'walley_reauthorize_order'       => WC_AJAX::get_endpoint( 'walley_reauthorize_order' ),
 				'walley_reauthorize_order_nonce' => wp_create_nonce( 'walley_reauthorize_order' ),
-				'order_id'                       => get_the_ID(),
+				'order_id'                       => walley_get_the_ID(),
 			)
 		);
 		wp_enqueue_script( 'walley-admin' );

--- a/classes/class-walley-checkout-assets.php
+++ b/classes/class-walley-checkout-assets.php
@@ -212,7 +212,7 @@ class Walley_Checkout_Assets {
 			if ( ! empty( $key ) ) {
 				$order_id = wc_get_order_id_by_order_key( wc_clean( $key ) );
 				$order    = wc_get_order( $order_id );
-				if ( 'collector_checkout' === $order->get_payment_method() ) {
+				if ( ! empty( $order ) && 'collector_checkout' === $order->get_payment_method() ) {
 					$custom_css = '
 		                .woocommerce-order-overview {
 				                        display: none;

--- a/classes/class-walley-checkout-confirmation.php
+++ b/classes/class-walley-checkout-confirmation.php
@@ -57,25 +57,12 @@ class Walley_Checkout_Confirmation {
 		}
 
 		$order_id = walley_get_order_id_by_public_token( $public_token );
-
 		if ( empty( $order_id ) ) {
 			return;
 		}
 
-		$order = wc_get_order( $order_id );
-
-		// If the order does not need processing, set the status to on-hold, and redirect.
-		// This is to prevent an error from attempting to complete an order before it has been moved to the order management api in Walley.
-		if ( ! $order->needs_processing() ) {
-			$order->update_meta_data( '_walley_pending_callback', 'yes' );
-			$order->update_status( 'on-hold', __( 'The payment has been completed, but awaiting callback from Walley to confirm the order.', 'collector-checkout-for-woocommerce' ) );
-			$order->save();
-			wp_safe_redirect( $order->get_checkout_order_received_url() );
-			exit;
-		}
-
+		$order  = wc_get_order( $order_id );
 		$result = walley_confirm_order( $order_id );
-
 		if ( $result ) {
 			$walley_payment_id = $order->get_meta( '_collector_payment_id', true );
 			CCO_WC()->logger::log( "Order ID $order_id confirmed on the confirmation page. Walley payment ID: $walley_payment_id." );

--- a/classes/class-walley-checkout-confirmation.php
+++ b/classes/class-walley-checkout-confirmation.php
@@ -51,7 +51,6 @@ class Walley_Checkout_Confirmation {
 	public function confirm_order() {
 		$walley_confirm = filter_input( INPUT_GET, 'walley_confirm', FILTER_SANITIZE_SPECIAL_CHARS );
 		$public_token   = filter_input( INPUT_GET, 'public-token', FILTER_SANITIZE_SPECIAL_CHARS );
-
 		// Return if we dont have our parameters set.
 		if ( empty( $walley_confirm ) || empty( $public_token ) ) {
 			return;
@@ -64,9 +63,10 @@ class Walley_Checkout_Confirmation {
 		}
 
 		$result = walley_confirm_order( $order_id );
+		$order = wc_get_order($order_id);
 
 		if ( $result ) {
-			$walley_payment_id = get_post_meta( $order_id, '_collector_payment_id', true );
+			$walley_payment_id = $order->get_meta( '_collector_payment_id', true );
 			CCO_WC()->logger::log( "Order ID $order_id confirmed on the confirmation page. Walley payment ID: $walley_payment_id." );
 		}
 

--- a/classes/class-walley-checkout-confirmation.php
+++ b/classes/class-walley-checkout-confirmation.php
@@ -62,15 +62,14 @@ class Walley_Checkout_Confirmation {
 			return;
 		}
 
-		$result = walley_confirm_order( $order_id );
-		$order = wc_get_order($order_id);
+		$order  = wc_get_order( $order_id );
+		$result = walley_confirm_order( $order );
 
 		if ( $result ) {
 			$walley_payment_id = $order->get_meta( '_collector_payment_id', true );
 			CCO_WC()->logger::log( "Order ID $order_id confirmed on the confirmation page. Walley payment ID: $walley_payment_id." );
 		}
 
-		$order = wc_get_order( $order_id );
 		wp_safe_redirect( $order->get_checkout_order_received_url() );
 		exit;
 	}

--- a/classes/class-walley-checkout-meta-box.php
+++ b/classes/class-walley-checkout-meta-box.php
@@ -27,11 +27,11 @@ class Walley_Checkout_Meta_Box {
 	 * @return void
 	 */
 	public function add_meta_box( $post_type ) {
-		if ( 'shop_order' === $post_type ) {
+		if ( in_array( $post_type, array( 'woocommerce_page_wc-orders', 'shop_order' ), true ) ) {
 			$order_id = get_the_ID();
 			$order    = wc_get_order( $order_id );
 			if ( 'collector_checkout' === $order->get_payment_method() && walley_use_new_api() ) {
-				add_meta_box( 'walley_checkout_meta_box', __( 'Walley', 'collector-checkout-for-woocommerce' ), array( $this, 'meta_box_content' ), 'shop_order', 'side', 'core' );
+				add_meta_box( 'walley_checkout_meta_box', __( 'Walley', 'collector-checkout-for-woocommerce' ), array( $this, 'meta_box_content' ), $post_type, 'side', 'core' );
 			}
 		}
 	}
@@ -40,13 +40,20 @@ class Walley_Checkout_Meta_Box {
 	/**
 	 * Adds content for the meta box.
 	 *
+	 * @param WC_Order $order The WooCommerce order.
+	 *
 	 * @return void
 	 */
-	public function meta_box_content() {
+	public function meta_box_content( $order = null ) {
+		if ( ! $order instanceof WC_Order ) {
+			$order_id = get_the_ID();
+			$order    = wc_get_order( $order_id );
+		} else {
+			$order_id = $order->get_id();
+		}
+
 		$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
 		$manage_orders      = $collector_settings['manage_collector_orders'];
-		$order_id           = get_the_ID();
-		$order              = wc_get_order( $order_id );
 
 		$payment_method             = $order->get_meta( '_collector_payment_method', true );
 		$payment_id                 = $order->get_meta( '_collector_payment_id', true );
@@ -118,7 +125,4 @@ class Walley_Checkout_Meta_Box {
 		$keys_for_meta_box = apply_filters( 'walley_checkout_meta_box_keys', $keys_for_meta_box );
 		include COLLECTOR_BANK_PLUGIN_DIR . '/templates/walley-checkout-meta-box.php';
 	}
-
-
-
 } new Walley_Checkout_Meta_Box();

--- a/classes/class-walley-checkout-meta-box.php
+++ b/classes/class-walley-checkout-meta-box.php
@@ -48,9 +48,9 @@ class Walley_Checkout_Meta_Box {
 		$order_id           = get_the_ID();
 		$order              = wc_get_order( $order_id );
 
-		$payment_method             = get_post_meta( $order_id, '_collector_payment_method', true );
-		$payment_id                 = get_post_meta( $order_id, '_collector_payment_id', true );
-		$walley_order_id            = get_post_meta( $order_id, '_collector_order_id', true );
+		$payment_method             = $order->get_meta( '_collector_payment_method', true );
+		$payment_id                 = $order->get_meta( '_collector_payment_id', true );
+		$walley_order_id            = $order->get_meta( '_collector_order_id', true );
 		$title_payment_method       = __( 'Payment method', 'collector-checkout-for-woocommerce' );
 		$title_walley_order_id      = __( 'Walley order id', 'collector-checkout-for-woocommerce' );
 		$title_walley_order_status  = __( 'Walley order status', 'collector-checkout-for-woocommerce' );

--- a/classes/class-walley-checkout-meta-box.php
+++ b/classes/class-walley-checkout-meta-box.php
@@ -27,8 +27,8 @@ class Walley_Checkout_Meta_Box {
 	 * @return void
 	 */
 	public function add_meta_box( $post_type ) {
-		if ( in_array( $post_type, array( 'woocommerce_page_wc-orders', 'shop_order' ), true ) ) {
-			$order_id = get_the_ID();
+		if ( walley_is_order_page() ) {
+			$order_id = walley_get_the_ID();
 			$order    = wc_get_order( $order_id );
 			if ( 'collector_checkout' === $order->get_payment_method() && walley_use_new_api() ) {
 				add_meta_box( 'walley_checkout_meta_box', __( 'Walley', 'collector-checkout-for-woocommerce' ), array( $this, 'meta_box_content' ), $post_type, 'side', 'core' );
@@ -40,23 +40,15 @@ class Walley_Checkout_Meta_Box {
 	/**
 	 * Adds content for the meta box.
 	 *
-	 * @param WC_Order $order The WooCommerce order.
+	 * @param WC_Order|WP_Post $order The post or Woo order ID.
 	 *
 	 * @return void
 	 */
 	public function meta_box_content( $order = null ) {
-		if ( ! $order instanceof WC_Order ) {
-			$order_id = get_the_ID();
-			$order    = wc_get_order( $order_id );
-		} else {
-			$order_id = $order->get_id();
-		}
-
-		$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
-		$manage_orders      = $collector_settings['manage_collector_orders'];
+		$order_id = walley_get_the_ID();
+		$order    = wc_get_order( $order_id );
 
 		$payment_method             = $order->get_meta( '_collector_payment_method', true );
-		$payment_id                 = $order->get_meta( '_collector_payment_id', true );
 		$walley_order_id            = $order->get_meta( '_collector_order_id', true );
 		$title_payment_method       = __( 'Payment method', 'collector-checkout-for-woocommerce' );
 		$title_walley_order_id      = __( 'Walley order id', 'collector-checkout-for-woocommerce' );
@@ -64,7 +56,7 @@ class Walley_Checkout_Meta_Box {
 		$title_walley_order_total   = __( 'Walley order total', 'collector-checkout-for-woocommerce' );
 		$title_order_total_mismatch = __( 'Order total mismatch', 'collector-checkout-for-woocommerce' );
 
-		if ( false === ( $walley_order_status_from_transient = get_transient( "walley_order_status_{$order_id}" ) ) ) {
+		if ( empty( $walley_order_status_from_transient = get_transient( "walley_order_status_{$order_id}" ) ) ) {
 			$walley_order = CCO_WC()->api->get_walley_order( $walley_order_id );
 
 			if ( is_wp_error( $walley_order ) ) {

--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -53,12 +53,12 @@ class  Walley_Checkout_Order_Management {
 			return;
 		}
 
-		if ( get_post_meta( $order_id, '_collector_order_activated', true ) ) {
+		if ( $order->get_meta( '_collector_order_activated', true ) ) {
 			$order->add_order_note( __( 'Could not activate Walley reservation, Walley reservation is already activated.', 'collector-checkout-for-woocommerce' ) );
 			return;
 		}
 
-		if ( empty( get_post_meta( $order_id, '_collector_order_id', true ) ) ) {
+		if ( empty( $order->get_meta( '_collector_order_id', true ) ) ) {
 			$order->add_order_note( __( 'Could not activate Walley reservation, Walley order ID is missing.', 'collector-checkout-for-woocommerce' ) );
 			return;
 		}
@@ -142,7 +142,7 @@ class  Walley_Checkout_Order_Management {
 		}
 
 		// If this reservation was already cancelled, do nothing.
-		if ( get_post_meta( $order_id, '_collector_order_cancelled', true ) ) {
+		if ( $order->get_meta( '_collector_order_cancelled', true ) ) {
 			$order->add_order_note( __( 'Could not cancel Walley reservation, Walley reservation is already cancelled.', 'collector-checkout-for-woocommerce' ) );
 			return;
 		}
@@ -206,18 +206,18 @@ class  Walley_Checkout_Order_Management {
 		}
 
 		// If this reservation was already cancelled, do nothing.
-		if ( get_post_meta( $order_id, '_collector_order_cancelled', true ) ) {
+		if ( $order->get_meta( '_collector_order_cancelled', true ) ) {
 			$order->add_order_note( __( 'Could not refund Walley order, Walley reservation is cancelled.', 'collector-checkout-for-woocommerce' ) );
 			return new WP_Error( 'error', __( 'Could not refund Walley order, Walley reservation is cancelled.', 'collector-checkout-for-woocommerce' ) );
 		}
 
 		// If this reservation was not activated, do nothing.
-		if ( empty( get_post_meta( $order_id, '_collector_order_activated', true ) ) ) {
+		if ( empty( $order->get_meta( '_collector_order_activated', true ) ) ) {
 			$order->add_order_note( __( 'There is nothing to refund. The order has not yet been captured in WooCommerce.', 'collector-checkout-for-woocommerce' ) );
 			return new WP_Error( 'error', __( 'There is nothing to refund. The order has not yet been captured in WooCommerce.', 'collector-checkout-for-woocommerce' ) );
 		}
 
-		if ( empty( get_post_meta( $order_id, '_collector_order_id', true ) ) ) {
+		if ( empty( $order->get_meta( '_collector_order_id', true ) ) ) {
 			$order->add_order_note( __( 'Could not refund Walley reservation, Walley order ID is missing.', 'collector-checkout-for-woocommerce' ) );
 			return new WP_Error( 'error', __( 'Could not refund Walley reservation, Walley order ID is missing.', 'collector-checkout-for-woocommerce' ) );
 		}
@@ -265,7 +265,7 @@ class  Walley_Checkout_Order_Management {
 	 */
 	public function is_ok_to_cancel( $order_id ) {
 		$wc_order  = wc_get_order( $order_id );
-		$walley_id = get_post_meta( $order_id, '_collector_order_id', true );
+		$walley_id = $order->get_meta( '_collector_order_id', true );
 		$response  = CCO_WC()->api->get_walley_order( $walley_id );
 		if ( ! is_wp_error( $response ) ) {
 
@@ -386,8 +386,7 @@ class  Walley_Checkout_Order_Management {
 
 			$current_screen = get_current_screen();
 			if ( is_object( $current_screen ) && 'edit-shop_order' === $current_screen->id ) {
-				$collector_payment_id = null !== get_post_meta( $order->get_id(), '_collector_payment_id', true ) ? get_post_meta( $order->get_id(), '_collector_payment_id', true ) : '';
-				//phpcs:ignore $collector_payment_id = get_post_meta( $order->get_id(), '_collector_payment_id', true );
+				$collector_payment_id = null !== $order->get_meta( '_collector_payment_id', true ) ? $order->get_meta( '_collector_payment_id', true ) : '';
 				if ( $collector_payment_id ) {
 					$order_number .= ' (' . $collector_payment_id . ')';
 				}

--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -339,17 +339,10 @@ class  Walley_Checkout_Order_Management {
 			if ( ! empty( $invoice_no ) && ! empty( $invoice_status ) ) {
 				CCO_WC()->logger::log( 'Collector Invoice Status Change callback hit' );
 				$collector_payment_id = $invoice_no;
-				$query_args           = array(
-					'post_type'   => wc_get_order_types(),
-					'post_status' => array_keys( wc_get_order_statuses() ),
-					'meta_key'    => '_collector_payment_id', // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
-					'meta_value'  => $collector_payment_id, // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
-				);
-				$orders               = get_posts( $query_args );
-				$order_id             = $orders[0]->ID;
-				$order                = wc_get_order( $order_id );
 
-				if ( is_object( $order ) ) {
+				$order = walley_get_order_by_key( '_collector_payment_id', $collector_payment_id );
+
+				if ( ! empty( $order ) ) {
 					// Add order note about the callback
 					// translators: Invoice status.
 					$order->add_order_note( sprintf( __( 'Invoice status callback from Walley. New Invoice status: %s', 'collector-checkout-for-woocommerce' ), $invoice_no ) );
@@ -375,7 +368,7 @@ class  Walley_Checkout_Order_Management {
 	}
 
 	/**
-	 * Display Collector payment id after WC order number on order overwiev page
+	 * Display Collector payment id after WC order number on orders overview page
 	 *
 	 * @param string   $order_number The WooCommerce order number.
 	 * @param WC_Order $order The WooCommerce order.
@@ -388,9 +381,9 @@ class  Walley_Checkout_Order_Management {
 			}
 
 			$current_screen = get_current_screen();
-			if ( is_object( $current_screen ) && 'edit-shop_order' === $current_screen->id ) {
-				$collector_payment_id = null !== $order->get_meta( '_collector_payment_id', true ) ? $order->get_meta( '_collector_payment_id', true ) : '';
-				if ( $collector_payment_id ) {
+			if ( isset( $current_screen ) && in_array( $current_screen->id, array( 'woocommerce_page_wc-orders', 'edit-shop_order' ) ) ) {
+				$collector_payment_id = $order->get_meta( '_collector_payment_id' );
+				if ( ! empty( $collector_payment_id ) ) {
 					$order_number .= ' (' . $collector_payment_id . ')';
 				}
 			}

--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -80,7 +80,8 @@ class  Walley_Checkout_Order_Management {
 
 			// Translators: Activated amount.
 			$order->add_order_note( sprintf( __( 'Order part activated with Walley Checkout. Activated amount %s', 'collector-checkout-for-woocommerce' ), wc_price( $order->get_total(), array( 'currency' => $order->get_currency() ) ) ) );
-			update_post_meta( $order_id, '_collector_order_activated', time() );
+			$order->update_meta_data( '_collector_order_activated', time() );
+			$order->save();
 
 			// Save received data to WP transient.
 			walley_save_order_data_to_transient(
@@ -107,7 +108,8 @@ class  Walley_Checkout_Order_Management {
 
 			$note = __( 'Walley Checkout order activated.', 'collector-checkout-for-woocommerce' );
 			$order->add_order_note( $note );
-			update_post_meta( $order_id, '_collector_order_activated', time() );
+			$order->update_meta_data( '_collector_order_activated', time() );
+			$order->save();
 
 			// Save received data to WP transient.
 			walley_save_order_data_to_transient(
@@ -147,7 +149,7 @@ class  Walley_Checkout_Order_Management {
 			return;
 		}
 
-		if ( empty( get_post_meta( $order_id, '_collector_order_id', true ) ) ) {
+		if ( $order->get_meta( '_collector_order_id', true ) ) {
 			$order->add_order_note( __( 'Could not cancel Walley reservation, Walley order ID is missing.', 'collector-checkout-for-woocommerce' ) );
 			return;
 		}
@@ -172,7 +174,8 @@ class  Walley_Checkout_Order_Management {
 
 		$note = __( 'Walley Checkout order cancelled.', 'collector-checkout-for-woocommerce' );
 		$order->add_order_note( $note );
-		update_post_meta( $order_id, '_collector_order_cancelled', time() );
+		$order->update_meta_data( '_collector_order_cancelled', time() );
+		$order->save();
 
 		// Save received data to WP transient.
 		walley_save_order_data_to_transient(

--- a/classes/class-walley-checkout.php
+++ b/classes/class-walley-checkout.php
@@ -131,6 +131,14 @@ class Walley_Checkout {
 			return;
 		}
 
+		// The cart has been updated. Check if it is empty.
+		// A cart is considered "empty" if the total amount is 0 even if it has items (e.g., 100% discount).
+		$cart_item_total = Collector_Checkout_Requests_Cart::cart();
+		if ( empty( $cart_item_total['items'] ) ) {
+			WC()->session->reload_checkout = true;
+			return;
+		}
+
 		// Trigger get if the ajax event is among the approved ones.
 		$ajax = filter_input( INPUT_GET, 'wc-ajax', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( ! in_array( $ajax, array( 'update_order_review' ), true ) ) {

--- a/classes/class-walley-part-payment-widget.php
+++ b/classes/class-walley-part-payment-widget.php
@@ -213,7 +213,7 @@ class Walley_Part_Payment_Widget {
 	 */
 	public function get_product_amount() {
 		// Get the product that we are currently on.
-		$product = wc_get_product( walley_get_the_ID() );
+		$product = wc_get_product();
 
 		// If the product is a variable product, get the min price.
 		if ( $product->is_type( 'variable' ) ) {

--- a/classes/class-walley-part-payment-widget.php
+++ b/classes/class-walley-part-payment-widget.php
@@ -213,7 +213,7 @@ class Walley_Part_Payment_Widget {
 	 */
 	public function get_product_amount() {
 		// Get the product that we are currently on.
-		$product = wc_get_product( get_the_ID() );
+		$product = wc_get_product( walley_get_the_ID() );
 
 		// If the product is a variable product, get the min price.
 		if ( $product->is_type( 'variable' ) ) {

--- a/classes/requests/helpers/class-collector-checkout-create-refund-data.php
+++ b/classes/requests/helpers/class-collector-checkout-create-refund-data.php
@@ -226,7 +226,7 @@ class Collector_Checkout_Create_Refund_Data {
 		// The entire shipping price is refunded.
 		$shipping_reference = 'Shipping';
 
-		$collector_shipping_reference = get_post_meta( $original_order->get_id(), '_collector_shipping_reference', true );
+		$collector_shipping_reference = $original_order->get_meta( '_collector_shipping_reference', true );
 		if ( isset( $collector_shipping_reference ) && ! empty( $collector_shipping_reference ) ) {
 			$shipping_reference = $collector_shipping_reference;
 		} else {

--- a/classes/requests/helpers/class-collector-checkout-create-refund-data.php
+++ b/classes/requests/helpers/class-collector-checkout-create-refund-data.php
@@ -135,27 +135,13 @@ class Collector_Checkout_Create_Refund_Data {
 	/**
 	 * Gets refunded order
 	 *
-	 * @param int $order_id The WooCommerce order id.
+	 * @param int $order_id The Woo order ID.
 	 * @return string
 	 */
 	public static function get_refunded_order( $order_id ) {
-		$query_args      = array(
-			'fields'         => 'id=>parent',
-			'post_type'      => 'shop_order_refund',
-			'post_status'    => 'any',
-			'posts_per_page' => -1,
-		);
-		$refunds         = get_posts( $query_args );
-		$refund_order_id = array_search( $order_id, $refunds, true );
-		if ( is_array( $refund_order_id ) ) {
-			foreach ( $refund_order_id as $key => $value ) {
-				if ( ! get_post_meta( $value, '_krokedil_refunded' ) ) {
-					$refund_order_id = $value;
-					break;
-				}
-			}
-		}
-		return $refund_order_id;
+		$order = wc_get_order( $order_id );
+		return $order->get_refunds()[0];
+
 	}
 	/**
 	 * Calculates tax.

--- a/classes/requests/helpers/class-collector-checkout-create-refund-data.php
+++ b/classes/requests/helpers/class-collector-checkout-create-refund-data.php
@@ -130,7 +130,6 @@ class Collector_Checkout_Create_Refund_Data {
 			}
 		}
 
-		// update_post_meta( $refund_order_id, '_krokedil_refunded', 'true' ); phpcs:ignore Squiz.PHP.CommentedOutCode.Found.
 		return $data;
 	}
 	/**
@@ -229,12 +228,10 @@ class Collector_Checkout_Create_Refund_Data {
 		$collector_shipping_reference = $original_order->get_meta( '_collector_shipping_reference', true );
 		if ( isset( $collector_shipping_reference ) && ! empty( $collector_shipping_reference ) ) {
 			$shipping_reference = $collector_shipping_reference;
-		} else {
-			if ( null !== $shipping->get_instance_id() ) {
+		} elseif ( null !== $shipping->get_instance_id() ) {
 				$shipping_reference = 'shipping|' . $shipping->get_method_id() . ':' . $shipping->get_instance_id();
-			} else {
-				$shipping_reference = 'shipping|' . $shipping->get_method_id();
-			}
+		} else {
+			$shipping_reference = 'shipping|' . $shipping->get_method_id();
 		}
 
 		$free_shipping = false;
@@ -311,6 +308,4 @@ class Collector_Checkout_Create_Refund_Data {
 		/* Always retrieve the most recent (current) refund (index 0). */
 		return $order->get_refunds()[0]->get_id();
 	}
-
-
 }

--- a/classes/requests/helpers/class-collector-checkout-requests-cart.php
+++ b/classes/requests/helpers/class-collector-checkout-requests-cart.php
@@ -155,7 +155,7 @@ class Collector_Checkout_Requests_Cart {
 	 * @return string
 	 */
 	public static function get_sku( $product, $product_id = 0 ) {
-		$part_number = ! empty( $product->get_sku() ) ? $product->get_sku() : $part_number = $product->get_id();
+		$part_number = ! empty( $product->get_sku() ) ? $product->get_sku() : $product->get_id();
 		return substr( $part_number, 0, 32 );
 	}
 
@@ -214,7 +214,7 @@ class Collector_Checkout_Requests_Cart {
 				foreach ( $items as $key => $item ) {
 					if ( $id_name === $item['id'] ) {// TODO Use strict comparisons === !
 						$items[ $key ]['id'] = $item['id'] . '_' . $i;
-						$i++;
+						++$i;
 					}
 				}
 			}

--- a/classes/requests/helpers/class-collector-checkout-requests-cart.php
+++ b/classes/requests/helpers/class-collector-checkout-requests-cart.php
@@ -92,7 +92,8 @@ class Collector_Checkout_Requests_Cart {
 		// Only check this on product line items.
 		if ( $product && 'yes' === self::get_add_product_electronic_id_fields() ) {
 			$product_id                              = $product->is_type( 'variation' ) ? $product->get_parent_id() : $product->get_id();
-			$collector_requires_electronic_id        = 'yes' === get_post_meta( $product_id, '_collector_requires_electronic_id', true ) ? true : false;
+			$product                                 = wc_get_product( $product_id );
+			$collector_requires_electronic_id        = 'yes' === $product->get_meta( '_collector_requires_electronic_id' ) ? true : false;
 			$configured_item['requiresElectronicId'] = $collector_requires_electronic_id;
 		}
 
@@ -153,12 +154,8 @@ class Collector_Checkout_Requests_Cart {
 	 * @param int        $product_id WooCommerce product ID.
 	 * @return string
 	 */
-	public static function get_sku( $product, $product_id ) {
-		if ( get_post_meta( $product_id, '_sku', true ) !== '' ) {
-			$part_number = $product->get_sku();
-		} else {
-			$part_number = $product->get_id();
-		}
+	public static function get_sku( $product, $product_id = 0 ) {
+		$part_number = ! empty( $product->get_sku() ) ? $product->get_sku() : $part_number = $product->get_id();
 		return substr( $part_number, 0, 32 );
 	}
 

--- a/classes/requests/helpers/class-collector-checkout-requests-helper-order-om.php
+++ b/classes/requests/helpers/class-collector-checkout-requests-helper-order-om.php
@@ -192,7 +192,7 @@ class Collector_Checkout_Requests_Helper_Order_Om {
 		$shipping_reference_from_delivery_module_data = walley_get_shipping_reference_from_delivery_module_data( $order->get_id() );
 
 		// Try to get shipping reference from regular purchase (shipping in woo).
-		$collector_shipping_reference = get_post_meta( $order->get_id(), '_collector_shipping_reference', true );
+		$collector_shipping_reference = $order->get_meta( '_collector_shipping_reference', true );
 
 		if ( isset( $collector_shipping_reference ) && ! empty( $collector_shipping_reference ) ) {
 			$shipping_reference = $collector_shipping_reference;

--- a/classes/requests/helpers/class-walley-checkout-requests-fees-helper.php
+++ b/classes/requests/helpers/class-walley-checkout-requests-fees-helper.php
@@ -185,12 +185,8 @@ class Walley_Checkout_Requests_Fees_Helper {
 	 * @param int        $product_id WooCommerce product ID.
 	 * @return string
 	 */
-	public static function get_sku( $product, $product_id ) {
-		if ( get_post_meta( $product_id, '_sku', true ) !== '' ) {
-			$part_number = $product->get_sku();
-		} else {
-			$part_number = $product->get_id();
-		}
+	public static function get_sku( $product, $product_id = 0 ) {
+		$part_number = ! empty( $product->get_sku() ) ? $product->get_sku() : $part_number = $product->get_id();
 		return substr( $part_number, 0, 32 );
 	}
 }

--- a/classes/requests/helpers/class-walley-checkout-requests-fees-helper.php
+++ b/classes/requests/helpers/class-walley-checkout-requests-fees-helper.php
@@ -107,7 +107,6 @@ class Walley_Checkout_Requests_Fees_Helper {
 		}
 
 		return $fees;
-
 	}
 
 	/**
@@ -186,7 +185,7 @@ class Walley_Checkout_Requests_Fees_Helper {
 	 * @return string
 	 */
 	public static function get_sku( $product, $product_id = 0 ) {
-		$part_number = ! empty( $product->get_sku() ) ? $product->get_sku() : $part_number = $product->get_id();
+		$part_number = ! empty( $product->get_sku() ) ? $product->get_sku() : $product->get_id();
 		return substr( $part_number, 0, 32 );
 	}
 }

--- a/classes/requests/manage-orders/post/class-walley-checkout-request-cancel-order.php
+++ b/classes/requests/manage-orders/post/class-walley-checkout-request-cancel-order.php
@@ -29,7 +29,8 @@ class Walley_Checkout_Request_Cancel_Order extends Walley_Checkout_Request_Post 
 	 * @return string
 	 */
 	protected function get_request_url() {
-		$walley_id = get_post_meta( $this->order_id, '_collector_order_id', true );
+		$order = wc_get_order($this->order_id);
+		$walley_id = $order->get_meta( '_collector_order_id', true );
 		return $this->get_api_url_base() . "/manage/orders/{$walley_id}/cancel";
 	}
 

--- a/classes/requests/manage-orders/post/class-walley-checkout-request-cancel-order.php
+++ b/classes/requests/manage-orders/post/class-walley-checkout-request-cancel-order.php
@@ -13,6 +13,13 @@ defined( 'ABSPATH' ) || exit;
 class Walley_Checkout_Request_Cancel_Order extends Walley_Checkout_Request_Post {
 
 	/**
+	 * The Woo order id.
+	 *
+	 * @var int
+	 */
+	private $order_id;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param array $arguments The request arguments.
@@ -29,7 +36,7 @@ class Walley_Checkout_Request_Cancel_Order extends Walley_Checkout_Request_Post 
 	 * @return string
 	 */
 	protected function get_request_url() {
-		$order = wc_get_order($this->order_id);
+		$order     = wc_get_order( $this->order_id );
 		$walley_id = $order->get_meta( '_collector_order_id', true );
 		return $this->get_api_url_base() . "/manage/orders/{$walley_id}/cancel";
 	}
@@ -40,8 +47,7 @@ class Walley_Checkout_Request_Cancel_Order extends Walley_Checkout_Request_Post 
 	 * @return array
 	 */
 	protected function get_body() {
-		$order = wc_get_order( $this->order_id );
-		$body  = array(
+		$body = array(
 			'amount' => Collector_Checkout_Requests_Helper_Order_Om::get_order_lines_total_amount( $this->order_id ),
 		);
 

--- a/classes/requests/manage-orders/post/class-walley-checkout-request-capture-order.php
+++ b/classes/requests/manage-orders/post/class-walley-checkout-request-capture-order.php
@@ -13,6 +13,13 @@ defined( 'ABSPATH' ) || exit;
 class Walley_Checkout_Request_Capture_Order extends Walley_Checkout_Request_Post {
 
 	/**
+	 * The Woo order ID.
+	 *
+	 * @var int
+	 */
+	private $order_id;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param array $arguments The request arguments.
@@ -29,7 +36,7 @@ class Walley_Checkout_Request_Capture_Order extends Walley_Checkout_Request_Post
 	 * @return string
 	 */
 	protected function get_request_url() {
-		$order = wc_get_order($this->order_id);
+		$order     = wc_get_order( $this->order_id );
 		$walley_id = $order->get_meta( '_collector_order_id', true );
 		return $this->get_api_url_base() . "/manage/orders/{$walley_id}/capture";
 	}
@@ -40,8 +47,7 @@ class Walley_Checkout_Request_Capture_Order extends Walley_Checkout_Request_Post
 	 * @return array
 	 */
 	protected function get_body() {
-		$order = wc_get_order( $this->order_id );
-		$body  = array(
+		$body = array(
 			'amount' => Collector_Checkout_Requests_Helper_Order_Om::get_order_lines_total_amount( $this->order_id ),
 		);
 

--- a/classes/requests/manage-orders/post/class-walley-checkout-request-capture-order.php
+++ b/classes/requests/manage-orders/post/class-walley-checkout-request-capture-order.php
@@ -29,7 +29,8 @@ class Walley_Checkout_Request_Capture_Order extends Walley_Checkout_Request_Post
 	 * @return string
 	 */
 	protected function get_request_url() {
-		$walley_id = get_post_meta( $this->order_id, '_collector_order_id', true );
+		$order = wc_get_order($this->order_id);
+		$walley_id = $order->get_meta( '_collector_order_id', true );
 		return $this->get_api_url_base() . "/manage/orders/{$walley_id}/capture";
 	}
 

--- a/classes/requests/manage-orders/post/class-walley-checkout-request-part-capture-order.php
+++ b/classes/requests/manage-orders/post/class-walley-checkout-request-part-capture-order.php
@@ -13,6 +13,13 @@ defined( 'ABSPATH' ) || exit;
 class Walley_Checkout_Request_Part_Capture_Order extends Walley_Checkout_Request_Post {
 
 	/**
+	 * The Woo order ID.
+	 *
+	 * @var int
+	 */
+	private $order_id;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param array $arguments The request arguments.
@@ -29,7 +36,7 @@ class Walley_Checkout_Request_Part_Capture_Order extends Walley_Checkout_Request
 	 * @return string
 	 */
 	protected function get_request_url() {
-		$order = wc_get_order($this->order_id);
+		$order     = wc_get_order( $this->order_id );
 		$walley_id = $order->get_meta( '_collector_order_id', true );
 		return $this->get_api_url_base() . "/manage/orders/{$walley_id}/capture";
 	}
@@ -40,8 +47,7 @@ class Walley_Checkout_Request_Part_Capture_Order extends Walley_Checkout_Request
 	 * @return array
 	 */
 	protected function get_body() {
-		$order = wc_get_order( $this->order_id );
-		$body  = array(
+		$body = array(
 			'amount' => Collector_Checkout_Requests_Helper_Order_Om::get_order_lines_total_amount( $this->order_id ),
 			'items'  => Collector_Checkout_Requests_Helper_Order_Om::get_order_lines( $this->order_id ),
 		);

--- a/classes/requests/manage-orders/post/class-walley-checkout-request-part-capture-order.php
+++ b/classes/requests/manage-orders/post/class-walley-checkout-request-part-capture-order.php
@@ -29,7 +29,8 @@ class Walley_Checkout_Request_Part_Capture_Order extends Walley_Checkout_Request
 	 * @return string
 	 */
 	protected function get_request_url() {
-		$walley_id = get_post_meta( $this->order_id, '_collector_order_id', true );
+		$order = wc_get_order($this->order_id);
+		$walley_id = $order->get_meta( '_collector_order_id', true );
 		return $this->get_api_url_base() . "/manage/orders/{$walley_id}/capture";
 	}
 

--- a/classes/requests/manage-orders/post/class-walley-checkout-request-reauthorize-order.php
+++ b/classes/requests/manage-orders/post/class-walley-checkout-request-reauthorize-order.php
@@ -29,7 +29,8 @@ class Walley_Checkout_Request_Reauthorize_Order extends Walley_Checkout_Request_
 	 * @return string
 	 */
 	protected function get_request_url() {
-		$walley_id = get_post_meta( $this->order_id, '_collector_order_id', true );
+		$order = wc_get_order( $this->order_id );
+		$walley_id = $order->get_meta( '_collector_order_id', true );
 		return $this->get_api_url_base() . "/manage/orders/{$walley_id}/reauthorize";
 	}
 

--- a/classes/requests/manage-orders/post/class-walley-checkout-request-refund-order-by-amount.php
+++ b/classes/requests/manage-orders/post/class-walley-checkout-request-refund-order-by-amount.php
@@ -29,7 +29,8 @@ class Walley_Checkout_Request_Refund_Order_By_Amount extends Walley_Checkout_Req
 	 * @return string
 	 */
 	protected function get_request_url() {
-		$walley_id = get_post_meta( $this->order_id, '_collector_order_id', true );
+		$order = wc_get_order( $this->order_id );
+		$walley_id = $order->get_meta( '_collector_order_id', true );
 		return $this->get_api_url_base() . "/manage/orders/{$walley_id}/refund";
 	}
 

--- a/classes/requests/manage-orders/post/class-walley-checkout-request-refund-order.php
+++ b/classes/requests/manage-orders/post/class-walley-checkout-request-refund-order.php
@@ -29,7 +29,7 @@ class Walley_Checkout_Request_Refund_Order extends Walley_Checkout_Request_Post 
 	 * @return string
 	 */
 	protected function get_request_url() {
-		$order = wc_get_order( $this->order_id );
+		$order     = wc_get_order( $this->order_id );
 		$walley_id = $order->get_meta( '_collector_order_id', true );
 		return $this->get_api_url_base() . "/manage/orders/{$walley_id}/refund";
 	}
@@ -41,7 +41,6 @@ class Walley_Checkout_Request_Refund_Order extends Walley_Checkout_Request_Post 
 	 */
 	protected function get_body() {
 		$refund_order_id = $this->arguments['refund_order_id'];
-		$refund_order    = wc_get_order( $refund_order_id );
 		$body            = array(
 			'amount' => $this->arguments['amount'],
 			'items'  => Collector_Checkout_Requests_Helper_Order_Om::get_refund_items( $refund_order_id ),

--- a/classes/requests/manage-orders/post/class-walley-checkout-request-refund-order.php
+++ b/classes/requests/manage-orders/post/class-walley-checkout-request-refund-order.php
@@ -29,7 +29,8 @@ class Walley_Checkout_Request_Refund_Order extends Walley_Checkout_Request_Post 
 	 * @return string
 	 */
 	protected function get_request_url() {
-		$walley_id = get_post_meta( $this->order_id, '_collector_order_id', true );
+		$order = wc_get_order( $this->order_id );
+		$walley_id = $order->get_meta( '_collector_order_id', true );
 		return $this->get_api_url_base() . "/manage/orders/{$walley_id}/refund";
 	}
 

--- a/classes/requests/soap/class-collector-checkout-soap-requests-activate-invoice.php
+++ b/classes/requests/soap/class-collector-checkout-soap-requests-activate-invoice.php
@@ -137,15 +137,16 @@ class Collector_Checkout_SOAP_Requests_Activate_Invoice {
 		if ( isset( $request->TotalAmount ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 			if ( isset( $request->InvoiceUrl ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-				update_post_meta( $order_id, '_collector_invoice_url', wc_clean( $request->InvoiceUrl ) );// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$order->update_meta_data( '_collector_invoice_url', wc_clean( $request->InvoiceUrl ) );// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$order->save();
 				$due_date = gmdate( get_option( 'date_format' ) . ' - ' . get_option( 'time_format' ), strtotime( $request->DueDate ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				$due_date = sprintf( __( 'Invoice due date: %s', 'collector-checkout-for-woocommerce' ), $due_date );
 			}
 
 			// translators: 1. Due date.
 			$order->add_order_note( sprintf( __( 'Order activated with Walley Checkout. %s', 'collector-checkout-for-woocommerce' ), $due_date ) );
-			update_post_meta( $order_id, '_collector_order_activated', time() );
-
+			$order->update_meta_data( '_collector_order_activated', time() );
+			$order->save();
 			$log = CCO_WC()->logger::format_log( $order_id, 'SOAP', 'CCO Activate order ', $args, '', wp_json_encode( $request ), '' );
 			CCO_WC()->logger::log( $log );
 

--- a/classes/requests/soap/class-collector-checkout-soap-requests-activate-invoice.php
+++ b/classes/requests/soap/class-collector-checkout-soap-requests-activate-invoice.php
@@ -71,7 +71,7 @@ class Collector_Checkout_SOAP_Requests_Activate_Invoice {
 		$this->password     = $collector_settings['collector_password'];
 		$order              = wc_get_order( $order_id );
 		$currency           = $order->get_currency();
-		$customer_type      = get_post_meta( $order_id, '_collector_customer_type', true );
+		$customer_type      = $order->get_meta( '_collector_customer_type', true );
 
 		switch ( $currency ) {
 			case 'SEK':
@@ -169,10 +169,11 @@ class Collector_Checkout_SOAP_Requests_Activate_Invoice {
 	 * @return array
 	 */
 	public function get_request_args( $order_id ) {
+		$order = wc_get_order($order_id);
 		return array(
 			'StoreId'     => $this->store_id,
 			'CountryCode' => $this->country_code,
-			'InvoiceNo'   => get_post_meta( $order_id, '_collector_payment_id' )[0],
+			'InvoiceNo'   => $order->get_meta( '_collector_payment_id' )[0],
 		);
 	}
 }

--- a/classes/requests/soap/class-collector-checkout-soap-requests-activate-invoice.php
+++ b/classes/requests/soap/class-collector-checkout-soap-requests-activate-invoice.php
@@ -138,7 +138,6 @@ class Collector_Checkout_SOAP_Requests_Activate_Invoice {
 
 			if ( isset( $request->InvoiceUrl ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				$order->update_meta_data( '_collector_invoice_url', wc_clean( $request->InvoiceUrl ) );// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-				$order->save();
 				$due_date = gmdate( get_option( 'date_format' ) . ' - ' . get_option( 'time_format' ), strtotime( $request->DueDate ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				$due_date = sprintf( __( 'Invoice due date: %s', 'collector-checkout-for-woocommerce' ), $due_date );
 			}
@@ -146,10 +145,10 @@ class Collector_Checkout_SOAP_Requests_Activate_Invoice {
 			// translators: 1. Due date.
 			$order->add_order_note( sprintf( __( 'Order activated with Walley Checkout. %s', 'collector-checkout-for-woocommerce' ), $due_date ) );
 			$order->update_meta_data( '_collector_order_activated', time() );
-			$order->save();
 			$log = CCO_WC()->logger::format_log( $order_id, 'SOAP', 'CCO Activate order ', $args, '', wp_json_encode( $request ), '' );
 			CCO_WC()->logger::log( $log );
 
+			$order->save();
 		} else {
 			$order->update_status( $order->get_status() );
 			$failed_request = wp_json_encode( $request );
@@ -170,7 +169,7 @@ class Collector_Checkout_SOAP_Requests_Activate_Invoice {
 	 * @return array
 	 */
 	public function get_request_args( $order_id ) {
-		$order = wc_get_order($order_id);
+		$order = wc_get_order( $order_id );
 		return array(
 			'StoreId'     => $this->store_id,
 			'CountryCode' => $this->country_code,

--- a/classes/requests/soap/class-collector-checkout-soap-requests-adjust-invoice.php
+++ b/classes/requests/soap/class-collector-checkout-soap-requests-adjust-invoice.php
@@ -60,7 +60,7 @@ class Collector_Checkout_SOAP_Requests_Adjust_Invoice {
 		$this->password     = $collector_settings['collector_password'];
 		$order              = wc_get_order( $order_id );
 		$currency           = $order->get_currency();
-		$customer_type      = get_post_meta( $order_id, '_collector_customer_type', true );
+		$customer_type      = $order->get_meta( '_collector_customer_type', true );
 		switch ( $currency ) {
 			case 'SEK':
 				$country_code   = 'SE';

--- a/classes/requests/soap/class-collector-checkout-soap-requests-cancel-invoice.php
+++ b/classes/requests/soap/class-collector-checkout-soap-requests-cancel-invoice.php
@@ -59,7 +59,7 @@ class Collector_Checkout_SOAP_Requests_Cancel_Invoice {
 		$this->password     = $collector_settings['collector_password'];
 		$order              = wc_get_order( $order_id );
 		$currency           = $order->get_currency();
-		$customer_type      = get_post_meta( $order_id, '_collector_customer_type', true );
+		$customer_type      = $order->get_meta( '_collector_customer_type', true );
 
 		switch ( $currency ) {
 			case 'SEK':
@@ -146,14 +146,15 @@ class Collector_Checkout_SOAP_Requests_Cancel_Invoice {
 	 */
 	public function get_request_args( $order_id ) {
 
-		$collector_invoice_data = json_decode( get_post_meta( $order_id, '_collector_activate_invoice_data', true ), true );
+		$order = wc_get_order($order_id);
+		$collector_invoice_data = json_decode( $order->get_meta( '_collector_activate_invoice_data', true ), true );
 
 		if ( is_array( $collector_invoice_data ) && isset( $collector_invoice_data[0]['NewInvoiceNo'] ) ) {
 			// The newest invoice is the latest one. Let's use that.
 			$reversed_invoice_data = array_reverse( $collector_invoice_data );
 			$invoice_no            = $reversed_invoice_data[0]['NewInvoiceNo'];
 		} else {
-			$invoice_no = get_post_meta( $order_id, '_collector_payment_id', true );
+			$invoice_no = $order->get_meta( '_collector_payment_id', true );
 		}
 
 		return array(

--- a/classes/requests/soap/class-collector-checkout-soap-requests-cancel-invoice.php
+++ b/classes/requests/soap/class-collector-checkout-soap-requests-cancel-invoice.php
@@ -124,7 +124,8 @@ class Collector_Checkout_SOAP_Requests_Cancel_Invoice {
 
 		if ( property_exists( $request, 'CorrelationId' ) && null === $request->CorrelationId ) {// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			$order->add_order_note( sprintf( __( 'Order canceled with Collector Bank', 'collector-checkout-for-woocommerce' ) ) );
-			update_post_meta( $order_id, '_collector_order_cancelled', time() );
+			$order->update_meta_data( '_collector_order_cancelled', time() );
+			$order->save();
 			$log = CCO_WC()->logger::format_log( $order_id, 'SOAP', 'CCO Cancel order', $args, '', wp_json_encode( $request ), '' );
 			CCO_WC()->logger::log( $log );
 		} else {

--- a/classes/requests/soap/class-collector-checkout-soap-requests-credit-payment.php
+++ b/classes/requests/soap/class-collector-checkout-soap-requests-credit-payment.php
@@ -140,9 +140,9 @@ class Collector_Checkout_SOAP_Requests_Credit_Payment {
 	 * @throws SoapFault SOAP Fault.
 	 */
 	public function request_part_credit( $order_id, $amount, $reason ) {
-		$order = wc_get_order($order_id);
-		$soap = new SoapClient( $this->endpoint );
-		$args = $this->get_request_args( $order_id );
+		$order = wc_get_order( $order_id );
+		$soap  = new SoapClient( $this->endpoint );
+		$args  = $this->get_request_args( $order_id );
 
 		$headers   = array();
 		$headers[] = new SoapHeader( 'http://schemas.ecommerce.collector.se/v30/InvoiceService', 'Username', $this->username );
@@ -179,7 +179,7 @@ class Collector_Checkout_SOAP_Requests_Credit_Payment {
 	 */
 	public function get_request_args( $order_id ) {
 
-		$order = wc_get_order($order_id);
+		$order                  = wc_get_order( $order_id );
 		$collector_invoice_data = json_decode( $order->get_meta( '_collector_activate_invoice_data', true ), true );
 
 		if ( is_array( $collector_invoice_data ) && isset( $collector_invoice_data[0]['NewInvoiceNo'] ) ) {

--- a/classes/requests/soap/class-collector-checkout-soap-requests-part-activate-invoice.php
+++ b/classes/requests/soap/class-collector-checkout-soap-requests-part-activate-invoice.php
@@ -138,17 +138,14 @@ class Collector_Checkout_SOAP_Requests_Part_Activate_Invoice {
 
 			if ( isset( $request->InvoiceUrl ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				$order->update_meta_data( '_collector_invoice_url', wc_clean( $request->InvoiceUrl ) );// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-				$order->save();
 				$due_date = gmdate( get_option( 'date_format' ) . ' - ' . get_option( 'time_format' ), strtotime( $request->DueDate ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				// Translators: Invoice due date.
 				$due_date = sprintf( __( 'Invoice due date: %s.', 'collector-checkout-for-woocommerce' ), $due_date );
 			}
 
 			if ( isset( $request->NewInvoiceNo ) && ! empty( $request->NewInvoiceNo ) ) {
-
-				$parent_order_id = $order->get_parent_id();
-
 				// Save info to parent order (if one exists).
+				$parent_order_id = $order->get_parent_id();
 				if ( ! empty( $parent_order_id ) ) {
 					$collector_new_invoice_no = json_decode( get_post_meta( $parent_order_id, '_collector_activate_invoice_data', true ), true );
 					if ( is_array( $collector_new_invoice_no ) ) {
@@ -159,11 +156,9 @@ class Collector_Checkout_SOAP_Requests_Part_Activate_Invoice {
 						);
 					}
 					$order->update_meta_data( '_collector_activate_invoice_data', wp_json_encode( $collector_new_invoice_no ) );
-					$order->save();
 				}
 
 				$order->update_meta_data( '_collector_activate_invoice_data', wp_json_encode( (array) $request ) );
-				$order->save();
 			}
 
 			// translators: 1. Due date.
@@ -195,7 +190,7 @@ class Collector_Checkout_SOAP_Requests_Part_Activate_Invoice {
 	 */
 	public function get_request_args( $order_id ) {
 
-		$order = wc_get_order($order_id);
+		$order                  = wc_get_order( $order_id );
 		$collector_invoice_data = json_decode( $order->get_meta( '_collector_activate_invoice_data', true ), true );
 
 		if ( is_array( $collector_invoice_data ) && isset( $collector_invoice_data[0]['NewInvoiceNo'] ) ) {

--- a/classes/requests/soap/class-collector-checkout-soap-requests-part-activate-invoice.php
+++ b/classes/requests/soap/class-collector-checkout-soap-requests-part-activate-invoice.php
@@ -192,14 +192,15 @@ class Collector_Checkout_SOAP_Requests_Part_Activate_Invoice {
 	 */
 	public function get_request_args( $order_id ) {
 
-		$collector_invoice_data = json_decode( get_post_meta( $order_id, '_collector_activate_invoice_data', true ), true );
+		$order = wc_get_order($order_id);
+		$collector_invoice_data = json_decode( $order->get_meta( '_collector_activate_invoice_data', true ), true );
 
 		if ( is_array( $collector_invoice_data ) && isset( $collector_invoice_data[0]['NewInvoiceNo'] ) ) {
 			// The newest invoice is the latest one. Let's use that.
 			$reversed_invoice_data = array_reverse( $collector_invoice_data );
 			$invoice_no            = $reversed_invoice_data[0]['NewInvoiceNo'];
 		} else {
-			$invoice_no = get_post_meta( $order_id, '_collector_payment_id', true );
+			$invoice_no = $order->get_meta( '_collector_payment_id', true );
 		}
 		return array(
 			'StoreId'     => $this->store_id,

--- a/classes/requests/soap/class-collector-checkout-soap-requests-part-activate-invoice.php
+++ b/classes/requests/soap/class-collector-checkout-soap-requests-part-activate-invoice.php
@@ -71,7 +71,7 @@ class Collector_Checkout_SOAP_Requests_Part_Activate_Invoice {
 		$this->password     = $collector_settings['collector_password'];
 		$order              = wc_get_order( $order_id );
 		$currency           = $order->get_currency();
-		$customer_type      = get_post_meta( $order_id, '_collector_customer_type', true );
+		$customer_type      = $order->get_meta( '_collector_customer_type', true );
 
 		switch ( $currency ) {
 			case 'SEK':

--- a/classes/requests/soap/class-collector-checkout-soap-requests-part-activate-invoice.php
+++ b/classes/requests/soap/class-collector-checkout-soap-requests-part-activate-invoice.php
@@ -137,7 +137,8 @@ class Collector_Checkout_SOAP_Requests_Part_Activate_Invoice {
 		if ( isset( $request->TotalAmount ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 			if ( isset( $request->InvoiceUrl ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-				update_post_meta( $order_id, '_collector_invoice_url', wc_clean( $request->InvoiceUrl ) );// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$order->update_meta_data( '_collector_invoice_url', wc_clean( $request->InvoiceUrl ) );// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$order->save();
 				$due_date = gmdate( get_option( 'date_format' ) . ' - ' . get_option( 'time_format' ), strtotime( $request->DueDate ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				// Translators: Invoice due date.
 				$due_date = sprintf( __( 'Invoice due date: %s.', 'collector-checkout-for-woocommerce' ), $due_date );
@@ -157,16 +158,18 @@ class Collector_Checkout_SOAP_Requests_Part_Activate_Invoice {
 							(array) $request,
 						);
 					}
-					update_post_meta( $parent_order_id, '_collector_activate_invoice_data', wp_json_encode( $collector_new_invoice_no ) );
+					$order->update_meta_data( '_collector_activate_invoice_data', wp_json_encode( $collector_new_invoice_no ) );
+					$order->save();
 				}
 
-				update_post_meta( $order_id, '_collector_activate_invoice_data', wp_json_encode( (array) $request ) );
-
+				$order->update_meta_data( '_collector_activate_invoice_data', wp_json_encode( (array) $request ) );
+				$order->save();
 			}
 
 			// translators: 1. Due date.
 			$order->add_order_note( sprintf( __( 'Order part activated with Walley Checkout. Activated amount %s', 'collector-checkout-for-woocommerce' ), wc_price( $request->TotalAmount, array( 'currency' => $order->get_currency() ) ), $due_date ) );
-			update_post_meta( $order_id, '_collector_order_activated', time() );
+			$order->update_meta_data( $order_id, '_collector_order_activated', time() );
+			$order->save();
 
 			$log = CCO_WC()->logger::format_log( $order_id, 'SOAP', 'CCO Part Activate order ', $args, '', wp_json_encode( $request ), '' );
 			CCO_WC()->logger::log( $log );

--- a/classes/requests/soap/class-collector-checkout-soap-requests-part-activate-invoice.php
+++ b/classes/requests/soap/class-collector-checkout-soap-requests-part-activate-invoice.php
@@ -147,7 +147,8 @@ class Collector_Checkout_SOAP_Requests_Part_Activate_Invoice {
 				// Save info to parent order (if one exists).
 				$parent_order_id = $order->get_parent_id();
 				if ( ! empty( $parent_order_id ) ) {
-					$collector_new_invoice_no = json_decode( get_post_meta( $parent_order_id, '_collector_activate_invoice_data', true ), true );
+					$parent_order             = wc_get_order( $parent_order_id );
+					$collector_new_invoice_no = json_decode( $parent_order->get_meta( '_collector_activate_invoice_data' ), true );
 					if ( is_array( $collector_new_invoice_no ) ) {
 						$collector_new_invoice_no[] = (array) $request;
 					} else {

--- a/classes/requests/soap/class-collector-checkout-soap-requests-part-credit-invoice.php
+++ b/classes/requests/soap/class-collector-checkout-soap-requests-part-credit-invoice.php
@@ -58,7 +58,7 @@ class Collector_Checkout_SOAP_Requests_Part_Credit_Invoice {
 		$this->password     = $collector_settings['collector_password'];
 		$order              = wc_get_order( $order_id );
 		$currency           = $order->get_currency();
-		$customer_type      = get_post_meta( $order_id, '_collector_customer_type', true );
+		$customer_type      = $order->get_meta( '_collector_customer_type', true );
 		switch ( $currency ) {
 			case 'SEK':
 				$country_code   = 'SE';
@@ -153,14 +153,14 @@ class Collector_Checkout_SOAP_Requests_Part_Credit_Invoice {
 	public function get_request_args( $order_id, $amount, $reason, $refunded_items ) {
 
 		$order                  = wc_get_order( $order_id );
-		$collector_invoice_data = json_decode( get_post_meta( $order_id, '_collector_activate_invoice_data', true ), true );
+		$collector_invoice_data = json_decode( $order->get_meta( '_collector_activate_invoice_data', true ), true );
 
 		if ( is_array( $collector_invoice_data ) && isset( $collector_invoice_data[0]['NewInvoiceNo'] ) ) {
 			// The newest invoice is the latest one. Let's use that.
 			$reversed_invoice_data = array_reverse( $collector_invoice_data );
 			$invoice_no            = $reversed_invoice_data[0]['NewInvoiceNo'];
 		} else {
-			$invoice_no = get_post_meta( $order_id, '_collector_payment_id', true );
+			$invoice_no = $order->get_meta( '_collector_payment_id', true );
 		}
 		$request_args = array(
 			'StoreId'       => $this->store_id,

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -111,6 +111,8 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 			// add_action( 'init', array( $this, 'collector_maybe_schedule_action' ) );
 			// Clean Collector db.
 			add_action( 'collector_clean_db', array( $this, 'collector_clean_db_callback' ) );
+
+			add_action( 'before_woocommerce_init', array( $this, 'declare_wc_compatibility' ) );
 		}
 
 		/**
@@ -355,6 +357,18 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 					<?php
 				}
 			);
+		}
+
+		/**
+		 * Declare compatibility with WooCommerce features.
+		 *
+		 * @return void
+		 */
+		public function declare_wc_compatibility() {
+			// Declare HPOS compatibility.
+			if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+				\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+			}
 		}
 	}
 

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -812,20 +812,29 @@ function walley_confirm_order( $order, $private_id = null ) {
 		$order->update_meta_data( '_collector_delivery_module_reference', $collector_order['data']['shipping']['pendingShipment']['id'] );
 	}
 
-	if ( 'Preliminary' === $payment_status || 'Completed' === $payment_status ) {
-		$order->payment_complete( $payment_id );
-	} elseif ( 'Signing' === $payment_status ) {
-		$order->add_order_note( __( 'Order is waiting for electronic signing by customer. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
-		$order->update_meta_data( '_transaction_id', $payment_id );
-		$order->update_status( 'on-hold' );
+	if ( $order->needs_processing() ) {
+		if ( 'Preliminary' === $payment_status || 'Completed' === $payment_status ) {
+			$order->payment_complete( $payment_id );
+		} elseif ( 'Signing' === $payment_status ) {
+			$order->add_order_note( __( 'Order is waiting for electronic signing by customer. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
+			$order->set_transaction_id( $payment_id );
+			$order->update_status( 'on-hold' );
+		} else {
+			$order->add_order_note( __( 'Order is PENDING APPROVAL by Collector. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
+			$order->set_transaction_id( $payment_id );
+			$order->update_status( 'on-hold' );
+		}
+		// Translators: Collector Payment method.
+		$order->add_order_note( sprintf( __( 'Purchase via %s', 'collector-checkout-for-woocommerce' ), wc_collector_get_payment_method_name( $payment_method ) ) );
 	} else {
-		$order->add_order_note( __( 'Order is PENDING APPROVAL by Collector. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
-		$order->update_meta_data( '_transaction_id', $payment_id );
-		$order->update_status( 'on-hold' );
+
+		// If the order does not need processing, set the status to on-hold, and redirect.
+		// This is to prevent an error from attempting to complete an order before it has been moved to the order management api in Walley.
+		$order->update_meta_data( '_walley_pending_callback', 'yes' );
+		$order->set_transaction_id( $payment_id );
+		$order->update_status( 'on-hold', __( 'The payment has been completed, but awaiting callback from Walley to confirm the order.', 'collector-checkout-for-woocommerce' ) );
 	}
 
-	// Translators: Collector Payment method.
-	$order->add_order_note( sprintf( __( 'Purchase via %s', 'collector-checkout-for-woocommerce' ), wc_collector_get_payment_method_name( $payment_method ) ) );
 	$order->save();
 	return true;
 }

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -94,15 +94,12 @@ function collector_wc_show_snippet() {
 		}
 
 		if ( isset( $collector_order['data']['status'] ) && 'PurchaseCompleted' === $collector_order['data']['status'] ) {
-			$order_id = wc_collector_get_order_id_by_private_id( $private_id );
+			$order = wc_collector_get_order_by_private_id( $private_id );
 
-			if ( ! empty( $order_id ) ) {
-				$order = wc_get_order( $order_id );
-				if ( $order ) {
-					CCO_WC()->logger::log( 'Trying to display checkout but status is PurchaseCompleted. Private id ' . $private_id . ', exist in order id ' . $order_id . '. Redirecting customer to thankyou page.' );
-					wp_safe_redirect( $order->get_checkout_order_received_url() );
-					exit;
-				}
+			if ( ! empty( $order ) ) {
+				CCO_WC()->logger::log( 'Trying to display checkout but status is PurchaseCompleted. Private id ' . $private_id . ', exist in order id ' . $order->get_id() . '. Redirecting customer to thankyou page.' );
+				wp_safe_redirect( $order->get_checkout_order_received_url() );
+				exit;
 			} else {
 				CCO_WC()->logger::log( 'Trying to display checkout but status is PurchaseCompleted. Private id ' . $private_id . '. No correlating order id can be found.' );
 			}
@@ -166,12 +163,16 @@ function collector_wc_show_customer_type_switcher() {
 /**
  * Unset Collector public token and private id
  *
- * @param string $order_id WooCommerce order id.
- * @param string $product_id WooCommerce product id.
+ * @param WC_Order|int $order The WooCommerce order or order id.
+ * @param string       $product_id WooCommerce product id.
  */
-function wc_collector_add_invoice_fee_to_order( $order_id, $product_id ) {
+function wc_collector_add_invoice_fee_to_order( $order, $product_id ) {
+	// Get the order object if the order is passed as an id.
+	if ( ! is_object( $order ) ) {
+		$order = wc_get_order( $order );
+	}
+
 	$result  = false;
-	$order   = wc_get_order( $order_id );
 	$product = wc_get_product( $product_id );
 
 	if ( is_object( $product ) && is_object( $order ) ) {
@@ -257,81 +258,59 @@ function is_collector_delivery_module( $currency = false ) {
 }
 
 /**
- * Finds an Order ID based on a private ID (the Collector session id during purchase).
+ * Finds an Order based on a private ID (the Collector session id during purchase).
  *
  * @param string $private_id Collector session id saved as _collector_private_id ID in WC order.
- * @return int The ID of an order, or 0 if the order could not be found.
+ *
+ * @return WC_Order|bool The WooCommerce order if found or false if not found.
  */
-function wc_collector_get_order_id_by_private_id( $private_id = null ) {
-
+function wc_collector_get_order_by_private_id( $private_id = null ) {
 	if ( empty( $private_id ) ) {
 		return false;
 	}
 
-	$query_args = array(
-		'fields'      => 'ids',
-		'post_type'   => wc_get_order_types(),
-		'post_status' => array_keys( wc_get_order_statuses() ),
-		'meta_key'    => '_collector_private_id', // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
-		'meta_value'  => sanitize_text_field( wp_unslash( $private_id ) ), // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
-		'orderby'     => 'date',
-		'order'       => 'DESC',
-		'date_query'  => array(
-			array(
-				'after' => '120 day ago',
-			),
-		),
+	$args = array(
+		'meta_key'     => '_collector_private_id',
+		'meta_value'   => $private_id,
+		'meta_compare' => '=',
+		'order'        => 'DESC',
+		'orderby'      => 'date',
+		'limit'        => 1,
+		'date_after'   => '120 day ago',
 	);
 
-	$orders = get_posts( $query_args );
+	$orders = wc_get_orders( $args );
 
-	if ( $orders ) {
-		$order_id = $orders[0];
-	} else {
-		$order_id = 0;
+	// If the orders array is empty, return false.
+	if ( empty( $orders ) ) {
+		return false;
 	}
 
-	return $order_id;
-}
+	// Get the first order in the array.
+	$order = reset( $orders );
 
-/**
- * Finds all Orders based on a private ID (the Collector session id during purchase).
- *
- * @param string $private_id Collector session id saved as _collector_private_id ID in WC order.
- * @return array WC orders that have the specific private id saved as meta.
- */
-function wc_collector_get_orders_by_private_id( $private_id = null ) {
+	// Validate that the order actually has the metadata we're looking for, and that it is the same.
+	$meta_value = $order->get_meta( '_collector_private_id', true );
 
-	if ( empty( $private_id ) ) {
-		return array();
+	// If the meta value is not the same as the Private id, return false.
+	if ( $meta_value !== $private_id ) {
+		return false;
 	}
 
-	$query_args = array(
-		'fields'      => 'ids',
-		'post_type'   => wc_get_order_types(),
-		'post_status' => array_keys( wc_get_order_statuses() ),
-		'meta_key'    => '_collector_private_id', // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
-		'meta_value'  => sanitize_text_field( wp_unslash( $private_id ) ), // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
-		'date_query'  => array(
-			array(
-				'after' => '120 day ago',
-			),
-		),
-	);
-
-	$order_ids = get_posts( $query_args );
-
-	return $order_ids;
+	return $order;
 }
 
 /**
  * Confirm order
  *
- * @param string $order_id WC order id.
- * @param string $private_id Collector session id saved as _collector_private_id ID in WC order.
+ * @param WC_Order|int $order The WooCommerce order or order id.
+ * @param string       $private_id Collector session id saved as _collector_private_id ID in WC order.
  */
-function wc_collector_confirm_order( $order_id, $private_id = null ) {
-	$order = wc_get_order( $order_id );
+function wc_collector_confirm_order( $order, $private_id = null ) {
+	// Get the order object if the order is passed as an id.
+	if ( ! is_object( $order ) ) {
+		$order = wc_get_order( $order );
+	}
 
 	if ( empty( $private_id ) ) {
 		$private_id = $order->get_meta( '_collector_private_id', true );
@@ -372,7 +351,7 @@ function wc_collector_confirm_order( $order_id, $private_id = null ) {
 		if ( walley_use_new_api() ) {
 			$update_reference = CCO_WC()->api->set_order_reference_in_walley(
 				array(
-					'order_id'      => $order_id,
+					'order_id'      => $order->get_id(),
 					'private_id'    => $private_id,
 					'customer_type' => $customer_type,
 				)
@@ -389,7 +368,7 @@ function wc_collector_confirm_order( $order_id, $private_id = null ) {
 		$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
 		$product_id         = $collector_settings['collector_invoice_fee'];
 		if ( $product_id ) {
-			wc_collector_add_invoice_fee_to_order( $order_id, $product_id );
+			wc_collector_add_invoice_fee_to_order( $order->get_id(), $product_id );
 		}
 	}
 
@@ -397,21 +376,20 @@ function wc_collector_confirm_order( $order_id, $private_id = null ) {
 	$order->update_meta_data( '_collector_payment_id', $payment_id );
 	$order->update_meta_data( '_collector_order_id', sanitize_key( $walley_order_id ) );
 	$order->save();
-	wc_collector_save_shipping_reference_to_order( $order_id, $collector_order );
+	wc_collector_save_shipping_reference_to_order( $order->get_id(), $collector_order );
 
 	if ( 'Preliminary' === $payment_status || 'Completed' === $payment_status ) {
 		$order->payment_complete( $payment_id );
 	} elseif ( 'Signing' === $payment_status ) {
 		$order->add_order_note( __( 'Order is waiting for electronic signing by customer. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
 		$order->update_meta_data( '_transaction_id', $payment_id );
-		$order->save();
-
 		$order->update_status( 'on-hold' );
+		$order->save();
 	} else {
 		$order->add_order_note( __( 'Order is PENDING APPROVAL by Collector. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
 		$order->add_meta_data( '_transaction_id', $payment_id );
+		$order->update_status( 'on-hold' );
 		$order->save();
-		$order->update_meta_data( 'on-hold' );
 	}
 
 	// Translators: Collector Payment method.
@@ -421,12 +399,16 @@ function wc_collector_confirm_order( $order_id, $private_id = null ) {
 /**
  * Saving shipping reference to order
  *
- * @param int   $order_id WooCommerce order id.
- * @param array $collector_order Collector payment data.
+ * @param WC_Order|int $order The WooCommerce order or order id.
+ * @param array        $collector_order Collector payment data.
  * @return void
  */
-function wc_collector_save_shipping_reference_to_order( $order_id, $collector_order ) {
-	$order = wc_get_order( $order_id );
+function wc_collector_save_shipping_reference_to_order( $order, $collector_order ) {
+	// Get the order object if the order is passed as an id.
+	if ( ! is_object( $order ) ) {
+		$order = wc_get_order( $order );
+	}
+
 	$order_items = $collector_order['data']['order']['items'] ?? array();
 	foreach ( $order_items as $item ) {
 		if ( strpos( $item['id'], 'shipping|' ) !== false ) {
@@ -443,7 +425,6 @@ function wc_collector_save_shipping_reference_to_order( $order_id, $collector_or
  * @return array
  */
 function wc_collector_allowed_tags() {
-
 	$allowed_tags = array(
 		'a'          => array(
 			'class' => array(),
@@ -733,11 +714,14 @@ function walley_get_order_id_by_public_token( $public_token ) {
 /**
  * Confirm order
  *
- * @param string $order_id WC order id.
- * @param string $private_id Collector session id saved as _collector_private_id ID in WC order.
+ * @param WC_Order|int $order The WooCommerce order or order id.
+ * @param string       $private_id Collector session id saved as _collector_private_id ID in WC order.
  */
-function walley_confirm_order( $order_id, $private_id = null ) {
-	$order = wc_get_order( $order_id );
+function walley_confirm_order( $order, $private_id = null ) {
+	// Get the order object if the order is passed as an id.
+	if ( ! is_object( $order ) ) {
+		$order = wc_get_order( $order );
+	}
 
 	// Check if the order has been confirmed already.
 	if ( ! empty( $order->get_date_paid() ) ) {
@@ -783,7 +767,7 @@ function walley_confirm_order( $order_id, $private_id = null ) {
 		if ( walley_use_new_api() ) {
 			$update_reference = CCO_WC()->api->set_order_reference_in_walley(
 				array(
-					'order_id'      => $order_id,
+					'order_id'      => $order->get_id(),
 					'private_id'    => $private_id,
 					'customer_type' => $customer_type,
 				)
@@ -800,41 +784,40 @@ function walley_confirm_order( $order_id, $private_id = null ) {
 		$collector_settings = get_option( 'woocommerce_collector_checkout_settings' );
 		$product_id         = $collector_settings['collector_invoice_fee'];
 		if ( $product_id ) {
-			wc_collector_add_invoice_fee_to_order( $order_id, $product_id );
+			wc_collector_add_invoice_fee_to_order( $order, $product_id );
 		}
 	}
 
 	$order->update_meta_data( '_collector_payment_method', $payment_method );
 	$order->update_meta_data( '_collector_payment_id', $payment_id );
 	$order->update_meta_data( '_collector_order_id', sanitize_key( $walley_order_id ) );
-	$order->save();
 
-	wc_collector_save_shipping_reference_to_order( $order_id, $collector_order );
+	wc_collector_save_shipping_reference_to_order( $order, $collector_order );
 
 	// Save custom fields data.
-	walley_save_custom_fields( $order_id, $collector_order );
+	walley_save_custom_fields( $order, $collector_order );
 
 	// Save shipping data.
 	if ( isset( $collector_order['data']['shipping'] ) ) {
 		$order->update_meta_data( '_collector_delivery_module_data', wp_json_encode( $collector_order['data']['shipping'], JSON_UNESCAPED_UNICODE ) );
 		$order->update_meta_data( '_collector_delivery_module_reference', $collector_order['data']['shipping']['pendingShipment']['id'] );
-		$order->save();
 	}
 
 	if ( 'Preliminary' === $payment_status || 'Completed' === $payment_status ) {
 		$order->payment_complete( $payment_id );
 	} elseif ( 'Signing' === $payment_status ) {
 		$order->add_order_note( __( 'Order is waiting for electronic signing by customer. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
-		update_post_meta( $order_id, '_transaction_id', $payment_id );
+		$order->update_meta_data( '_transaction_id', $payment_id );
 		$order->update_status( 'on-hold' );
 	} else {
 		$order->add_order_note( __( 'Order is PENDING APPROVAL by Collector. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
-		update_post_meta( $order_id, '_transaction_id', $payment_id );
+		$order->update_meta_data( '_transaction_id', $payment_id );
 		$order->update_status( 'on-hold' );
 	}
 
 	// Translators: Collector Payment method.
 	$order->add_order_note( sprintf( __( 'Purchase via %s', 'collector-checkout-for-woocommerce' ), wc_collector_get_payment_method_name( $payment_method ) ) );
+	$order->save();
 	return true;
 }
 
@@ -880,7 +863,7 @@ function walley_add_rounding_order_line() {
  * @return string
  */
 function walley_get_shipping_reference_from_delivery_module_data( $order_id ) {
-	$order = wc_get_order($order_id);
+	$order                   = wc_get_order( $order_id );
 	$collector_delivery_data = json_decode( $order->get_meta( '_collector_delivery_module_data', true ), true ) ?? array();
 	$shipping_reference      = $collector_delivery_data['shippingFeeId'] ?? '';
 	return $shipping_reference;
@@ -921,14 +904,16 @@ function walley_get_cart_shipping_classes() {
 /**
  * Save custom fields to WooCommerce order if they exist in Walley order.
  *
- * @param int   $order_id WooCommerce order ID.
- * @param array $walley_order Walley order data.
+ * @param WC_Order|int $order The WooCommerce order or order id.
+ * @param array        $walley_order Walley order data.
  *
  * @return void
  */
-function walley_save_custom_fields( $order_id, $walley_order ) {
-
-	$order = wc_get_order( $order_id );
+function walley_save_custom_fields( $order, $walley_order ) {
+	// Get the order object if the order is passed as an id.
+	if ( ! is_object( $order ) ) {
+		$order = wc_get_order( $order );
+	}
 
 	// Save customFields data.
 	if ( is_object( $order ) && isset( $walley_order['data']['customFields'] ) ) {

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -808,9 +808,10 @@ function walley_confirm_order( $order_id, $private_id = null ) {
 		}
 	}
 
-	update_post_meta( $order_id, '_collector_payment_method', $payment_method );
-	update_post_meta( $order_id, '_collector_payment_id', $payment_id );
-	update_post_meta( $order_id, '_collector_order_id', sanitize_key( $walley_order_id ) );
+	$order->update_meta_data( '_collector_payment_method', $payment_method );
+	$order->update_meta_data( '_collector_payment_id', $payment_id );
+	$order->update_meta_data( '_collector_order_id', sanitize_key( $walley_order_id ) );
+	$order->save();
 
 	wc_collector_save_shipping_reference_to_order( $order_id, $collector_order );
 
@@ -819,8 +820,9 @@ function walley_confirm_order( $order_id, $private_id = null ) {
 
 	// Save shipping data.
 	if ( isset( $collector_order['data']['shipping'] ) ) {
-		update_post_meta( $order_id, '_collector_delivery_module_data', wp_json_encode( $collector_order['data']['shipping'], JSON_UNESCAPED_UNICODE ) );
-		update_post_meta( $order_id, '_collector_delivery_module_reference', $collector_order['data']['shipping']['pendingShipment']['id'] );
+		$order->update_meta_data( '_collector_delivery_module_data', wp_json_encode( $collector_order['data']['shipping'], JSON_UNESCAPED_UNICODE ) );
+		$order->update_meta_data( '_collector_delivery_module_reference', $collector_order['data']['shipping']['pendingShipment']['id'] );
+		$order->save();
 	}
 
 	if ( 'Preliminary' === $payment_status || 'Completed' === $payment_status ) {

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -375,7 +375,6 @@ function wc_collector_confirm_order( $order, $private_id = null ) {
 	$order->update_meta_data( '_collector_payment_method', $payment_method );
 	$order->update_meta_data( '_collector_payment_id', $payment_id );
 	$order->update_meta_data( '_collector_order_id', sanitize_key( $walley_order_id ) );
-	$order->save();
 	wc_collector_save_shipping_reference_to_order( $order->get_id(), $collector_order );
 
 	if ( 'Preliminary' === $payment_status || 'Completed' === $payment_status ) {
@@ -384,16 +383,15 @@ function wc_collector_confirm_order( $order, $private_id = null ) {
 		$order->add_order_note( __( 'Order is waiting for electronic signing by customer. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
 		$order->update_meta_data( '_transaction_id', $payment_id );
 		$order->update_status( 'on-hold' );
-		$order->save();
 	} else {
 		$order->add_order_note( __( 'Order is PENDING APPROVAL by Collector. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
 		$order->add_meta_data( '_transaction_id', $payment_id );
 		$order->update_status( 'on-hold' );
-		$order->save();
 	}
 
 	// Translators: Collector Payment method.
 	$order->add_order_note( sprintf( __( 'Purchase via %s', 'collector-checkout-for-woocommerce' ), wc_collector_get_payment_method_name( $payment_method ) ) );
+	$order->save();
 }
 
 /**

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -925,7 +925,7 @@ function walley_save_custom_fields( $order, $walley_order ) {
 	}
 
 	// Save customFields data.
-	if ( is_object( $order ) && isset( $walley_order['data']['customFields'] ) ) {
+	if ( ! empty( $order ) && isset( $walley_order['data']['customFields'] ) ) {
 
 		// Save the entire customFields object as json in order.
 		if ( apply_filters( 'walley_save_custom_fields_raw_data', true ) ) {

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -179,8 +179,7 @@ function wc_collector_add_invoice_fee_to_order( $order, $product_id ) {
 	$product = wc_get_product( $product_id );
 
 	if ( is_object( $product ) && is_object( $order ) ) {
-		$tax_display_mode = get_option( 'woocommerce_tax_display_shop' );
-		$price            = wc_get_price_excluding_tax( $product );
+		$price = wc_get_price_excluding_tax( $product );
 
 		if ( $product->is_taxable() ) {
 			$product_tax = true;
@@ -406,7 +405,7 @@ function wc_collector_confirm_order( $order, $private_id = null ) {
  */
 function wc_collector_save_shipping_reference_to_order( $order, $collector_order ) {
 	// Get the order object if the order is passed as an id.
-	if ( ! is_object( $order ) ) {
+	if ( ! $order instanceof WC_Order ) {
 		$order = wc_get_order( $order );
 	}
 
@@ -414,9 +413,10 @@ function wc_collector_save_shipping_reference_to_order( $order, $collector_order
 	foreach ( $order_items as $item ) {
 		if ( strpos( $item['id'], 'shipping|' ) !== false ) {
 			$order->update_meta_data( '_collector_shipping_reference', $item['id'] );
-			$order->save();
 		}
 	}
+
+	$order->save();
 }
 
 /**
@@ -725,8 +725,8 @@ function walley_get_order_by_key( $key, $value ) {
  * @param string       $private_id Collector session id saved as _collector_private_id ID in WC order.
  */
 function walley_confirm_order( $order, $private_id = null ) {
-	// Get the order object if the order is passed as an id.
-	if ( ! is_object( $order ) ) {
+	// Get the Woo order if the order is passed as an int.
+	if ( ! $order instanceof WC_Order ) {
 		$order = wc_get_order( $order );
 	}
 
@@ -759,6 +759,8 @@ function walley_confirm_order( $order, $private_id = null ) {
 
 	if ( is_wp_error( $collector_order ) ) {
 		$order->add_order_note( __( 'Could not retreive Walley order during walley_confirm_order function.', 'collector-checkout-for-woocommerce' ) );
+		$order->save();
+
 		return false;
 	}
 
@@ -926,12 +928,12 @@ function walley_save_custom_fields( $order, $walley_order ) {
 	if ( is_object( $order ) && isset( $walley_order['data']['customFields'] ) ) {
 
 		// Save the entire customFields object as json in order.
-		if ( true === apply_filters( 'walley_save_custom_fields_raw_data', true ) ) {
+		if ( apply_filters( 'walley_save_custom_fields_raw_data', true ) ) {
 			$order->update_meta_data( '_collector_custom_fields', wp_json_encode( $walley_order['data']['customFields'] ) );
 		}
 
 		// Save each individual custom field as id:value.
-		if ( true === apply_filters( 'walley_save_individual_custom_field', true ) ) {
+		if ( apply_filters( 'walley_save_individual_custom_field', true ) ) {
 			foreach ( $walley_order['data']['customFields'] as $custom_field_group ) {
 
 				foreach ( $custom_field_group['fields'] as $custom_field ) {

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -336,10 +336,10 @@ function wc_collector_confirm_order( $order_id, $private_id = null ) {
 	$order = wc_get_order( $order_id );
 
 	if ( empty( $private_id ) ) {
-		$private_id = get_post_meta( $order_id, '_collector_private_id', true );
+		$private_id = $order->get_meta( '_collector_private_id', true );
 	}
 
-	$customer_type = get_post_meta( $order_id, '_collector_customer_type', true );
+	$customer_type = $order->get_meta( '_collector_customer_type', true );
 	if ( empty( $customer_type ) ) {
 		$customer_type = 'b2c';
 	}
@@ -743,10 +743,10 @@ function walley_confirm_order( $order_id, $private_id = null ) {
 	}
 
 	if ( empty( $private_id ) ) {
-		$private_id = get_post_meta( $order_id, '_collector_private_id', true );
+		$private_id = $order->get_meta( '_collector_private_id', true );
 	}
 
-	$customer_type = get_post_meta( $order_id, '_collector_customer_type', true );
+	$customer_type = $order->get_meta( '_collector_customer_type', true );
 	if ( empty( $customer_type ) ) {
 		$customer_type = 'b2c';
 	}
@@ -876,7 +876,8 @@ function walley_add_rounding_order_line() {
  * @return string
  */
 function walley_get_shipping_reference_from_delivery_module_data( $order_id ) {
-	$collector_delivery_data = json_decode( get_post_meta( $order_id, '_collector_delivery_module_data', true ), true ) ?? array();
+	$order = wc_get_order($order_id);
+	$collector_delivery_data = json_decode( $order->get_meta( '_collector_delivery_module_data', true ), true ) ?? array();
 	$shipping_reference      = $collector_delivery_data['shippingFeeId'] ?? '';
 	return $shipping_reference;
 }

--- a/includes/collector-status-report.php
+++ b/includes/collector-status-report.php
@@ -39,7 +39,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 				$amount_of_api_callback_orders = 0;
 				foreach ( $orders as $order_id ) {
 
-					if ( 'collector_checkout_api' === get_post_meta( $order_id, '_created_via', true ) ) {
+					$order = wc_get_order($order_id);
+					if ( 'collector_checkout_api' === $order->get_meta( '_created_via', true ) ) {
 						$amount_of_api_callback_orders++;
 					}
 				}


### PR DESCRIPTION
As described in the [recipe book](https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book):
- `get_post( $post_id )` → `wc_get_order( $post_id )`
- `update_post_meta` → `WC_Order::update_meta_data`
- `add_post_meta` → `WC_Order::add_meta_data`
- `delete_post_meta` → `WC_Order::delete_meta_data`

Furthermore, where applicable, if a method is available for the meta field, that will be used in favor of retrieving it through the meta data function.  For example,  

```
get_post_meta($order_id, '_transaction_id', true)
```
is replaced with 
```
WC_Order::get_transaction_id()
```

If a meta data function is available, and `update_meta_data` is still used, WooCommerce will warn about directly modifying internal meta data.

Note:
1. The HPOS-related methods _must_ be followed at some point by a `save()` call.
2. The recipe book does not seem to reference a replacement for `get_post_meta`, but this should be replaced by `WC_Order::get_meta`.

## Changelog

These are changes that were added in addition to HPOS support.

- if `get_walley_order` is called without an ID, a `WP_Error` will be returned (see [slack](https://krokedil.slack.com/archives/C04LGJDP89Z/p1715694377083319)).
- call `walley_confirm_order` even for orders that do not need processing. This ensures that necessary metadata is added in one function, and fixes the issue where it was missing for orders that do not need processing (e.g., "virtual + downloadable" only products in  carts).
- check if cart is empty after calculate totals. This should prevent 4xx errors where we try to update an "empty" Walley order.
- removed redundant `$order` initialization in `process_payment`.
- refactor `is_available` to reduce `if` nesting.