### PR TITLE
Convert string to float before calculation

### DIFF
--- a/classes/class-walley-part-payment-widget.php
+++ b/classes/class-walley-part-payment-widget.php
@@ -221,7 +221,7 @@ class Walley_Part_Payment_Widget {
 		}
 
 		// Else return the price.
-		return $product->get_price() * 100;
+		return floatval( $product->get_price() ) * 100;
 	}
 
 	/**


### PR DESCRIPTION
`get_price` sometimes return a `string`. This causes a critical error when attempting to multiply it by an integer.

Task: https://app.clickup.com/t/869517b1t