### PR TITLE
wc_get_log_file_path has been deprecated without replacement

### DIFF
--- a/includes/collector-checkout-settings.php
+++ b/includes/collector-checkout-settings.php
@@ -269,12 +269,10 @@ $settings = array(
 		'default' => 'no',
 	),
 	'debug_mode'                      => array(
-		'title'       => __( 'Debug', 'collector-checkout-for-woocommerce' ),
-		'type'        => 'checkbox',
-		'label'       => __( 'Enable logging.', 'collector-checkout-for-woocommerce' ),
-		/* Translators: link to logs */
-		'description' => sprintf( __( 'Log Walley events, in <code>%s</code>', 'collector-checkout-for-woocommerce' ), wc_get_log_file_path( 'collector_checkout' ) ),
-		'default'     => 'no',
+		'title'   => __( 'Debug', 'collector-checkout-for-woocommerce' ),
+		'type'    => 'checkbox',
+		'label'   => __( 'Enable logging.', 'collector-checkout-for-woocommerce' ),
+		'default' => 'no',
 	),
 );
 


### PR DESCRIPTION
wc_get_log_file_path has been removed without a replacement. See https://github.com/woocommerce/woocommerce/discussions/44369

https://app.clickup.com/t/86959g5kv