### PR TITLE
Define $manage_orders

### DIFF
--- a/classes/class-walley-checkout-meta-box.php
+++ b/classes/class-walley-checkout-meta-box.php
@@ -115,6 +115,9 @@ class Walley_Checkout_Meta_Box {
 			);
 		}
 		$keys_for_meta_box = apply_filters( 'walley_checkout_meta_box_keys', $keys_for_meta_box );
+
+		// DO NOT REMOVE! Used in the template file.
+		$manage_orders = wc_string_to_bool( get_option( 'woocommerce_collector_checkout_settings', array() )['manage_collector_orders'] ?? 'no' );
 		include COLLECTOR_BANK_PLUGIN_DIR . '/templates/walley-checkout-meta-box.php';
 	}
 } new Walley_Checkout_Meta_Box();

--- a/templates/walley-checkout-meta-box.php
+++ b/templates/walley-checkout-meta-box.php
@@ -2,7 +2,7 @@
 /**
  * The HTML for the admin order metabox content.
  *
- * @package Briqpay_For_WooCommerce/Templates
+ * @package Collector_Checkout/Templates
  */
 
 foreach ( $keys_for_meta_box as $item ) {
@@ -11,7 +11,8 @@ foreach ( $keys_for_meta_box as $item ) {
 	<?php
 }
 
-if ( 'yes' !== $manage_orders ) {
+$manage_orders = get_option( 'woocommerce_collector_checkout_settings', array() )['manage_collector_orders'] ?? 'no';
+if ( ! ( isset( $manage_orders ) || wc_string_to_bool( $manage_orders ) ) ) {
 	return;
 }
 

--- a/templates/walley-checkout-meta-box.php
+++ b/templates/walley-checkout-meta-box.php
@@ -11,8 +11,8 @@ foreach ( $keys_for_meta_box as $item ) {
 	<?php
 }
 
-$manage_orders = get_option( 'woocommerce_collector_checkout_settings', array() )['manage_collector_orders'] ?? 'no';
-if ( ! ( isset( $manage_orders ) || wc_string_to_bool( $manage_orders ) ) ) {
+// Declared in class-walley-checkout-meta-box.php.
+if ( ! isset( $manage_orders ) || false === $manage_orders ) {
 	return;
 }
 


### PR DESCRIPTION
Seems like `$manage_orders` was accidentally removed in PR #219. Probably recognized as an unused variable whereas it is used in the template file. I've decided to move it to the template file to avoid this from happening again.

https://app.clickup.com/t/8695fjcqk