### PR TITLE
Declare needed class properties

### DIFF
--- a/classes/class-collector-checkout-admin-notices.php
+++ b/classes/class-collector-checkout-admin-notices.php
@@ -21,6 +21,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Collector_Checkout_Admin_Notices {
 
 	/**
+	 * The enabled setting.
+	 *
+	 * @var string
+	 */
+	private $enabled;
+
+	/**
 	 * Collector_Checkout_Admin_Notices constructor.
 	 */
 	public function __construct() {
@@ -74,8 +81,6 @@ class Collector_Checkout_Admin_Notices {
 			echo '</div>';
 		}
 	}
-
-
 }
 
 $collector_checkout_admin_notices = new Collector_Checkout_Admin_Notices();

--- a/classes/class-collector-checkout-gateway.php
+++ b/classes/class-collector-checkout-gateway.php
@@ -13,6 +13,70 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Class Collector_Checkout_Gateway
  */
 class Collector_Checkout_Gateway extends WC_Payment_Gateway {
+
+	/**
+	 * The id of the gateway.
+	 *
+	 * @var string
+	 */
+	public $id;
+
+	/**
+	 * The method title.
+	 *
+	 * @var string
+	 */
+	public $method_title;
+
+	/**
+	 * The method description.
+	 *
+	 * @var string
+	 */
+	public $method_description;
+
+	/**
+	 * The title of the gateway.
+	 *
+	 * @var string
+	 */
+	public $title;
+
+	/**
+	 * The description of the gateway.
+	 *
+	 * @var string
+	 */
+	public $description;
+
+	/**
+	 * The enabled setting.
+	 *
+	 * @var string
+	 */
+	public $enabled;
+
+	/**
+	 * The Walley API client id.
+	 *
+	 * @var string
+	 */
+	public $walley_api_client_id;
+
+	/**
+	 * The Walley API secret.
+	 *
+	 * @var string
+	 */
+	public $walley_api_secret;
+
+	/**
+	 * The delivery module setting.
+	 *
+	 * @var string
+	 */
+	public $delivery_module;
+
 	/**
 	 * Class constructor.
 	 */

--- a/classes/class-collector-checkout-post-checkout.php
+++ b/classes/class-collector-checkout-post-checkout.php
@@ -15,6 +15,28 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Collector_Checkout_Post_Checkout {
 
 	/**
+	 * The manage orders setting.
+	 *
+	 * @var string
+	 */
+	private $manage_orders;
+
+	/**
+	 * The display invoice number setting.
+	 *
+	 * @var string
+	 */
+	private $display_invoice_no;
+
+	/**
+	 * The activate individual order lines setting.
+	 *
+	 * @var string
+	 */
+	private $activate_individual_order_lines;
+
+
+	/**
 	 * Class constructor
 	 */
 	public function __construct() {
@@ -163,4 +185,3 @@ class Collector_Checkout_Post_Checkout {
 		return $order_number;
 	}
 }
-

--- a/classes/class-collector-checkout-product-fields.php
+++ b/classes/class-collector-checkout-product-fields.php
@@ -19,6 +19,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Collector_Checkout_Product_Fields {
 
 	/**
+	 * The add product fields setting.
+	 *
+	 * @var string
+	 */
+	private $add_product_fields;
+
+	/**
 	 * Class constructor.
 	 */
 	public function __construct() {
@@ -50,7 +57,6 @@ class Collector_Checkout_Product_Fields {
 			'description' => __( 'If this product requires Electronic ID signing in Walley Checkout.', 'kroconnect-extra-fields' ),
 		);
 		woocommerce_wp_checkbox( $args );
-
 	}
 
 	/**
@@ -66,7 +72,5 @@ class Collector_Checkout_Product_Fields {
 		$product->update_meta_data( '_collector_requires_electronic_id', sanitize_text_field( $collector_requires_electronic_id ) );
 		$product->save();
 	}
-
-
 }
 new Collector_Checkout_Product_Fields();

--- a/classes/class-collector-checkout-shipping-method.php
+++ b/classes/class-collector-checkout-shipping-method.php
@@ -17,6 +17,55 @@ if ( class_exists( 'WC_Shipping_Method' ) ) {
 	class Collector_Delivery_Module_Shipping_Method extends WC_Shipping_Method {
 
 		/**
+		 * The shipping method id.
+		 *
+		 * @var string
+		 */
+		public $id;
+
+		/**
+		 * The shipping method instance id.
+		 *
+		 * @var integer
+		 */
+		public $instance_id;
+
+		/**
+		 * The shipping method title.
+		 *
+		 * @var string
+		 */
+		public $title;
+
+		/**
+		 * The shipping method method title.
+		 *
+		 * @var string
+		 */
+		public $method_title;
+
+		/**
+		 * The shipping method method description.
+		 *
+		 * @var string
+		 */
+		public $method_description;
+
+		/**
+		 * The shipping method supports.
+		 *
+		 * @var array
+		 */
+		public $supports;
+
+		/**
+		 * The shipping method collector tax amount.
+		 *
+		 * @var boolean
+		 */
+		public $collector_tax_amount;
+
+		/**
 		 * Class constructor.
 		 *
 		 * @param integer $instance_id The instance id.

--- a/classes/class-collector-checkout-templates.php
+++ b/classes/class-collector-checkout-templates.php
@@ -21,6 +21,13 @@ class Collector_Checkout_Templates {
 	protected static $instance;
 
 	/**
+	 * Checkout layout.
+	 *
+	 * @var string
+	 */
+	protected $checkout_layout;
+
+	/**
 	 * Returns the *Singleton* instance of this class.
 	 *
 	 * @return self::$instance The *Singleton* instance.

--- a/classes/class-walley-checkout-order-actions.php
+++ b/classes/class-walley-checkout-order-actions.php
@@ -10,7 +10,28 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class Walley_Checkout_Order_Actions
  */
-class  Walley_Checkout_Order_Actions {
+class Walley_Checkout_Order_Actions {
+
+	/**
+	 * The manage orders setting.
+	 *
+	 * @var string
+	 */
+	private $manage_orders;
+
+	/**
+	 * The display invoice number setting.
+	 *
+	 * @var string
+	 */
+	private $display_invoice_no;
+
+	/**
+	 * The activate individual order lines setting.
+	 *
+	 * @var string
+	 */
+	private $activate_individual_order_lines;
 
 	/**
 	 * Class constructor

--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -13,6 +13,27 @@ defined( 'ABSPATH' ) || exit;
 class Walley_Checkout_Order_Management {
 
 	/**
+	 * The manage orders setting.
+	 *
+	 * @var string
+	 */
+	private $manage_orders;
+
+	/**
+	 * The display invoice number setting.
+	 *
+	 * @var string
+	 */
+	private $display_invoice_no;
+
+	/**
+	 * The activate individual order lines setting.
+	 *
+	 * @var string
+	 */
+	private $activate_individual_order_lines;
+
+	/**
 	 * Class constructor
 	 */
 	public function __construct() {

--- a/classes/requests/helpers/class-collector-checkout-requests-helper-order-fees.php
+++ b/classes/requests/helpers/class-collector-checkout-requests-helper-order-fees.php
@@ -29,6 +29,13 @@ class Collector_Checkout_Requests_Helper_Order_Fees {
 	public $price = 0;
 
 	/**
+	 * Delivery module
+	 *
+	 * @var string
+	 */
+	public $delivery_module;
+
+	/**
 	 * Class constructor.
 	 */
 	public function __construct() {

--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -59,6 +59,48 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 		protected static $instance;
 
 		/**
+		 * The Walley API client id.
+		 *
+		 * @var string
+		 */
+		protected $walley_api_client_id;
+
+		/**
+		 * The Walley API secret.
+		 *
+		 * @var string
+		 */
+		protected $walley_api_secret;
+
+		/**
+		 * The API class.
+		 *
+		 * @var Walley_Checkout_API
+		 */
+		protected $api;
+
+		/**
+		 * The Order Management class.
+		 *
+		 * @var Walley_Checkout_Order_Management
+		 */
+		protected $order_management;
+
+		/**
+		 * The Order Items class.
+		 *
+		 * @var Collector_Checkout_Requests_Helper_Order
+		 */
+		protected $order_items;
+
+		/**
+		 * The Order Fees class.
+		 *
+		 * @var Collector_Checkout_Requests_Helper_Order_Fees
+		 */
+		protected $order_fees;
+
+		/**
 		 * Returns the *Singleton* instance of this class.
 		 *
 		 * @return self::$instance The *Singleton* instance.


### PR DESCRIPTION
Declare needed class properties throughout the plugin, to resolve PHP "Creation of dynamic property is deprecated" warning.