### PR TITLE
Set customer type to environment variables

### DIFF
--- a/classes/requests/widgets/post/class-walley-create-widget-token.php
+++ b/classes/requests/widgets/post/class-walley-create-widget-token.php
@@ -18,8 +18,9 @@ class Walley_Create_Widget_Token extends Walley_Checkout_Request_Post {
 	 * @param  array $arguments  The request arguments.
 	 */
 	public function __construct( $arguments = array() ) {
+		$customer_type = WC()->session->get( 'collector_customer_type' ) ?? 'b2c';
 		parent::__construct( $arguments );
-		$this->set_environment_variables();
+		$this->set_environment_variables( array( 'customer_type' => $customer_type ) );
 		$this->log_title = 'Create Widget Token';
 	}
 

--- a/classes/requests/widgets/post/class-walley-create-widget-token.php
+++ b/classes/requests/widgets/post/class-walley-create-widget-token.php
@@ -18,7 +18,7 @@ class Walley_Create_Widget_Token extends Walley_Checkout_Request_Post {
 	 * @param  array $arguments  The request arguments.
 	 */
 	public function __construct( $arguments = array() ) {
-		$customer_type = WC()->session->get( 'collector_customer_type' ) ?? 'b2c';
+		$customer_type = wc_collector_get_selected_customer_type();
 		parent::__construct( $arguments );
 		$this->set_environment_variables( array( 'customer_type' => $customer_type ) );
 		$this->log_title = 'Create Widget Token';


### PR DESCRIPTION
Set customer type to environment variables, to avoid issue with part payment widget not showing up for B2B configurations.