### PR TITLE
Change needed property to public

### DIFF
--- a/collector-checkout-for-woocommerce.php
+++ b/collector-checkout-for-woocommerce.php
@@ -77,7 +77,7 @@ if ( ! class_exists( 'Collector_Checkout' ) ) {
 		 *
 		 * @var Walley_Checkout_API
 		 */
-		protected $api;
+		public $api;
 
 		/**
 		 * The Order Management class.


### PR DESCRIPTION
Change needed property to public, to avoid fatal error on checkout.