### PR TITLE
Add check if order is not found

### DIFF
--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -280,7 +280,7 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 		$order              = wc_get_order( $order_id );
 
 		// If something went wrong in get_customer_data() - display a "thank you page light".
-		if ( 'not-completed' === $purchase_status ) {
+		if ( empty( $order ) || 'not-completed' === $purchase_status ) {
 			$public_token = filter_input( INPUT_POST, 'public_token', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			if ( WC()->session->get( 'collector_customer_type' ) ) {
 				$customer_type = WC()->session->get( 'collector_customer_type' );


### PR DESCRIPTION
If order is not found in `get_checkout_thank_you`, also show the "Thank you light", to avoid fatal error when attempting to get order meta.

Is it plausible that this could happen without any other issues being present, or should I troubleshoot the cause of this?