### PR TITLE
Add "Rejected" callback handling & Refactor

### DIFF
--- a/classes/class-collector-checkout-api-callbacks.php
+++ b/classes/class-collector-checkout-api-callbacks.php
@@ -157,6 +157,10 @@ class Collector_Api_Callbacks {
 			update_post_meta( $order->get_id(), '_transaction_id', $collector_order['data']['purchase']['purchaseIdentifier'] );
 			$order->update_status( 'on-hold' );
 			CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to On hold.' );
+		} elseif ( 'Rejected' === $collector_order['data']['purchase']['result'] ) {
+			$order->add_order_note( __( 'Order is REJECTED by Walley. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $collector_order['data']['purchase']['purchaseIdentifier'] );
+			$order->update_status( 'failed' );
+			CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to Failed.' );
 		} else {
 			$order->add_order_note( __( 'Order is PENDING APPROVAL by Walley. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $collector_order['data']['purchase']['purchaseIdentifier'] );
 			$order->update_status( 'on-hold' );

--- a/classes/class-collector-checkout-api-callbacks.php
+++ b/classes/class-collector-checkout-api-callbacks.php
@@ -129,7 +129,7 @@ class Collector_Api_Callbacks {
 				$payment_id     = $collector_order['data']['purchase']['purchaseIdentifier'];
 
 				// Set order status in Woo.
-				set_order_status( $order, $payment_status, $payment_id );
+				walley_set_order_status( $order, $payment_status, $payment_id );
 
 				$order->save();
 			}

--- a/classes/class-collector-checkout-api-callbacks.php
+++ b/classes/class-collector-checkout-api-callbacks.php
@@ -129,7 +129,7 @@ class Collector_Api_Callbacks {
 				$payment_id     = $collector_order['data']['purchase']['purchaseIdentifier'];
 
 				// Set order status in Woo.
-				walley_set_order_status( $order, $payment_status, $payment_id, false );
+				walley_set_order_status( $order, $payment_status, $payment_id, false, true );
 
 				$order->save();
 			}

--- a/classes/class-collector-checkout-api-callbacks.php
+++ b/classes/class-collector-checkout-api-callbacks.php
@@ -125,8 +125,13 @@ class Collector_Api_Callbacks {
 
 			// Check order status.
 			if ( empty( $order->get_date_paid() ) ) {
+				$payment_status = $collector_order['data']['purchase']['result'];
+				$payment_id     = $collector_order['data']['purchase']['purchaseIdentifier'];
+
 				// Set order status in Woo.
-				$this->set_order_status( $order, $collector_order );
+				set_order_status( $order, $payment_status, $payment_id );
+
+				$order->save();
 			}
 
 			// Compare order totals between the orders.
@@ -136,35 +141,6 @@ class Collector_Api_Callbacks {
 			if ( empty( $collector_order['data']['reference'] ) ) {
 				$this->update_order_reference_in_collector( $order, $customer_type, $private_id );
 			}
-		}
-	}
-
-	/**
-	 * Set order status function
-	 *
-	 * @param WC_Order $order The WooCommerce order.
-	 * @param array    $collector_order The Collector order.
-	 *
-	 * @return void
-	 */
-	public function set_order_status( $order, $collector_order ) {
-		if ( 'Preliminary' === $collector_order['data']['purchase']['result'] || 'Completed' === $collector_order['data']['purchase']['result'] ) {
-			$order->payment_complete( $collector_order['data']['purchase']['purchaseIdentifier'] );
-			$order->add_order_note( 'Payment via Collector Checkout. Payment ID: ' . sanitize_key( $collector_order['data']['purchase']['purchaseIdentifier'] ) );
-			CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to Processing/Completed.' );
-		} elseif ( 'Signing' === $collector_order['data']['purchase']['result'] ) {
-			$order->add_order_note( __( 'Order is waiting for electronic signing by customer. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $collector_order['data']['purchase']['purchaseIdentifier'] );
-			update_post_meta( $order->get_id(), '_transaction_id', $collector_order['data']['purchase']['purchaseIdentifier'] );
-			$order->update_status( 'on-hold' );
-			CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to On hold.' );
-		} elseif ( 'Rejected' === $collector_order['data']['purchase']['result'] ) {
-			$order->add_order_note( __( 'Order is REJECTED by Walley. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $collector_order['data']['purchase']['purchaseIdentifier'] );
-			$order->update_status( 'failed' );
-			CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to Failed.' );
-		} else {
-			$order->add_order_note( __( 'Order is PENDING APPROVAL by Walley. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $collector_order['data']['purchase']['purchaseIdentifier'] );
-			$order->update_status( 'on-hold' );
-			CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to On hold.' );
 		}
 	}
 

--- a/classes/class-collector-checkout-api-callbacks.php
+++ b/classes/class-collector-checkout-api-callbacks.php
@@ -129,7 +129,7 @@ class Collector_Api_Callbacks {
 				$payment_id     = $collector_order['data']['purchase']['purchaseIdentifier'];
 
 				// Set order status in Woo.
-				walley_set_order_status( $order, $payment_status, $payment_id );
+				walley_set_order_status( $order, $payment_status, $payment_id, false );
 
 				$order->save();
 			}

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -1183,45 +1183,50 @@ function walley_is_order_page() {
  *
  * @return void
  */
-function walley_set_order_status( $order, $payment_status, $payment_id, $save_order = true ) {
+function walley_set_order_status( $order, $payment_status, $payment_id, $save_order = true, $is_callback = false ) {
 	switch ( $payment_status ) {
 		case 'Preliminary':
-			$order->payment_complete( $payment_id );
-			$order->add_order_note( 'Payment via Walley Checkout. Payment ID: ' . sanitize_key( $payment_id ) );
-			CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to Processing/Completed.' );
-			break;
 		case 'Activated':
 			$order->payment_complete( $payment_id );
 			$order->add_order_note( 'Payment via Walley Checkout. Payment ID: ' . sanitize_key( $payment_id ) );
-			CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to Processing/Completed.' );
-			$order->set_transaction_id( $payment_id );
+			if ( $is_callback ) {
+				CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to Processing/Completed.' );
+			}
 			break;
 
 		case 'Signing':
 			$order->add_order_note( __( 'Order is waiting for electronic signing by customer. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
 			$order->update_status( 'on-hold' );
-			CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to On hold.' );
+			if ( $is_callback ) {
+				CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to On hold.' );
+			}
 			$order->set_transaction_id( $payment_id );
 			break;
 
 		case 'Rejected':
 			$order->add_order_note( __( 'Order is REJECTED by Walley. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
 			$order->update_status( 'failed' );
-			CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to Failed.' );
+			if ( $is_callback ) {
+				CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to Failed.' );
+			}
 			$order->set_transaction_id( $payment_id );
 			break;
 
 		case 'OnHold':
 			$order->add_order_note( __( 'Order is ON HOLD by Walley. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
 			$order->update_status( 'on-hold' );
-			CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to On hold.' );
+			if ( $is_callback ) {
+				CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to On hold.' );
+			}
 			$order->set_transaction_id( $payment_id );
 			break;
 
 		default:
 			$order->add_order_note( __( 'Order is PENDING APPROVAL by Walley. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
 			$order->update_status( 'on-hold' );
-			CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to On hold.' );
+			if ( $is_callback ) {
+				CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to On hold.' );
+			}
 			$order->set_transaction_id( $payment_id );
 			break;
 	}

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -347,10 +347,10 @@ function wc_collector_confirm_order( $order, $private_id = null ) {
 		return;
 	}
 
-	$payment_status  = $collector_order['data']['purchase']['result'];
 	$payment_method  = $collector_order['data']['purchase']['paymentName'];
 	$payment_id      = $collector_order['data']['purchase']['purchaseIdentifier'];
 	$walley_order_id = $collector_order['data']['order']['orderId'];
+	$payment_status  = $collector_order['data']['purchase']['result'];
 
 	// Check if we need to update reference in collectors system.
 	if ( empty( $collector_order['data']['reference'] ) ) {
@@ -385,20 +385,8 @@ function wc_collector_confirm_order( $order, $private_id = null ) {
 	$order->update_meta_data( '_collector_order_id', sanitize_key( $walley_order_id ) );
 	wc_collector_save_shipping_reference_to_order( $order->get_id(), $collector_order );
 
-	if ( 'Preliminary' === $payment_status || 'Completed' === $payment_status ) {
-		$order->payment_complete( $payment_id );
-	} elseif ( 'Signing' === $payment_status ) {
-		$order->add_order_note( __( 'Order is waiting for electronic signing by customer. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
-		$order->update_meta_data( '_transaction_id', $payment_id );
-		$order->update_status( 'on-hold' );
-	} else {
-		$order->add_order_note( __( 'Order is PENDING APPROVAL by Collector. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
-		$order->add_meta_data( '_transaction_id', $payment_id );
-		$order->update_status( 'on-hold' );
-	}
+	set_order_status( $order, $payment_status, $payment_id );
 
-	// Translators: Collector Payment method.
-	$order->add_order_note( sprintf( __( 'Purchase via %s', 'collector-checkout-for-woocommerce' ), wc_collector_get_payment_method_name( $payment_method ) ) );
 	$order->save();
 }
 
@@ -818,20 +806,7 @@ function walley_confirm_order( $order, $private_id = null ) {
 		$order->update_meta_data( '_collector_delivery_module_reference', $collector_order['data']['shipping']['pendingShipment']['id'] );
 	}
 
-	if ( 'Preliminary' === $payment_status || 'Completed' === $payment_status ) {
-		$order->payment_complete( $payment_id );
-	} elseif ( 'Signing' === $payment_status ) {
-		$order->add_order_note( __( 'Order is waiting for electronic signing by customer. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
-		$order->set_transaction_id( $payment_id );
-		$order->update_status( 'on-hold' );
-	} else {
-		$order->add_order_note( __( 'Order is PENDING APPROVAL by Collector. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
-		$order->set_transaction_id( $payment_id );
-		$order->update_status( 'on-hold' );
-	}
-
-	// Translators: Collector Payment method.
-	$order->add_order_note( sprintf( __( 'Purchase via %s', 'collector-checkout-for-woocommerce' ), wc_collector_get_payment_method_name( $payment_method ) ) );
+	set_order_status( $order, $payment_status, $payment_id );
 
 	$order->save();
 	return true;
@@ -1197,4 +1172,35 @@ function walley_is_order_page() {
 	}
 
 	return walley_is_order_type( walley_get_the_ID() );
+}
+
+/**
+ * Set the order status.
+ *
+ * @param WC_Order $order The WooCommerce order.
+ * @param string   $payment_status The payment status.
+ * @param string   $payment_id The payment ID.
+ *
+ * @return void
+ */
+function set_order_status( $order, $payment_status, $payment_id ) {
+	if ( 'Preliminary' === $payment_status || 'Completed' === $payment_status ) {
+		$order->payment_complete( $payment_id );
+		$order->add_order_note( 'Payment via Walley Checkout. Payment ID: ' . sanitize_key( $payment_id ) );
+		CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to Processing/Completed.' );
+	} elseif ( 'Signing' === $payment_status ) {
+		$order->add_order_note( __( 'Order is waiting for electronic signing by customer. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
+		$order->update_status( 'on-hold' );
+		CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to On hold.' );
+	} elseif ( 'Rejected' === $payment_status ) {
+		$order->add_order_note( __( 'Order is REJECTED by Walley. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
+		$order->update_status( 'failed' );
+		CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to Failed.' );
+	} else {
+		$order->add_order_note( __( 'Order is PENDING APPROVAL by Walley. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
+		$order->update_status( 'on-hold' );
+		CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to On hold.' );
+	}
+
+	update_post_meta( $order->get_id(), '_transaction_id', $payment_id );
 }

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -1183,24 +1183,50 @@ function walley_is_order_page() {
  *
  * @return void
  */
-function walley_set_order_status( $order, $payment_status, $payment_id ) {
-	if ( 'Preliminary' === $payment_status || 'Completed' === $payment_status ) {
-		$order->payment_complete( $payment_id );
-		$order->add_order_note( 'Payment via Walley Checkout. Payment ID: ' . sanitize_key( $payment_id ) );
-		CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to Processing/Completed.' );
-	} elseif ( 'Signing' === $payment_status ) {
-		$order->add_order_note( __( 'Order is waiting for electronic signing by customer. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
-		$order->update_status( 'on-hold' );
-		CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to On hold.' );
-	} elseif ( 'Rejected' === $payment_status ) {
-		$order->add_order_note( __( 'Order is REJECTED by Walley. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
-		$order->update_status( 'failed' );
-		CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to Failed.' );
-	} else {
-		$order->add_order_note( __( 'Order is PENDING APPROVAL by Walley. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
-		$order->update_status( 'on-hold' );
-		CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to On hold.' );
+function walley_set_order_status( $order, $payment_status, $payment_id, $save_order = true ) {
+	switch ( $payment_status ) {
+		case 'Preliminary':
+			$order->payment_complete( $payment_id );
+			$order->add_order_note( 'Payment via Walley Checkout. Payment ID: ' . sanitize_key( $payment_id ) );
+			CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to Processing/Completed.' );
+			break;
+		case 'Activated':
+			$order->payment_complete( $payment_id );
+			$order->add_order_note( 'Payment via Walley Checkout. Payment ID: ' . sanitize_key( $payment_id ) );
+			CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to Processing/Completed.' );
+			$order->set_transaction_id( $payment_id );
+			break;
+
+		case 'Signing':
+			$order->add_order_note( __( 'Order is waiting for electronic signing by customer. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
+			$order->update_status( 'on-hold' );
+			CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to On hold.' );
+			$order->set_transaction_id( $payment_id );
+			break;
+
+		case 'Rejected':
+			$order->add_order_note( __( 'Order is REJECTED by Walley. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
+			$order->update_status( 'failed' );
+			CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to Failed.' );
+			$order->set_transaction_id( $payment_id );
+			break;
+
+		case 'OnHold':
+			$order->add_order_note( __( 'Order is ON HOLD by Walley. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
+			$order->update_status( 'on-hold' );
+			CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to On hold.' );
+			$order->set_transaction_id( $payment_id );
+			break;
+
+		default:
+			$order->add_order_note( __( 'Order is PENDING APPROVAL by Walley. Payment ID: ', 'collector-checkout-for-woocommerce' ) . $payment_id );
+			$order->update_status( 'on-hold' );
+			CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to On hold.' );
+			$order->set_transaction_id( $payment_id );
+			break;
 	}
 
-	$order->update_meta_data( '_transaction_id', $payment_id );
+	if ( $save_order ) {
+		$order->save();
+	}
 }

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -385,7 +385,7 @@ function wc_collector_confirm_order( $order, $private_id = null ) {
 	$order->update_meta_data( '_collector_order_id', sanitize_key( $walley_order_id ) );
 	wc_collector_save_shipping_reference_to_order( $order->get_id(), $collector_order );
 
-	set_order_status( $order, $payment_status, $payment_id );
+	walley_set_order_status( $order, $payment_status, $payment_id );
 
 	$order->save();
 }
@@ -806,7 +806,7 @@ function walley_confirm_order( $order, $private_id = null ) {
 		$order->update_meta_data( '_collector_delivery_module_reference', $collector_order['data']['shipping']['pendingShipment']['id'] );
 	}
 
-	set_order_status( $order, $payment_status, $payment_id );
+	walley_set_order_status( $order, $payment_status, $payment_id );
 
 	$order->save();
 	return true;
@@ -1183,7 +1183,7 @@ function walley_is_order_page() {
  *
  * @return void
  */
-function set_order_status( $order, $payment_status, $payment_id ) {
+function walley_set_order_status( $order, $payment_status, $payment_id ) {
 	if ( 'Preliminary' === $payment_status || 'Completed' === $payment_status ) {
 		$order->payment_complete( $payment_id );
 		$order->add_order_note( 'Payment via Walley Checkout. Payment ID: ' . sanitize_key( $payment_id ) );
@@ -1202,5 +1202,5 @@ function set_order_status( $order, $payment_status, $payment_id ) {
 		CCO_WC()->logger::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to On hold.' );
 	}
 
-	update_post_meta( $order->get_id(), '_transaction_id', $payment_id );
+	$order->update_meta_data( '_transaction_id', $payment_id );
 }

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -385,7 +385,7 @@ function wc_collector_confirm_order( $order, $private_id = null ) {
 	$order->update_meta_data( '_collector_order_id', sanitize_key( $walley_order_id ) );
 	wc_collector_save_shipping_reference_to_order( $order->get_id(), $collector_order );
 
-	walley_set_order_status( $order, $payment_status, $payment_id );
+	walley_set_order_status( $order, $payment_status, $payment_id, false );
 
 	$order->save();
 }
@@ -806,7 +806,7 @@ function walley_confirm_order( $order, $private_id = null ) {
 		$order->update_meta_data( '_collector_delivery_module_reference', $collector_order['data']['shipping']['pendingShipment']['id'] );
 	}
 
-	walley_set_order_status( $order, $payment_status, $payment_id );
+	walley_set_order_status( $order, $payment_status, $payment_id, false );
 
 	$order->save();
 	return true;


### PR DESCRIPTION
- Adds handling of the status "Rejected" on callback from walley.
- Refactors the order status code in a helper function, that is then reused throughout the code.

Is something like this what you had in mind? Only basic testing has been done, needs more thorough testing of all statuses (will do this if it looks like a good solution).