### PR TITLE
Add & implement numeric conversion helper

### DIFF
--- a/classes/requests/helpers/class-collector-checkout-create-refund-data.php
+++ b/classes/requests/helpers/class-collector-checkout-create-refund-data.php
@@ -83,12 +83,12 @@ class Collector_Checkout_Create_Refund_Data {
 							break;
 						}
 					}
-					if ( abs( $shipping->get_total() ) / abs( $shipping->get_quantity() ) === $original_order_shipping->get_total() / $original_order_shipping->get_quantity() ) {
+					if ( abs( walley_ensure_numeric( $shipping->get_total() ) ) / abs( $shipping->get_quantity() ) === walley_ensure_numeric( $original_order_shipping->get_total() ) / $original_order_shipping->get_quantity() ) {
 						// The entire shipping price is refunded.
 						array_push( $full_item_refund, self::get_full_refund_shipping_data( $shipping, $original_order ) );
 					} else {
 						// The shipping is partial refunded.
-						$modified_item_prices += abs( $shipping->get_total() + $shipping->get_total_tax() );
+						$modified_item_prices += abs( walley_ensure_numeric( $shipping->get_total() ) + $shipping->get_total_tax() );
 					}
 				}
 				if ( $modified_item_prices > 0 ) {
@@ -225,8 +225,8 @@ class Collector_Checkout_Create_Refund_Data {
 		}
 
 		$title    = $shipping->get_name();
-		$tax_rate = ( $free_shipping ) ? 0 : intval( round( $shipping->get_total_tax() / $shipping->get_total() * 100 ) );
-		$total    = ( $free_shipping ) ? 0 : $shipping->get_total();
+		$tax_rate = ( $free_shipping ) ? 0 : intval( round( $shipping->get_total_tax() / walley_ensure_numeric( $shipping->get_total() ) * 100 ) );
+		$total    = ( $free_shipping ) ? 0 : walley_ensure_numeric( $shipping->get_total() );
 		$quantity = ( 0 === $shipping->get_quantity() ) ? 1 : $shipping->get_quantity();
 
 		return array(

--- a/classes/requests/helpers/class-collector-checkout-requests-helper-order-om.php
+++ b/classes/requests/helpers/class-collector-checkout-requests-helper-order-om.php
@@ -191,7 +191,7 @@ class Collector_Checkout_Requests_Helper_Order_Om {
 		}
 
 		// Shipping should be added even if it is 0 since free shipping is added to the original purchase.
-		$unit_price = self::format_number( ( $order_item->get_total() + $order_item->get_total_tax() ) / $order_item->get_quantity() );
+		$unit_price = self::format_number( ( walley_ensure_numeric( $order_item->get_total() ) + $order_item->get_total_tax() ) / $order_item->get_quantity() );
 
 		return array(
 			'id'          => $shipping_reference,

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -1165,3 +1165,33 @@ function walley_set_order_status( $order, $payment_status, $payment_id, $save_or
 		$order->save();
 	}
 }
+
+/**
+ * Ensure that a value is numeric. If the value is not numeric, it will attempt to convert it.
+ * If the value is an empty value, it will be set to 0.
+ * If the value cannot be converted to a numeric value, it will return the default value.
+ *
+ * @param mixed     $value The value to ensure is numeric.
+ * @param float|int $default The default value to return if the value is not numeric and $throw_error is false. Default 0.
+ *
+ * @return float|int Returns the numeric value of the input, or the default value if the input is not numeric and cannot be converted.
+ */
+function walley_ensure_numeric( $value, $default = 0 ) {
+	if ( is_numeric( $value ) ) {
+		return floatval( $value );
+	}
+
+	// If the value is empty, return 0 instead of default to reflect that the value is not set.
+	if ( empty( $value ) ) {
+		return 0;
+	}
+
+	// Try to convert the value to a numeric value.
+	$converted_value = floatval( $value );
+
+	if ( is_numeric( $converted_value ) ) {
+		return $converted_value;
+	}
+
+	return $default; // Return the default value if the value is still not numeric.
+}


### PR DESCRIPTION
Add a numeric conversion helper and implement for the shipping price, to ensure a numeric value. Resolves potential for fatal errors on order management, in cases where shipping option price is returned as a string value.