### PR TITLE
Develop EU Checkout + EU/FI tweak

### DIFF
--- a/.github/workflows/create-dev-zip.yml
+++ b/.github/workflows/create-dev-zip.yml
@@ -1,0 +1,74 @@
+name: Create Dev Zip
+
+on:
+  workflow_dispatch:
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      PLUGIN_SLUG: collector-checkout-for-woocommerce
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
+    - name: Create composer cache directory
+      run: mkdir -p ~/.composer/cache
+
+    - name: Cache Composer dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.composer/cache
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-
+
+    - name: Cache npm dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-npm-
+
+    - name: Install dependencies and build project
+      run: |
+        mkdir -p ~/.composer/cache
+        composer install --prefer-dist --no-progress
+        npm ci && npm run build
+
+    - name: Get branch name and commit hash
+      id: vars
+      run: |
+        BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+        COMMIT_HASH=$(git rev-parse --short HEAD)
+        ZIP_FILE_NAME="${{ env.PLUGIN_SLUG }}-dev-${BRANCH_NAME}-${COMMIT_HASH}.zip"
+        echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_ENV
+        echo "COMMIT_HASH=${COMMIT_HASH}" >> $GITHUB_ENV
+        echo "ZIP_FILE_NAME=${ZIP_FILE_NAME}" >> $GITHUB_ENV
+
+    - name: Modify version, prepare zip directory, and create zip file
+      run: |
+        sed -i "s/^ \* Version: \(.*\)/ \* Version: \1-dev.${BRANCH_NAME}.${COMMIT_HASH}/" ${{ env.PLUGIN_SLUG }}.php
+        mkdir -p dev-zip-temp/${{ env.PLUGIN_SLUG }}
+        rsync -av --exclude-from='.distignore' --exclude='dev-zip-temp' . dev-zip-temp/${{ env.PLUGIN_SLUG }}
+        cd dev-zip-temp
+        zip -r ../${{ env.ZIP_FILE_NAME }} ${{ env.PLUGIN_SLUG }}
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_KROKEDIL_PLUGIN_DEV_ZIP }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_KROKEDIL_PLUGIN_DEV_ZIP }}
+        aws-region: eu-north-1
+
+    - name: Upload to S3
+      run: |
+        aws s3 cp ${{ env.ZIP_FILE_NAME }} s3://krokedil-plugin-dev-zip/${{ env.ZIP_FILE_NAME }}
+
+    - name: Add annotation to workflow run with dev zip url
+      run: echo "::notice::Dev Zip Url available for 30 days, https://krokedil-plugin-dev-zip.s3.eu-north-1.amazonaws.com/${{ env.ZIP_FILE_NAME }}"

--- a/.github/workflows/create-dev-zip.yml
+++ b/.github/workflows/create-dev-zip.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         mkdir -p ~/.composer/cache
         composer install --prefer-dist --no-progress
-        npm ci && npm run build
+        npm ci
 
     - name: Get branch name and commit hash
       id: vars

--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -188,6 +188,7 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 				WC()->session->set( 'collector_private_id', $collector_order['data']['privateId'] );
 				WC()->session->set( 'collector_customer_type', $customer_type );
 				WC()->session->set( 'collector_currency', get_woocommerce_currency() );
+				WC()->session->set( 'collector_billing_country', WC()->customer->get_billing_country() );
 
 				wp_send_json_success( $return );
 			}

--- a/classes/class-walley-checkout.php
+++ b/classes/class-walley-checkout.php
@@ -85,10 +85,12 @@ class Walley_Checkout {
 			return;
 		}
 
+		// When the country is updated in the Walley payment form, it is not available in WC()->customer->get_billing_country() until the customer is updated.
 		$this->update_customer_in_woo( $this->collector_order );
+		// Now that the customer is updated, we can retrieve the country from the checkout.
 		$country_from_checkout = WC()->customer->get_billing_country();
 
-		// The Customer object should now contain the country retrieved from Walley. Overwrite the existing $country.
+		// Do not use the country from the session, as it contain the old data. Pass the country from the checkout.
 		if ( self::maybe_clear_session_on_country_change( $country_from_checkout ) ) {
 			return;
 		}

--- a/classes/class-walley-checkout.php
+++ b/classes/class-walley-checkout.php
@@ -90,6 +90,7 @@ class Walley_Checkout {
 		$country_from_checkout = WC()->customer->get_billing_country();
 
 		// Do not use the country from the session, as it contain the old data. Pass the country from the checkout.
+		if ( $this->maybe_clear_session_on_country_change( $country_from_checkout ) ) {
 			return;
 		}
 

--- a/classes/class-walley-checkout.php
+++ b/classes/class-walley-checkout.php
@@ -234,25 +234,25 @@ class Walley_Checkout {
 			}
 
 			// Old API.
-			$update_metadata         = new Collector_Checkout_Requests_Update_Metadata( $private_id, $customer_type, $metadata );
-			$collecor_order_metadata = $update_metadata->request();
+			$update_metadata          = new Collector_Checkout_Requests_Update_Metadata( $private_id, $customer_type, $metadata );
+			$collector_order_metadata = $update_metadata->request();
 
 			// Check that everything went alright.
-			if ( is_wp_error( $collecor_order_metadata ) ) {
+			if ( is_wp_error( $collector_order_metadata ) ) {
 				// Check if purchase was completed, if it was don't redirect customer.
-				if ( 900 === $collecor_order_metadata->get_error_code() ) {
-					if ( ! empty( $collecor_order_metadata->get_error_message( 'Purchase_Completed' ) ) || ! empty( $collecor_order_metadata->get_error_message( 'Purchase_Commitment_Found' ) ) ) {
+				if ( 900 === $collector_order_metadata->get_error_code() ) {
+					if ( ! empty( $collector_order_metadata->get_error_message( 'Purchase_Completed' ) ) || ! empty( $collector_order_metadata->get_error_message( 'Purchase_Commitment_Found' ) ) ) {
 						WC()->session->reload_checkout = true;
 					}
 				}
 				// Check if we had validation error.
-				if ( 400 === $collecor_order_metadata->get_error_code() ) {
-					if ( ! empty( $collecor_order_metadata->get_error_message( 'Validation_Error' ) ) ) {
+				if ( 400 === $collector_order_metadata->get_error_code() ) {
+					if ( ! empty( $collector_order_metadata->get_error_message( 'Validation_Error' ) ) ) {
 						WC()->session->reload_checkout = true;
 					}
 				}
 				// Check if the resource is temporarily locked, if it was don't redirect customer.
-				if ( 423 === $collecor_order_metadata->get_error_code() ) {
+				if ( 423 === $collector_order_metadata->get_error_code() ) {
 					WC()->session->reload_checkout = true;
 				}
 			}

--- a/classes/class-walley-checkout.php
+++ b/classes/class-walley-checkout.php
@@ -38,7 +38,6 @@ class Walley_Checkout {
 	 * @return void
 	 */
 	public function update_shipping_method() {
-
 		if ( ! is_checkout() ) {
 			return;
 		}
@@ -91,7 +90,6 @@ class Walley_Checkout {
 		$country_from_checkout = WC()->customer->get_billing_country();
 
 		// Do not use the country from the session, as it contain the old data. Pass the country from the checkout.
-		if ( self::maybe_clear_session_on_country_change( $country_from_checkout ) ) {
 			return;
 		}
 
@@ -374,10 +372,12 @@ class Walley_Checkout {
 	 *
 	 * Use the return value to determine whether the current request should proceed or not.
 	 *
+	 * @note This will not call reload_checkout.
+	 *
 	 * @param string $country_from_checkout The country from the checkout.
 	 * @return bool Whether the session has been cleared.
 	 */
-	public static function maybe_clear_session_on_country_change( $country_from_checkout ) {
+	public function maybe_clear_session_on_country_change( $country_from_checkout ) {
 		$country_from_session = WC()->session->get( 'collector_billing_country' );
 		if ( $country_from_session === $country_from_checkout ) {
 			return false;
@@ -406,7 +406,7 @@ class Walley_Checkout {
 		WC()->session->set( 'collector_billing_country', $country_from_checkout );
 
 		if ( $clear_session ) {
-			WC()->session->reload_checkout = true;
+			// NOTE: We cannot reload_checkout here, as it will cause an infinite loop as that will trigger the after_calculate hook to be triggered after reload.
 			wc_collector_unset_sessions();
 		}
 

--- a/classes/class-walley-checkout.php
+++ b/classes/class-walley-checkout.php
@@ -397,7 +397,7 @@ class Walley_Checkout {
 				$clear_session = isset( $settings[ "collector_merchant_id_{$country}_{$customer_type}" ] );
 				break;
 			case 'EUR':
-				$clear_session = 'FI' === $country_from_checkout && isset( $settings[ "collector_merchant_id_fi_{$customer_type}" ] );
+				$clear_session = 'FI' === $country_from_session && isset( $settings[ "collector_merchant_id_fi_{$customer_type}" ] );
 				break;
 			default:
 				break;

--- a/classes/requests/checkouts/get/class-walley-checkout-request-get-checkout.php
+++ b/classes/requests/checkouts/get/class-walley-checkout-request-get-checkout.php
@@ -13,6 +13,20 @@ defined( 'ABSPATH' ) || exit;
 class Walley_Checkout_Request_Get_Checkout extends Walley_Checkout_Request_Get {
 
 	/**
+	 * The WC order ID.
+	 *
+	 * @var string
+	 */
+	protected $order_id;
+
+	/**
+	 * The private ID of the checkout.
+	 *
+	 * @var string
+	 */
+	protected $private_id;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param array $arguments The request arguments.

--- a/classes/requests/checkouts/post/class-walley-checkout-request-initialize-checkout.php
+++ b/classes/requests/checkouts/post/class-walley-checkout-request-initialize-checkout.php
@@ -13,6 +13,13 @@ defined( 'ABSPATH' ) || exit;
 class Walley_Checkout_Request_Initialize_Checkout extends Walley_Checkout_Request_Post {
 
 	/**
+	 * The WC order ID.
+	 *
+	 * @var string
+	 */
+	protected $order_id;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param array $arguments The request arguments.

--- a/classes/requests/checkouts/put/class-walley-checkout-request-update-checkout.php
+++ b/classes/requests/checkouts/put/class-walley-checkout-request-update-checkout.php
@@ -13,6 +13,20 @@ defined( 'ABSPATH' ) || exit;
 class Walley_Checkout_Request_Update_Checkout extends Walley_Checkout_Request_Put {
 
 	/**
+	 * The WC order ID.
+	 *
+	 * @var string
+	 */
+	protected $order_id;
+
+	/**
+	 * The private ID of the checkout.
+	 *
+	 * @var string
+	 */
+	protected $private_id;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param array $arguments The request arguments.

--- a/classes/requests/class-collector-checkout-requests.php
+++ b/classes/requests/class-collector-checkout-requests.php
@@ -121,11 +121,12 @@ class Collector_Checkout_Requests {
 		}
 
 		// Check the status code, if its not between 200 and 299 then its an error.
-		if ( wp_remote_retrieve_response_code( $response ) < 200 || wp_remote_retrieve_response_code( $response ) > 299 ) {
+		$code = wp_remote_retrieve_response_code( $response );
+		if ( $code < 200 || $code > 299 ) {
 			if ( null !== json_decode( $response['body'], true ) ) {
 				$response_body = json_decode( $response['body'], true );
 				$error         = new WP_Error();
-				$error->add( wp_remote_retrieve_response_code( $response ), $response_body['error']['message'] );
+				$error->add( $code, $response_body['error']['message'] );
 				foreach ( $response_body['error']['errors'] as $key => $collector_error ) {
 					$error->add( $collector_error['reason'], $collector_error['message'] );
 				}

--- a/classes/requests/class-collector-checkout-requests.php
+++ b/classes/requests/class-collector-checkout-requests.php
@@ -98,7 +98,7 @@ class Collector_Checkout_Requests {
 	 */
 	public static function log( $message ) {
 		$dibs_settings = get_option( 'woocommerce_collector_checkout_settings' );
-		if ( 'yes' === $dibs_settings['debug_mode'] ) {
+		if ( wc_string_to_bool( $dibs_settings['debug_mode'] ?? 'no' ) ) {
 			if ( empty( self::$log ) ) {
 				self::$log = new WC_Logger();
 			}

--- a/classes/requests/class-collector-checkout-requests.php
+++ b/classes/requests/class-collector-checkout-requests.php
@@ -129,8 +129,9 @@ class Collector_Checkout_Requests {
 				foreach ( $response_body['error']['errors'] as $key => $collector_error ) {
 					$error->add( $collector_error['reason'], $collector_error['message'] );
 				}
+
+				return $error;
 			}
-			return $error;
 		}
 		return json_decode( wp_remote_retrieve_body( $response ), true );
 	}

--- a/classes/requests/class-collector-checkout-requests.php
+++ b/classes/requests/class-collector-checkout-requests.php
@@ -17,9 +17,9 @@ class Collector_Checkout_Requests {
 	/**
 	 * Static log variable.
 	 *
-	 * @var string
+	 * @var WC_Logger
 	 */
-	protected static $log = '';
+	protected static $log = null;
 
 	/**
 	 * The Collector base url.

--- a/classes/requests/class-collector-checkout-requests.php
+++ b/classes/requests/class-collector-checkout-requests.php
@@ -122,16 +122,6 @@ class Collector_Checkout_Requests {
 
 		// Check the status code, if its not between 200 and 299 then its an error.
 		if ( wp_remote_retrieve_response_code( $response ) < 200 || wp_remote_retrieve_response_code( $response ) > 299 ) {
-			$data          = 'URL: ' . $request_url . ' - ' . wp_json_encode( $request_args );
-			$error_message = '';
-			// Get the error messages.
-			// @todo - remove this if?
-			if ( null !== $response['response'] ) {
-				$aco_error_code    = isset( $response['response']['code'] ) ? $response['response']['code'] . ' ' : '';
-				$aco_error_message = isset( $response['response']['message'] ) ? $response['response']['message'] . ' ' : '';
-				$error_message     = $aco_error_code . $aco_error_message;
-			}
-
 			if ( null !== json_decode( $response['body'], true ) ) {
 				$response_body = json_decode( $response['body'], true );
 				$error         = new WP_Error();

--- a/classes/requests/class-walley-checkout-request.php
+++ b/classes/requests/class-walley-checkout-request.php
@@ -305,13 +305,15 @@ abstract class Walley_Checkout_Request {
 				$this->delivery_module = $this->settings['collector_delivery_module_dk'] ?? 'no';
 				break;
 			case 'EUR':
-				$order_id     = $arguments['order_id'] ?? $this->arguments['order_id'] ?? false;
-				$country_code = $this->get_customer_country( wc_get_order( $order_id ) );
-				if ( 'FI' === $country_code || 'b2b' === $this->customer_type ) {
+				$order_id              = $arguments['order_id'] ?? $this->arguments['order_id'] ?? false;
+				$customer_country_code = $this->get_customer_country( wc_get_order( $order_id ) );
+				if ( 'FI' === $customer_country_code || 'b2b' === $this->customer_type ) {
+					$country_code          = 'FI';
 					$this->store_id        = $this->settings[ "collector_merchant_id_fi_{$this->customer_type}" ];
 					$this->delivery_module = $this->settings['collector_delivery_module_fi'] ?? 'no';
 				} else {
 					// Only available for B2C.
+					$country_code          = 'EU';
 					$this->store_id        = $this->settings['collector_merchant_id_eu_b2c'];
 					$this->delivery_module = $this->settings['collector_delivery_module_eu'] ?? 'no';
 

--- a/classes/requests/class-walley-checkout-request.php
+++ b/classes/requests/class-walley-checkout-request.php
@@ -307,12 +307,12 @@ abstract class Walley_Checkout_Request {
 			case 'EUR':
 				$order_id     = $arguments['order_id'] ?? $this->arguments['order_id'] ?? false;
 				$country_code = $this->get_customer_country( wc_get_order( $order_id ) );
-				if ( 'FI' === $country_code || 'b2c' === $this->customer_type ) {
+				if ( 'FI' === $country_code || 'b2b' === $this->customer_type ) {
 					$this->store_id        = $this->settings[ "collector_merchant_id_fi_{$this->customer_type}" ];
 					$this->delivery_module = $this->settings['collector_delivery_module_fi'] ?? 'no';
 				} else {
-					// Only available for B2B.
-					$this->store_id        = $this->settings['collector_merchant_id_eu_b2b'];
+					// Only available for B2C.
+					$this->store_id        = $this->settings['collector_merchant_id_eu_b2c'];
 					$this->delivery_module = $this->settings['collector_delivery_module_eu'] ?? 'no';
 
 				}

--- a/classes/requests/class-walley-checkout-request.php
+++ b/classes/requests/class-walley-checkout-request.php
@@ -329,7 +329,7 @@ abstract class Walley_Checkout_Request {
 				break;
 			default:
 				$country_code          = 'SE';
-				$this->store_id        = $this->settings[ 'collector_merchant_id_se_' . $this->customer_type ];
+				$this->store_id        = $this->settings[ "collector_merchant_id_se_{$this->customer_type}" ];
 				$this->delivery_module = $this->settings['collector_delivery_module_se'] ?? 'no';
 				break;
 		}

--- a/classes/requests/class-walley-checkout-request.php
+++ b/classes/requests/class-walley-checkout-request.php
@@ -318,6 +318,7 @@ abstract class Walley_Checkout_Request {
 
 					if ( empty( $this->store_id ) ) {
 						// Only available for B2C.
+						$country_code    = 'EU';
 						$store_id        = $this->settings['collector_merchant_id_eu_b2c'];
 						$delivery_module = $this->settings['collector_delivery_module_eu'] ?? 'no';
 					}

--- a/classes/requests/class-walley-checkout-request.php
+++ b/classes/requests/class-walley-checkout-request.php
@@ -294,27 +294,27 @@ abstract class Walley_Checkout_Request {
 			case 'SEK':
 				$country_code          = 'SE';
 				$this->store_id        = $this->settings[ 'collector_merchant_id_se_' . $this->customer_type ];
-				$this->delivery_module = isset( $this->settings['collector_delivery_module_se'] ) ? $this->settings['collector_delivery_module_se'] : 'no';
+				$this->delivery_module = $this->settings['collector_delivery_module_se'] ?? 'no';
 				break;
 			case 'NOK':
 				$country_code          = 'NO';
 				$this->store_id        = $this->settings[ 'collector_merchant_id_no_' . $this->customer_type ];
-				$this->delivery_module = isset( $this->settings['collector_delivery_module_no'] ) ? $this->settings['collector_delivery_module_no'] : 'no';
+				$this->delivery_module = $this->settings['collector_delivery_module_no'] ?? 'no';
 				break;
 			case 'DKK':
 				$country_code          = 'DK';
 				$this->store_id        = $this->settings[ 'collector_merchant_id_dk_' . $this->customer_type ];
-				$this->delivery_module = isset( $this->settings['collector_delivery_module_dk'] ) ? $this->settings['collector_delivery_module_dk'] : 'no';
+				$this->delivery_module = $this->settings['collector_delivery_module_dk'] ?? 'no';
 				break;
 			case 'EUR':
 				$country_code          = 'FI';
 				$this->store_id        = $this->settings[ 'collector_merchant_id_fi_' . $this->customer_type ];
-				$this->delivery_module = isset( $this->settings['collector_delivery_module_fi'] ) ? $this->settings['collector_delivery_module_fi'] : 'no';
+				$this->delivery_module = $this->settings['collector_delivery_module_fi'] ?? 'no';
 				break;
 			default:
 				$country_code          = 'SE';
 				$this->store_id        = $this->settings[ 'collector_merchant_id_se_' . $this->customer_type ];
-				$this->delivery_module = isset( $this->settings['collector_delivery_module_se'] ) ? $this->settings['collector_delivery_module_se'] : 'no';
+				$this->delivery_module = $this->settings['collector_delivery_module_se'] ?? 'no';
 				break;
 		}
 		$this->country_code = $country_code;

--- a/classes/requests/class-walley-checkout-request.php
+++ b/classes/requests/class-walley-checkout-request.php
@@ -316,10 +316,10 @@ abstract class Walley_Checkout_Request {
 						$delivery_module = $this->settings['collector_delivery_module_fi'] ?? 'no';
 					}
 
-					if ( empty( $this->store_id ) ) {
+					if ( empty( $store_id ) ) {
 						// Only available for B2C.
 						$country_code    = 'EU';
-						$store_id        = $this->settings['collector_merchant_id_eu_b2c'];
+						$store_id        = $this->settings['collector_merchant_id_eu_b2c'] ?? '';
 						$delivery_module = $this->settings['collector_delivery_module_eu'] ?? 'no';
 					}
 

--- a/classes/requests/class-walley-checkout-request.php
+++ b/classes/requests/class-walley-checkout-request.php
@@ -305,18 +305,25 @@ abstract class Walley_Checkout_Request {
 				$this->delivery_module = $this->settings['collector_delivery_module_dk'] ?? 'no';
 				break;
 			case 'EUR':
-				$order_id              = $arguments['order_id'] ?? $this->arguments['order_id'] ?? false;
-				$customer_country_code = $this->get_customer_country( wc_get_order( $order_id ) );
-				if ( 'FI' === $customer_country_code || 'b2b' === $this->customer_type ) {
-					$country_code          = 'FI';
+				$order_id     = $arguments['order_id'] ?? $this->arguments['order_id'] ?? false;
+				$country_code = $this->get_customer_country( wc_get_order( $order_id ) );
+				if ( 'b2b' === $this->customer_type ) {
 					$this->store_id        = $this->settings[ "collector_merchant_id_fi_{$this->customer_type}" ];
 					$this->delivery_module = $this->settings['collector_delivery_module_fi'] ?? 'no';
 				} else {
-					// Only available for B2C.
-					$country_code          = 'EU';
-					$this->store_id        = $this->settings['collector_merchant_id_eu_b2c'];
-					$this->delivery_module = $this->settings['collector_delivery_module_eu'] ?? 'no';
+					if ( 'FI' === $country_code ) {
+						$store_id        = $this->settings[ "collector_merchant_id_fi_{$this->customer_type}" ];
+						$delivery_module = $this->settings['collector_delivery_module_fi'] ?? 'no';
+					}
 
+					if ( empty( $this->store_id ) ) {
+						// Only available for B2C.
+						$store_id        = $this->settings['collector_merchant_id_eu_b2c'];
+						$delivery_module = $this->settings['collector_delivery_module_eu'] ?? 'no';
+					}
+
+					$this->store_id        = $store_id;
+					$this->delivery_module = $delivery_module;
 				}
 				break;
 			default:

--- a/classes/requests/class-walley-checkout-request.php
+++ b/classes/requests/class-walley-checkout-request.php
@@ -47,6 +47,48 @@ abstract class Walley_Checkout_Request {
 	 */
 	protected $settings;
 
+	/**
+	 * Customer type. Either 'b2c' or 'b2b'.
+	 *
+	 * @var string
+	 */
+	protected $customer_type = 'b2c';
+
+	/**
+	 * Currency.
+	 *
+	 * @var string
+	 */
+	protected $currency = 'SEK';
+
+	/**
+	 * Store ID.
+	 *
+	 * @var string
+	 */
+	protected $store_id;
+
+	/**
+	 * Delivery module.
+	 *
+	 * @var string
+	 */
+	protected $delivery_module;
+
+	/**
+	 * Country code.
+	 *
+	 * @var string
+	 */
+	protected $country_code;
+
+	/**
+	 * Terms page.
+	 *
+	 * @var string
+	 */
+	protected $terms_page;
+
 
 	/**
 	 * Class constructor.

--- a/classes/requests/class-walley-checkout-request.php
+++ b/classes/requests/class-walley-checkout-request.php
@@ -151,6 +151,7 @@ abstract class Walley_Checkout_Request {
 			return '';
 		}
 
+		$access_token = "{$response['token_type']} {$response['access_token']}";
 		set_transient( 'walley_checkout_access_token', $access_token, absint( $response['expires_in'] ) );
 		return $access_token;
 	}

--- a/classes/requests/class-walley-checkout-request.php
+++ b/classes/requests/class-walley-checkout-request.php
@@ -291,27 +291,28 @@ abstract class Walley_Checkout_Request {
 		switch ( $this->currency ) {
 			case 'SEK':
 				$country_code          = 'SE';
-				$this->store_id        = $this->settings[ 'collector_merchant_id_se_' . $this->customer_type ];
+				$this->store_id        = $this->settings[ "collector_merchant_id_se_{$this->customer_type}" ];
 				$this->delivery_module = $this->settings['collector_delivery_module_se'] ?? 'no';
 				break;
 			case 'NOK':
 				$country_code          = 'NO';
-				$this->store_id        = $this->settings[ 'collector_merchant_id_no_' . $this->customer_type ];
+				$this->store_id        = $this->settings[ "collector_merchant_id_no_{$this->customer_type}" ];
 				$this->delivery_module = $this->settings['collector_delivery_module_no'] ?? 'no';
 				break;
 			case 'DKK':
 				$country_code          = 'DK';
-				$this->store_id        = $this->settings[ 'collector_merchant_id_dk_' . $this->customer_type ];
+				$this->store_id        = $this->settings[ "collector_merchant_id_dk_{$this->customer_type}" ];
 				$this->delivery_module = $this->settings['collector_delivery_module_dk'] ?? 'no';
 				break;
 			case 'EUR':
 				$order_id     = $arguments['order_id'] ?? $this->arguments['order_id'] ?? false;
 				$country_code = $this->get_customer_country( wc_get_order( $order_id ) );
-				if ( 'FI' === $country_code ) {
-					$this->store_id        = $this->settings[ 'collector_merchant_id_fi_' . $this->customer_type ];
+				if ( 'FI' === $country_code || 'b2c' === $this->customer_type ) {
+					$this->store_id        = $this->settings[ "collector_merchant_id_fi_{$this->customer_type}" ];
 					$this->delivery_module = $this->settings['collector_delivery_module_fi'] ?? 'no';
 				} else {
-					$this->store_id        = $this->settings[ 'collector_merchant_id_eu_' . $this->customer_type ];
+					// Only available for B2B.
+					$this->store_id        = $this->settings['collector_merchant_id_eu_b2b'];
 					$this->delivery_module = $this->settings['collector_delivery_module_eu'] ?? 'no';
 
 				}

--- a/classes/requests/class-walley-checkout-request.php
+++ b/classes/requests/class-walley-checkout-request.php
@@ -244,7 +244,6 @@ abstract class Walley_Checkout_Request {
 		$title  = $this->log_title;
 		$code   = wp_remote_retrieve_response_code( $response );
 
-		$body     = json_decode( $response['body'], true );
 		$order_id = $this->private_id ?? $this->order_id ?? null;
 		$log      = Collector_Checkout_Logger::format_log( $order_id, $method, $title, $request_args, $request_url, $response, $code );
 		Collector_Checkout_Logger::log( $log );

--- a/classes/requests/class-walley-checkout-request.php
+++ b/classes/requests/class-walley-checkout-request.php
@@ -151,7 +151,6 @@ abstract class Walley_Checkout_Request {
 			return '';
 		}
 
-		$access_token = $response['token_type'] . ' ' . $response['access_token'];
 		set_transient( 'walley_checkout_access_token', $access_token, absint( $response['expires_in'] ) );
 		return $access_token;
 	}
@@ -220,7 +219,7 @@ abstract class Walley_Checkout_Request {
 				}
 			}
 
-			$error_message = empty( $error_message ) ? "API Error ${response_code}" : "API Error ${error_message}";
+			$error_message = empty( $error_message ) ? "API Error {$response_code}" : "API Error {$error_message}";
 			$return        = new WP_Error( $response_code, $error_message, $data );
 		} else {
 			$return = json_decode( wp_remote_retrieve_body( $response ), true );

--- a/classes/requests/class-walley-checkout-request.php
+++ b/classes/requests/class-walley-checkout-request.php
@@ -212,9 +212,8 @@ abstract class Walley_Checkout_Request {
 			$data          = 'URL: ' . $request_url . ' - ' . wp_json_encode( $request_args );
 			$error_message = '';
 			// Get the error messages.
-			if ( null !== json_decode( $response['body'], true ) ) {
-				$errors = json_decode( $response['body'], true );
-
+			$errors = json_decode( $response ['body'], true );
+			if ( $errors ) {
 				foreach ( $errors as $error ) {
 					$error_message .= ' ' . wp_json_encode( $error );
 				}

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "type": "wordpress-plugin",
     "require-dev": {
         "wp-coding-standards/wpcs": "^3.0",
-        "php-stubs/woocommerce-stubs": "^8.2"
+        "php-stubs/woocommerce-stubs": "^8.2",
+        "squizlabs/php_codesniffer": "^3.13"
     },
     "license": "GPL-v3",
     "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1968b0cd1a2136222d3c50cb85c554be",
+    "content-hash": "d6bbbd5001e2a0c92a1981f080511d26",
     "packages": [
         {
             "name": "krokedil/shop-widgets",
@@ -69,28 +69,28 @@
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.0.0",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da"
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
+                "composer-plugin-api": "^2.2",
                 "php": ">=5.4",
                 "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
-                "composer/composer": "*",
+                "composer/composer": "^2.2",
                 "ext-json": "*",
                 "ext-zip": "*",
-                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9.0",
                 "yoast/phpunit-polyfills": "^1.0"
             },
@@ -110,9 +110,9 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl",
-                    "role": "Developer / IT Manager"
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
                 },
                 {
                     "name": "Contributors",
@@ -120,7 +120,6 @@
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -141,9 +140,28 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
                 "source": "https://github.com/PHPCSStandards/composer-installer"
             },
-            "time": "2023-01-05T11:28:13+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-07-17T20:45:56+00:00"
         },
         {
             "name": "php-stubs/woocommerce-stubs",
@@ -191,16 +209,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.8.1",
+            "version": "v6.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "92e444847d94f7c30f88c60004648f507688acd5"
+                "reference": "9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/92e444847d94f7c30f88c60004648f507688acd5",
-                "reference": "92e444847d94f7c30f88c60004648f507688acd5",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8",
+                "reference": "9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8",
                 "shasum": ""
             },
             "conflict": {
@@ -208,7 +226,7 @@
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-                "nikic/php-parser": "^5.4",
+                "nikic/php-parser": "^5.5",
                 "php": "^7.4 || ^8.0",
                 "php-stubs/generator": "^0.8.3",
                 "phpdocumentor/reflection-docblock": "^5.4.1",
@@ -236,35 +254,35 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.8.1"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.8.2"
             },
-            "time": "2025-05-02T12:33:34+00:00"
+            "time": "2025-07-16T06:41:00+00:00"
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "46d08eb86eec622b96c466adec3063adfed280dd"
+                "reference": "fa4b8d051e278072928e32d817456a7fdb57b6ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/46d08eb86eec622b96c466adec3063adfed280dd",
-                "reference": "46d08eb86eec622b96c466adec3063adfed280dd",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/fa4b8d051e278072928e32d817456a7fdb57b6ca",
+                "reference": "fa4b8d051e278072928e32d817456a7fdb57b6ca",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.0.9",
-                "squizlabs/php_codesniffer": "^3.12.1"
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.0 || ^4.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcsstandards/phpcsdevcs": "^1.1.6",
                 "phpcsstandards/phpcsdevtools": "^1.2.1",
-                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -320,33 +338,33 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-04-20T23:35:32+00:00"
+            "time": "2025-06-14T07:40:39+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.12",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c"
+                "reference": "f7eb16f2fa4237d5db9e8fed8050239bee17a9bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/87b233b00daf83fb70f40c9a28692be017ea7c6c",
-                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/f7eb16f2fa4237d5db9e8fed8050239bee17a9bd",
+                "reference": "f7eb16f2fa4237d5db9e8fed8050239bee17a9bd",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.10.0 || 4.0.x-dev@dev"
+                "squizlabs/php_codesniffer": "^3.13.0 || ^4.0"
             },
             "require-dev": {
                 "ext-filter": "*",
                 "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcsstandards/phpcsdevcs": "^1.1.6",
-                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0"
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -383,6 +401,7 @@
                 "phpcodesniffer-standard",
                 "phpcs",
                 "phpcs3",
+                "phpcs4",
                 "standards",
                 "static analysis",
                 "tokens",
@@ -406,22 +425,26 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-05-20T13:34:27+00:00"
+            "time": "2025-08-10T01:04:45+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.0",
+            "version": "3.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "65ff2489553b83b4597e89c3b8b721487011d186"
+                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/65ff2489553b83b4597e89c3b8b721487011d186",
-                "reference": "65ff2489553b83b4597e89c3b8b721487011d186",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5b5e3821314f947dd040c70f7992a64eac89025c",
+                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c",
                 "shasum": ""
             },
             "require": {
@@ -492,20 +515,20 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-05-11T03:36:00+00:00"
+            "time": "2025-06-17T22:17:01+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.1.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "9333efcbff231f10dfd9c56bb7b65818b4733ca7"
+                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/9333efcbff231f10dfd9c56bb7b65818b4733ca7",
-                "reference": "9333efcbff231f10dfd9c56bb7b65818b4733ca7",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/d2421de7cec3274ae622c22c744de9a62c7925af",
+                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af",
                 "shasum": ""
             },
             "require": {
@@ -514,13 +537,13 @@
                 "ext-tokenizer": "*",
                 "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "phpcsstandards/phpcsextra": "^1.2.1",
-                "phpcsstandards/phpcsutils": "^1.0.10",
-                "squizlabs/php_codesniffer": "^3.9.0"
+                "phpcsstandards/phpcsextra": "^1.4.0",
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9.0",
                 "phpcsstandards/phpcsdevtools": "^1.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
@@ -558,18 +581,18 @@
                     "type": "custom"
                 }
             ],
-            "time": "2024-03-25T16:39:00+00:00"
+            "time": "2025-07-24T20:08:31+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "~7.4 || ~8.0"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4"
     },

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -57,6 +57,7 @@ function collector_wc_show_snippet() {
 			WC()->session->set( 'collector_public_token', $collector_order['data']['publicToken'] );
 			WC()->session->set( 'collector_private_id', $collector_order['data']['privateId'] );
 			WC()->session->set( 'collector_currency', get_woocommerce_currency() );
+			WC()->session->set( 'collector_billing_country', WC()->customer->get_billing_country() );
 
 			$public_token = $collector_order['data']['publicToken'];
 			$output       = array(
@@ -933,8 +934,10 @@ function wc_collector_get_available_customer_types() {
 			$b2b_set = ! empty( $collector_settings['collector_merchant_id_fi_b2b'] ?? false );
 		}
 
-		// For EUR currency, if FI is not set, check if EU B2C is set. This also applies to other countries that use EUR currency.
-		$b2c_set = empty( $b2c_set ) ? ! empty( $collector_settings['collector_merchant_id_eu_b2c'] ?? false ) : false;
+		// For EUR currency, if FI B2C is not set, check if EU B2C is set. This also applies to other countries that use EUR currency.
+		if ( ! $b2c_set ) {
+			$b2c_set = ! empty( $collector_settings['collector_merchant_id_eu_b2c'] ?? false );
+		}
 	} else {
 		// Get the merchant id for the selected country, for both B2C and B2B.
 		$b2c_set = ! empty( $collector_settings[ "collector_merchant_id_{$country}_b2c" ] ?? false );

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -925,19 +925,21 @@ function wc_collector_get_available_customer_types() {
 		return false;
 	}
 
-	// For EUR, if FI is set, prefer it. If not, fallback to EU.
 	$b2c_set = false;
+	$b2b_set = false;
 	if ( 'EUR' === $currency ) {
 		if ( 'fi' === $country ) {
 			$b2c_set = ! empty( $collector_settings['collector_merchant_id_fi_b2c'] ?? false );
+			$b2b_set = ! empty( $collector_settings['collector_merchant_id_fi_b2b'] ?? false );
 		}
 
-		$b2c_set = empty( $b2c_set ) ? ! empty( $collector_settings['collector_merchant_id_eu_b2c'] ) : $b2c_set;
+		// For EUR currency, if FI is not set, check if EU B2C is set.
+		$b2c_set = empty( $b2c_set ) ? ! empty( $collector_settings['collector_merchant_id_eu_b2c'] ?? false ) : false;
+	} else {
+		// Get the merchant id for the selected country, for both B2C and B2B.
+		$b2c_set = ! empty( $collector_settings[ "collector_merchant_id_{$country}_b2c" ] ?? false );
+		$b2b_set = ! empty( $collector_settings[ "collector_merchant_id_{$country}_b2b" ] ?? false );
 	}
-
-	// Get the merchant id for the selected country, for both B2C and B2B.
-	$b2c_set = empty( $b2c_set ) ? ! empty( $collector_settings[ "collector_merchant_id_{$country}_b2c" ] ) : $b2c_set;
-	$b2b_set = ! empty( $collector_settings[ "collector_merchant_id_{$country}_b2b" ] ?? false );
 
 	// Build the return value dynamically based on the availability of b2c and b2b.
 	$result = 'collector-';

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -933,7 +933,7 @@ function wc_collector_get_available_customer_types() {
 			$b2b_set = ! empty( $collector_settings['collector_merchant_id_fi_b2b'] ?? false );
 		}
 
-		// For EUR currency, if FI is not set, check if EU B2C is set.
+		// For EUR currency, if FI is not set, check if EU B2C is set. This also applies to other countries that use EUR currency.
 		$b2c_set = empty( $b2c_set ) ? ! empty( $collector_settings['collector_merchant_id_eu_b2c'] ?? false ) : false;
 	} else {
 		// Get the merchant id for the selected country, for both B2C and B2B.

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -139,6 +139,8 @@ function wc_collector_unset_sessions() {
 		if ( WC()->session->get( 'collector_currency' ) ) {
 			WC()->session->__unset( 'collector_currency' );
 		}
+
+		WC()->session->__unset( 'collector_billing_country' );
 	}
 }
 

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -925,8 +925,18 @@ function wc_collector_get_available_customer_types() {
 		return false;
 	}
 
+	// For EUR, if FI is set, prefer it. If not, fallback to EU.
+	$b2c_set = false;
+	if ( 'EUR' === $currency ) {
+		if ( 'fi' === $country ) {
+			$b2c_set = ! empty( $collector_settings['collector_merchant_id_fi_b2c'] ?? false );
+		}
+
+		$b2c_set = empty( $b2c_set ) ? ! empty( $collector_settings['collector_merchant_id_eu_b2c'] ) : $b2c_set;
+	}
+
 	// Get the merchant id for the selected country, for both B2C and B2B.
-	$b2c_set = ! empty( $collector_settings[ "collector_merchant_id_{$country}_b2c" ] ?? false );
+	$b2c_set = empty( $b2c_set ) ? ! empty( $collector_settings[ "collector_merchant_id_{$country}_b2c" ] ) : $b2c_set;
 	$b2b_set = ! empty( $collector_settings[ "collector_merchant_id_{$country}_b2b" ] ?? false );
 
 	// Build the return value dynamically based on the availability of b2c and b2b.

--- a/includes/collector-checkout-settings.php
+++ b/includes/collector-checkout-settings.php
@@ -65,10 +65,10 @@ $settings = array(
 		'title' => __( 'EU', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
 	),
-	'collector_merchant_id_eu_b2b'    => array(
-		'title'       => __( 'Merchant ID EU B2B', 'collector-checkout-for-woocommerce' ),
+	'collector_merchant_id_eu_b2c'    => array(
+		'title'       => __( 'Merchant ID EU B2C', 'collector-checkout-for-woocommerce' ),
 		'type'        => 'text',
-		'description' => __( 'Enter your Walley Checkout Merchant ID for B2B purchases in EU', 'collector-checkout-for-woocommerce' ),
+		'description' => __( 'Enter your Walley Checkout Merchant ID for B2C purchases in EU', 'collector-checkout-for-woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
 	),

--- a/includes/collector-checkout-settings.php
+++ b/includes/collector-checkout-settings.php
@@ -60,6 +60,29 @@ $settings = array(
 		'default'     => '',
 		'desc_tip'    => false,
 	),
+
+	'eu_settings_title'               => array(
+		'title' => __( 'EU', 'collector-checkout-for-woocommerce' ),
+		'type'  => 'title',
+	),
+	'collector_merchant_id_eu_b2b'    => array(
+		'title'       => __( 'Merchant ID EU B2B', 'collector-checkout-for-woocommerce' ),
+		'type'        => 'text',
+		'description' => __( 'Enter your Walley Checkout Merchant ID for B2B purchases in EU', 'collector-checkout-for-woocommerce' ),
+		'default'     => '',
+		'desc_tip'    => true,
+	),
+	'collector_delivery_module_eu'    => array(
+		'title'   => __( 'Walley nShift Delivery', 'collector-checkout-for-woocommerce' ),
+		'type'    => 'checkbox',
+		'label'   => __( 'Activate Walley nShift Delivery EU', 'collector-checkout-for-woocommerce' ),
+		'default' => 'no',
+	),
+	'collector_custom_profile_eu'     => array(
+		'title'   => __( 'Custom Profile EU', 'collector-checkout-for-woocommerce' ),
+		'type'    => 'text',
+		'default' => '',
+	),
 	'se_settings_title'               => array(
 		'title' => __( 'Sweden', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
@@ -85,10 +108,9 @@ $settings = array(
 		'default' => 'no',
 	),
 	'collector_custom_profile_se'     => array(
-		'title'       => __( 'Custom Profile Sweden', 'collector-checkout-for-woocommerce' ),
-		'type'        => 'text',
-		'description' => __( '', 'collector-checkout-for-woocommerce' ),
-		'default'     => '',
+		'title'   => __( 'Custom Profile Sweden', 'collector-checkout-for-woocommerce' ),
+		'type'    => 'text',
+		'default' => '',
 	),
 	'no_settings_title'               => array(
 		'title' => __( 'Norway', 'collector-checkout-for-woocommerce' ),
@@ -115,10 +137,9 @@ $settings = array(
 		'default' => 'no',
 	),
 	'collector_custom_profile_no'     => array(
-		'title'       => __( 'Custom Profile Norway', 'collector-checkout-for-woocommerce' ),
-		'type'        => 'text',
-		'description' => __( '', 'collector-checkout-for-woocommerce' ),
-		'default'     => '',
+		'title'   => __( 'Custom Profile Norway', 'collector-checkout-for-woocommerce' ),
+		'type'    => 'text',
+		'default' => '',
 	),
 	'fi_settings_title'               => array(
 		'title' => __( 'Finland', 'collector-checkout-for-woocommerce' ),
@@ -145,10 +166,9 @@ $settings = array(
 		'default' => 'no',
 	),
 	'collector_custom_profile_fi'     => array(
-		'title'       => __( 'Custom Profile Finland', 'collector-checkout-for-woocommerce' ),
-		'type'        => 'text',
-		'description' => __( '', 'collector-checkout-for-woocommerce' ),
-		'default'     => '',
+		'title'   => __( 'Custom Profile Finland', 'collector-checkout-for-woocommerce' ),
+		'type'    => 'text',
+		'default' => '',
 	),
 	'dk_settings_title'               => array(
 		'title' => __( 'Denmark', 'collector-checkout-for-woocommerce' ),
@@ -175,10 +195,9 @@ $settings = array(
 		'default' => 'no',
 	),
 	'collector_custom_profile_dk'     => array(
-		'title'       => __( 'Custom Profile Denmark', 'collector-checkout-for-woocommerce' ),
-		'type'        => 'text',
-		'description' => __( '', 'collector-checkout-for-woocommerce' ),
-		'default'     => '',
+		'title'   => __( 'Custom Profile Denmark', 'collector-checkout-for-woocommerce' ),
+		'type'    => 'text',
+		'default' => '',
 	),
 	'checkout_settings_title'         => array(
 		'title' => __( 'Checkout settings', 'collector-checkout-for-woocommerce' ),

--- a/includes/collector-checkout-settings.php
+++ b/includes/collector-checkout-settings.php
@@ -60,29 +60,6 @@ $settings = array(
 		'default'     => '',
 		'desc_tip'    => false,
 	),
-
-	'eu_settings_title'               => array(
-		'title' => __( 'EU', 'collector-checkout-for-woocommerce' ),
-		'type'  => 'title',
-	),
-	'collector_merchant_id_eu_b2c'    => array(
-		'title'       => __( 'Merchant ID EU B2C', 'collector-checkout-for-woocommerce' ),
-		'type'        => 'text',
-		'description' => __( 'Enter your Walley Checkout Merchant ID for B2C purchases in EU', 'collector-checkout-for-woocommerce' ),
-		'default'     => '',
-		'desc_tip'    => true,
-	),
-	'collector_delivery_module_eu'    => array(
-		'title'   => __( 'Walley nShift Delivery', 'collector-checkout-for-woocommerce' ),
-		'type'    => 'checkbox',
-		'label'   => __( 'Activate Walley nShift Delivery EU', 'collector-checkout-for-woocommerce' ),
-		'default' => 'no',
-	),
-	'collector_custom_profile_eu'     => array(
-		'title'   => __( 'Custom Profile EU', 'collector-checkout-for-woocommerce' ),
-		'type'    => 'text',
-		'default' => '',
-	),
 	'se_settings_title'               => array(
 		'title' => __( 'Sweden', 'collector-checkout-for-woocommerce' ),
 		'type'  => 'title',
@@ -196,6 +173,28 @@ $settings = array(
 	),
 	'collector_custom_profile_dk'     => array(
 		'title'   => __( 'Custom Profile Denmark', 'collector-checkout-for-woocommerce' ),
+		'type'    => 'text',
+		'default' => '',
+	),
+	'eu_settings_title'               => array(
+		'title' => __( 'EU', 'collector-checkout-for-woocommerce' ),
+		'type'  => 'title',
+	),
+	'collector_merchant_id_eu_b2c'    => array(
+		'title'       => __( 'Merchant ID EU B2C', 'collector-checkout-for-woocommerce' ),
+		'type'        => 'text',
+		'description' => __( 'Enter your Walley Checkout Merchant ID for B2C purchases in EU', 'collector-checkout-for-woocommerce' ),
+		'default'     => '',
+		'desc_tip'    => true,
+	),
+	'collector_delivery_module_eu'    => array(
+		'title'   => __( 'Walley nShift Delivery', 'collector-checkout-for-woocommerce' ),
+		'type'    => 'checkbox',
+		'label'   => __( 'Activate Walley nShift Delivery EU', 'collector-checkout-for-woocommerce' ),
+		'default' => 'no',
+	),
+	'collector_custom_profile_eu'     => array(
+		'title'   => __( 'Custom Profile EU', 'collector-checkout-for-woocommerce' ),
 		'type'    => 'text',
 		'default' => '',
 	),


### PR DESCRIPTION
https://app.clickup.com/t/8699dzkk8

This is the same PR as https://github.com/krokedil/collector-checkout-for-woocommerce/pull/255, but with an extra commit that fixes issues related to EU/FI logic. Also the current develop branch is merged into this bransch.

The changes in [the extra commit](https://github.com/krokedil/collector-checkout-for-woocommerce/commit/3b3e77527c4214d4184d6876c70e041f155b4590) is the following:

* Set WC session `collector_billing_country` directly when initializing a new Walley session.
* Fix issue related to which store_id to use when EUR is the selected currency in `set_environment_variables` method.
* Improve logic in `maybe_clear_session_on_country_change` method to detect when to clear session (related to EUR).
* Improve logic in `wc_collector_get_available_customer_types` function when $b2c_set is set (for EUR).
* Check if a new Walley session should be created in both `woocommerce_before_calculate_totals` and `woocommerce_after_calculate_totals` method. `woocommerce_before_calculate_totals` is used for scenarios when country has changed in Walleys checkout. `woocommerce_before_calculate_totals` is used for scenarios when country has changed in Woo.