### PR TITLE
Develop already activated status

### DIFF
--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -95,7 +95,7 @@ class Walley_Checkout_Order_Management {
 				$text          = __( 'Part activate Walley Checkout order error: ', 'collector-checkout-for-woocommerce' ) . '%s %s';
 				$formated_text = sprintf( $text, $code, $message );
 				$order->add_order_note( $formated_text );
-				$order->update_status( 'on-hold' );
+				$this->maybe_set_order_on_hold( $order, $message, $code );
 				return;
 			}
 
@@ -123,7 +123,7 @@ class Walley_Checkout_Order_Management {
 				$text          = __( 'Activate Walley Checkout order error: ', 'collector-checkout-for-woocommerce' ) . '%s %s';
 				$formated_text = sprintf( $text, $code, $message );
 				$order->add_order_note( $formated_text );
-				$order->update_status( 'on-hold' );
+				$this->maybe_set_order_on_hold( $order, $message, $code );
 				return;
 			}
 
@@ -411,5 +411,22 @@ class Walley_Checkout_Order_Management {
 			}
 		}
 		return $order_number;
+	}
+
+	/**
+	 * Maybe set order on hold based on error code and message.
+	 *
+	 * @param WC_Order $order The WooCommerce order.
+	 * @param string   $message The error message.
+	 * @param string   $code The error code.
+	 */
+	public function maybe_set_order_on_hold( $order, $message, $code ) {
+
+		// If the order is simply already captured there's no need to set on-hold.
+		if ( 422 === $code && strpos( $message, 'CAPTURE_ORDER_ALREADY_CAPTURED' ) !== false ) {
+			return;
+		}
+
+		$order->update_status( 'on-hold' );
 	}
 }

--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -95,8 +95,12 @@ class Walley_Checkout_Order_Management {
 				$text          = __( 'Part activate Walley Checkout order error: ', 'collector-checkout-for-woocommerce' ) . '%s %s';
 				$formated_text = sprintf( $text, $code, $message );
 				$order->add_order_note( $formated_text );
-				$this->maybe_set_order_on_hold( $order, $message, $code );
-				return;
+
+				$set_order_on_hold = $this->maybe_set_order_on_hold( $message, $code );
+				if ( $set_order_on_hold ) {
+					$order->update_status( 'on-hold' );
+					return;
+				}
 			}
 
 			// Translators: Activated amount.
@@ -123,8 +127,12 @@ class Walley_Checkout_Order_Management {
 				$text          = __( 'Activate Walley Checkout order error: ', 'collector-checkout-for-woocommerce' ) . '%s %s';
 				$formated_text = sprintf( $text, $code, $message );
 				$order->add_order_note( $formated_text );
-				$this->maybe_set_order_on_hold( $order, $message, $code );
-				return;
+
+				$set_order_on_hold = $this->maybe_set_order_on_hold( $message, $code );
+				if ( $set_order_on_hold ) {
+					$order->update_status( 'on-hold' );
+					return;
+				}
 			}
 
 			$note = __( 'Walley Checkout order activated.', 'collector-checkout-for-woocommerce' );
@@ -416,17 +424,16 @@ class Walley_Checkout_Order_Management {
 	/**
 	 * Maybe set order on hold based on error code and message.
 	 *
-	 * @param WC_Order $order The WooCommerce order.
-	 * @param string   $message The error message.
-	 * @param string   $code The error code.
+	 * @param string $message The error message.
+	 * @param string $code The error code.
 	 */
-	private function maybe_set_order_on_hold( $order, $message, $code ) {
+	private function maybe_set_order_on_hold( $message, $code ) {
 
 		// If the order is simply already captured there's no need to set on-hold.
 		if ( 422 === (int) $code && strpos( $message, 'CAPTURE_ORDER_ALREADY_CAPTURED' ) !== false ) {
-			return;
+			return false;
 		}
 
-		$order->update_status( 'on-hold' );
+		return true;
 	}
 }

--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -90,14 +90,14 @@ class Walley_Checkout_Order_Management {
 
 			if ( is_wp_error( $response ) ) {
 				// If error save error message.
-				$code          = $response->get_error_code();
-				$message       = $response->get_error_message();
-				$text          = __( 'Part activate Walley Checkout order error: ', 'collector-checkout-for-woocommerce' ) . '%s %s';
-				$formated_text = sprintf( $text, $code, $message );
-				$order->add_order_note( $formated_text );
+				$code    = $response->get_error_code();
+				$message = $response->get_error_message();
 
 				$set_order_on_hold = $this->maybe_set_order_on_hold( $message, $code );
 				if ( $set_order_on_hold ) {
+					$text          = __( 'Part activate Walley Checkout order error: ', 'collector-checkout-for-woocommerce' ) . '%s %s';
+					$formated_text = sprintf( $text, $code, $message );
+					$order->add_order_note( $formated_text );
 					$order->update_status( 'on-hold' );
 					return;
 				}
@@ -122,14 +122,14 @@ class Walley_Checkout_Order_Management {
 
 			if ( is_wp_error( $response ) ) {
 				// If error save error message.
-				$code          = $response->get_error_code();
-				$message       = $response->get_error_message();
-				$text          = __( 'Activate Walley Checkout order error: ', 'collector-checkout-for-woocommerce' ) . '%s %s';
-				$formated_text = sprintf( $text, $code, $message );
-				$order->add_order_note( $formated_text );
+				$code    = $response->get_error_code();
+				$message = $response->get_error_message();
 
 				$set_order_on_hold = $this->maybe_set_order_on_hold( $message, $code );
 				if ( $set_order_on_hold ) {
+					$text          = __( 'Activate Walley Checkout order error: ', 'collector-checkout-for-woocommerce' ) . '%s %s';
+					$formated_text = sprintf( $text, $code, $message );
+					$order->add_order_note( $formated_text );
 					$order->update_status( 'on-hold' );
 					return;
 				}

--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -423,7 +423,7 @@ class Walley_Checkout_Order_Management {
 	public function maybe_set_order_on_hold( $order, $message, $code ) {
 
 		// If the order is simply already captured there's no need to set on-hold.
-		if ( 422 === $code && strpos( $message, 'CAPTURE_ORDER_ALREADY_CAPTURED' ) !== false ) {
+		if ( 422 === (int) $code && strpos( $message, 'CAPTURE_ORDER_ALREADY_CAPTURED' ) !== false ) {
 			return;
 		}
 

--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -420,7 +420,7 @@ class Walley_Checkout_Order_Management {
 	 * @param string   $message The error message.
 	 * @param string   $code The error code.
 	 */
-	public function maybe_set_order_on_hold( $order, $message, $code ) {
+	private function maybe_set_order_on_hold( $order, $message, $code ) {
 
 		// If the order is simply already captured there's no need to set on-hold.
 		if ( 422 === (int) $code && strpos( $message, 'CAPTURE_ORDER_ALREADY_CAPTURED' ) !== false ) {


### PR DESCRIPTION
Check the returned error from Walley on order completion, to avoid updating the order status to "on hold" when the order has simply already been captured through the merchant portal.