### PR TITLE
Provide statuses to transient

### DIFF
--- a/classes/class-walley-checkout-meta-box.php
+++ b/classes/class-walley-checkout-meta-box.php
@@ -56,36 +56,28 @@ class Walley_Checkout_Meta_Box {
 		$title_walley_order_total   = __( 'Walley order total', 'collector-checkout-for-woocommerce' );
 		$title_order_total_mismatch = __( 'Order total mismatch', 'collector-checkout-for-woocommerce' );
 
-		if ( empty( $walley_order_status_from_transient = get_transient( "walley_order_status_{$order_id}" ) ) ) {
-			$walley_order = CCO_WC()->api->get_walley_order( $walley_order_id );
+		$walley_order = CCO_WC()->api->get_walley_order( $walley_order_id );
 
-			if ( is_wp_error( $walley_order ) ) {
-				$walley_order_status   = 'unknown';
-				$walley_order_total    = '';
-				$walley_order_currency = '';
-				$order_total_mismatch  = '';
-			} else {
-				$walley_order_status   = $walley_order['data']['status'] ?? 'unknown';
-				$walley_order_total    = $walley_order['data']['totalAmount'] ?? '';
-				$walley_order_currency = $walley_order['data']['currency'] ?? '';
-				// Translators: Woo order total & Walley order total.
-				$order_total_mismatch = floatval( Collector_Checkout_Requests_Helper_Order_Om::get_order_lines_total_amount( $order_id ) ) !== floatval( $walley_order_total ) ? sprintf( __( '<i>Order total differs between systems (WooCommerce: %1$s, Walley: %2$s)</i>', 'collector-checkout-for-woocommerce' ), Collector_Checkout_Requests_Helper_Order_Om::get_order_lines_total_amount( $order_id ), $walley_order_total ) : '';
-				// Save received data to WP transient.
-				walley_save_order_data_to_transient(
-					array(
-						'order_id'     => $order_id,
-						'status'       => $walley_order_status,
-						'total_amount' => $walley_order_total,
-						'currency'     => $walley_order_currency,
-					)
-				);
-			}
+		if ( is_wp_error( $walley_order ) ) {
+			$walley_order_status   = 'unknown';
+			$walley_order_total    = '';
+			$walley_order_currency = '';
+			$order_total_mismatch  = '';
 		} else {
-			$walley_order_status   = $walley_order_status_from_transient['status'] ?? 'unknown';
-			$walley_order_total    = $walley_order_status_from_transient['total_amount'] ?? '';
-			$walley_order_currency = $walley_order_status_from_transient['currency'] ?? '';
+			$walley_order_status   = $walley_order['data']['status'] ?? 'unknown';
+			$walley_order_total    = $walley_order['data']['totalAmount'] ?? '';
+			$walley_order_currency = $walley_order['data']['currency'] ?? '';
 			// Translators: Woo order total & Walley order total.
 			$order_total_mismatch = floatval( Collector_Checkout_Requests_Helper_Order_Om::get_order_lines_total_amount( $order_id ) ) !== floatval( $walley_order_total ) ? sprintf( __( '<i>Order total differs between systems (WooCommerce: %1$s, Walley: %2$s)</i>', 'collector-checkout-for-woocommerce' ), Collector_Checkout_Requests_Helper_Order_Om::get_order_lines_total_amount( $order_id ), $walley_order_total ) : '';
+			// Save received data to WP transient.
+			walley_save_order_data_to_transient(
+				array(
+					'order_id'     => $order_id,
+					'status'       => $walley_order_status,
+					'total_amount' => $walley_order_total,
+					'currency'     => $walley_order_currency,
+				)
+			);
 		}
 
 		$keys_for_meta_box = array(

--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -84,6 +84,9 @@ class Walley_Checkout_Order_Management {
 			return;
 		}
 
+		$walley_order_id = $order->get_meta( '_collector_order_id', true );
+		$order_status    = '';
+
 		// Part activate or activate the entire order.
 		if ( 'yes' === $this->activate_individual_order_lines || apply_filters( 'wpd_delivery_order_type', 'shop_order_delivery', $order ) === $order->get_type() ) {
 			$response = CCO_WC()->api->part_capture_walley_order( $order_id );
@@ -104,11 +107,16 @@ class Walley_Checkout_Order_Management {
 			$order->update_meta_data( '_collector_order_activated', time() );
 			$order->save();
 
+			$walley_order = CCO_WC()->api->get_walley_order( $walley_order_id );
+			if ( ! is_wp_error( $walley_order ) ) {
+				$order_status = $walley_order['data']['status'] ?? '';
+			}
+
 			// Save received data to WP transient.
 			walley_save_order_data_to_transient(
 				array(
 					'order_id'     => $order_id,
-					'status'       => 'PartActivated',
+					'status'       => $order_status,
 					'total_amount' => $order->get_total(),
 					'currency'     => $order->get_currency(),
 				)
@@ -133,11 +141,16 @@ class Walley_Checkout_Order_Management {
 			$order->update_meta_data( '_collector_order_activated', time() );
 			$order->save();
 
+			$walley_order = CCO_WC()->api->get_walley_order( $walley_order_id );
+			if ( ! is_wp_error( $walley_order ) ) {
+				$order_status = $walley_order['data']['status'] ?? '';
+			}
+
 			// Save received data to WP transient.
 			walley_save_order_data_to_transient(
 				array(
 					'order_id'     => $order_id,
-					'status'       => 'Activated',
+					'status'       => $order_status,
 					'total_amount' => $order->get_total(),
 					'currency'     => $order->get_currency(),
 				)
@@ -201,11 +214,19 @@ class Walley_Checkout_Order_Management {
 		$order->update_meta_data( '_collector_order_cancelled', time() );
 		$order->save();
 
+		$walley_order_id = $order->get_meta( '_collector_order_id', true );
+		$order_status    = '';
+
+		$walley_order = CCO_WC()->api->get_walley_order( $walley_order_id );
+		if ( ! is_wp_error( $walley_order ) ) {
+			$order_status = $walley_order['data']['status'] ?? '';
+		}
+
 		// Save received data to WP transient.
 		walley_save_order_data_to_transient(
 			array(
 				'order_id'     => $order_id,
-				'status'       => 'Cancelled',
+				'status'       => $order_status,
 				'total_amount' => $order->get_total(),
 				'currency'     => $order->get_currency(),
 			)
@@ -271,11 +292,19 @@ class Walley_Checkout_Order_Management {
 			return $response;
 		}
 
+		$walley_order_id = $order->get_meta( '_collector_order_id', true );
+		$order_status    = '';
+
+		$walley_order = CCO_WC()->api->get_walley_order( $walley_order_id );
+		if ( ! is_wp_error( $walley_order ) ) {
+			$order_status = $walley_order['data']['status'] ?? '';
+		}
+
 		// Save received data to WP transient.
 		walley_save_order_data_to_transient(
 			array(
 				'order_id'     => $order_id,
-				'status'       => 'Refunded',
+				'status'       => $order_status,
 				'total_amount' => $order->get_total(),
 				'currency'     => $order->get_currency(),
 			)

--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -274,9 +274,10 @@ class Walley_Checkout_Order_Management {
 		// Save received data to WP transient.
 		walley_save_order_data_to_transient(
 			array(
-				'order_id' => $order_id,
-				'status'   => 'Refunded',
-				'currency' => $order->get_currency(),
+				'order_id'     => $order_id,
+				'status'       => 'Refunded',
+				'total_amount' => $order->get_total(),
+				'currency'     => $order->get_currency(),
 			)
 		);
 

--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -108,6 +108,7 @@ class Walley_Checkout_Order_Management {
 			walley_save_order_data_to_transient(
 				array(
 					'order_id'     => $order_id,
+					'status'       => 'PartActivated',
 					'total_amount' => $order->get_total(),
 					'currency'     => $order->get_currency(),
 				)
@@ -136,6 +137,7 @@ class Walley_Checkout_Order_Management {
 			walley_save_order_data_to_transient(
 				array(
 					'order_id'     => $order_id,
+					'status'       => 'Activated',
 					'total_amount' => $order->get_total(),
 					'currency'     => $order->get_currency(),
 				)
@@ -203,6 +205,7 @@ class Walley_Checkout_Order_Management {
 		walley_save_order_data_to_transient(
 			array(
 				'order_id'     => $order_id,
+				'status'       => 'Cancelled',
 				'total_amount' => $order->get_total(),
 				'currency'     => $order->get_currency(),
 			)
@@ -272,6 +275,7 @@ class Walley_Checkout_Order_Management {
 		walley_save_order_data_to_transient(
 			array(
 				'order_id' => $order_id,
+				'status'   => 'Refunded',
 				'currency' => $order->get_currency(),
 			)
 		);

--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -74,6 +74,11 @@ class Walley_Checkout_Order_Management {
 			return;
 		}
 
+		if ( ! empty( $order->get_meta( Walley_Subscription::ZERO_AMOUNT_ORDER ) ) ) {
+			$order->add_order_note( __( 'Walley order activation skipped. This is a zero amount order.', 'collector-checkout-for-woocommerce' ) );
+			return;
+		}
+
 		if ( $order->get_meta( '_collector_order_activated', true ) ) {
 			$order->add_order_note( __( 'Could not activate Walley reservation, Walley reservation is already activated.', 'collector-checkout-for-woocommerce' ) );
 			return;
@@ -84,22 +89,23 @@ class Walley_Checkout_Order_Management {
 			return;
 		}
 
-		$walley_order_id = $order->get_meta( '_collector_order_id', true );
-		$order_status    = '';
-
 		// Part activate or activate the entire order.
 		if ( 'yes' === $this->activate_individual_order_lines || apply_filters( 'wpd_delivery_order_type', 'shop_order_delivery', $order ) === $order->get_type() ) {
 			$response = CCO_WC()->api->part_capture_walley_order( $order_id );
 
 			if ( is_wp_error( $response ) ) {
 				// If error save error message.
-				$code          = $response->get_error_code();
-				$message       = $response->get_error_message();
-				$text          = __( 'Part activate Walley Checkout order error: ', 'collector-checkout-for-woocommerce' ) . '%s %s';
-				$formated_text = sprintf( $text, $code, $message );
-				$order->add_order_note( $formated_text );
-				$order->update_status( 'on-hold' );
-				return;
+				$code    = $response->get_error_code();
+				$message = $response->get_error_message();
+
+				$set_order_on_hold = $this->maybe_set_order_on_hold( $message, $code );
+				if ( $set_order_on_hold ) {
+					$text          = __( 'Part activate Walley Checkout order error: ', 'collector-checkout-for-woocommerce' ) . '%s %s';
+					$formated_text = sprintf( $text, $code, $message );
+					$order->add_order_note( $formated_text );
+					$order->update_status( 'on-hold' );
+					return;
+				}
 			}
 
 			// Translators: Activated amount.
@@ -107,16 +113,10 @@ class Walley_Checkout_Order_Management {
 			$order->update_meta_data( '_collector_order_activated', time() );
 			$order->save();
 
-			$walley_order = CCO_WC()->api->get_walley_order( $walley_order_id );
-			if ( ! is_wp_error( $walley_order ) ) {
-				$order_status = $walley_order['data']['status'] ?? '';
-			}
-
 			// Save received data to WP transient.
 			walley_save_order_data_to_transient(
 				array(
 					'order_id'     => $order_id,
-					'status'       => $order_status,
 					'total_amount' => $order->get_total(),
 					'currency'     => $order->get_currency(),
 				)
@@ -127,13 +127,17 @@ class Walley_Checkout_Order_Management {
 
 			if ( is_wp_error( $response ) ) {
 				// If error save error message.
-				$code          = $response->get_error_code();
-				$message       = $response->get_error_message();
-				$text          = __( 'Activate Walley Checkout order error: ', 'collector-checkout-for-woocommerce' ) . '%s %s';
-				$formated_text = sprintf( $text, $code, $message );
-				$order->add_order_note( $formated_text );
-				$order->update_status( 'on-hold' );
-				return;
+				$code    = $response->get_error_code();
+				$message = $response->get_error_message();
+
+				$set_order_on_hold = $this->maybe_set_order_on_hold( $message, $code );
+				if ( $set_order_on_hold ) {
+					$text          = __( 'Activate Walley Checkout order error: ', 'collector-checkout-for-woocommerce' ) . '%s %s';
+					$formated_text = sprintf( $text, $code, $message );
+					$order->add_order_note( $formated_text );
+					$order->update_status( 'on-hold' );
+					return;
+				}
 			}
 
 			$note = __( 'Walley Checkout order activated.', 'collector-checkout-for-woocommerce' );
@@ -141,16 +145,10 @@ class Walley_Checkout_Order_Management {
 			$order->update_meta_data( '_collector_order_activated', time() );
 			$order->save();
 
-			$walley_order = CCO_WC()->api->get_walley_order( $walley_order_id );
-			if ( ! is_wp_error( $walley_order ) ) {
-				$order_status = $walley_order['data']['status'] ?? '';
-			}
-
 			// Save received data to WP transient.
 			walley_save_order_data_to_transient(
 				array(
 					'order_id'     => $order_id,
-					'status'       => $order_status,
 					'total_amount' => $order->get_total(),
 					'currency'     => $order->get_currency(),
 				)
@@ -214,19 +212,10 @@ class Walley_Checkout_Order_Management {
 		$order->update_meta_data( '_collector_order_cancelled', time() );
 		$order->save();
 
-		$walley_order_id = $order->get_meta( '_collector_order_id', true );
-		$order_status    = '';
-
-		$walley_order = CCO_WC()->api->get_walley_order( $walley_order_id );
-		if ( ! is_wp_error( $walley_order ) ) {
-			$order_status = $walley_order['data']['status'] ?? '';
-		}
-
 		// Save received data to WP transient.
 		walley_save_order_data_to_transient(
 			array(
 				'order_id'     => $order_id,
-				'status'       => $order_status,
 				'total_amount' => $order->get_total(),
 				'currency'     => $order->get_currency(),
 			)
@@ -292,21 +281,11 @@ class Walley_Checkout_Order_Management {
 			return $response;
 		}
 
-		$walley_order_id = $order->get_meta( '_collector_order_id', true );
-		$order_status    = '';
-
-		$walley_order = CCO_WC()->api->get_walley_order( $walley_order_id );
-		if ( ! is_wp_error( $walley_order ) ) {
-			$order_status = $walley_order['data']['status'] ?? '';
-		}
-
 		// Save received data to WP transient.
 		walley_save_order_data_to_transient(
 			array(
-				'order_id'     => $order_id,
-				'status'       => $order_status,
-				'total_amount' => $order->get_total(),
-				'currency'     => $order->get_currency(),
+				'order_id' => $order_id,
+				'currency' => $order->get_currency(),
 			)
 		);
 
@@ -445,5 +424,21 @@ class Walley_Checkout_Order_Management {
 			}
 		}
 		return $order_number;
+	}
+
+	/**
+	 * Maybe set order on hold based on error code and message.
+	 *
+	 * @param string $message The error message.
+	 * @param string $code The error code.
+	 */
+	private function maybe_set_order_on_hold( $message, $code ) {
+
+		// If the order is simply already captured there's no need to set on-hold.
+		if ( 422 === (int) $code && strpos( $message, 'CAPTURE_ORDER_ALREADY_CAPTURED' ) !== false ) {
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/classes/requests/manage-orders/get/class-walley-checkout-request-get-order.php
+++ b/classes/requests/manage-orders/get/class-walley-checkout-request-get-order.php
@@ -13,6 +13,13 @@ defined( 'ABSPATH' ) || exit;
 class Walley_Checkout_Request_Get_Order extends Walley_Checkout_Request_Get {
 
 	/**
+	 * The order ID.
+	 *
+	 * @var string
+	 */
+	protected $order_id;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param array $arguments The request arguments.


### PR DESCRIPTION
Provide status to transient for all order statuses, used to display "Walley order status" in the order metabox.

Not sure if we orthodoxly want to use the status returned from Walley in the metabox, but from what I can see, we do not receive any in these particular responses. 

Maybe better to input some status here than to leave it empty? 