### PR TITLE
Prevent infinite checkout reload

### DIFF
--- a/classes/class-walley-checkout.php
+++ b/classes/class-walley-checkout.php
@@ -154,7 +154,6 @@ class Walley_Checkout {
 			return;
 		}
 
-		// Abort update if we don't have any Walley session identifiers yet.
 		$public_token = WC()->session->get( 'collector_public_token' );
 		$private_id   = WC()->session->get( 'collector_private_id' );
 		if ( empty( $public_token ) && empty( $private_id ) ) {

--- a/classes/class-walley-checkout.php
+++ b/classes/class-walley-checkout.php
@@ -442,7 +442,9 @@ class Walley_Checkout {
 
 		if ( $clear_session ) {
 			wc_collector_unset_sessions();
-			WC()->session->reload_checkout = true;
+			if ( ! WC()->session->get( 'collector_error_no_reload_needed' ) ) {
+				WC()->session->reload_checkout = true;
+			}
 		}
 
 		return $clear_session;

--- a/classes/class-walley-checkout.php
+++ b/classes/class-walley-checkout.php
@@ -445,8 +445,6 @@ class Walley_Checkout {
 			if ( ! WC()->session->get( 'collector_error_no_reload_needed' ) ) {
 				WC()->session->reload_checkout = true;
 			}
-
-			WC()->session->set( 'collector_error_no_reload_needed', false );
 		}
 
 		return $clear_session;

--- a/classes/class-walley-checkout.php
+++ b/classes/class-walley-checkout.php
@@ -156,6 +156,8 @@ class Walley_Checkout {
 
 		$public_token = WC()->session->get( 'collector_public_token' );
 		$private_id   = WC()->session->get( 'collector_private_id' );
+
+		// If we don't have a public token or private id, show an error message and bail.
 		if ( empty( $public_token ) && empty( $private_id ) ) {
 			$notice = __( 'Unable to update checkout right now. Please try again in a moment.', 'collector-checkout-for-woocommerce' );
 			if ( ! wc_has_notice( $notice, 'error' ) ) {
@@ -193,7 +195,6 @@ class Walley_Checkout {
 			return;
 		}
 
-		$private_id = WC()->session->get( 'collector_private_id' );
 		if ( empty( $private_id ) ) {
 			CCO_WC()->logger::log( 'Walley private id is missing in update Walley order function.' );
 			return walley_print_error_message( new WP_Error( 'error', __( 'Missing Walley private id. Possible API error', 'collector-checkout-for-woocommerce' ) ) );

--- a/classes/class-walley-checkout.php
+++ b/classes/class-walley-checkout.php
@@ -445,6 +445,8 @@ class Walley_Checkout {
 			if ( ! WC()->session->get( 'collector_error_no_reload_needed' ) ) {
 				WC()->session->reload_checkout = true;
 			}
+
+			WC()->session->set( 'collector_error_no_reload_needed', false );
 		}
 
 		return $clear_session;

--- a/classes/class-walley-checkout.php
+++ b/classes/class-walley-checkout.php
@@ -154,6 +154,17 @@ class Walley_Checkout {
 			return;
 		}
 
+		// Abort update if we don't have any Walley session identifiers yet.
+		$public_token = WC()->session->get( 'collector_public_token' );
+		$private_id   = WC()->session->get( 'collector_private_id' );
+		if ( empty( $public_token ) && empty( $private_id ) ) {
+			$notice = __( 'Unable to update checkout right now. Please try again in a moment.', 'collector-checkout-for-woocommerce' );
+			if ( ! wc_has_notice( $notice, 'error' ) ) {
+				wc_add_notice( $notice, 'error' );
+			}
+			return;
+		}
+
 		// If we need to reload the checkout, do it now.
 		if ( $this->reload_checkout ) {
 			// Unset sessions and reload checkout has already been set in maybe_clear_session_on_country_change.
@@ -442,9 +453,7 @@ class Walley_Checkout {
 
 		if ( $clear_session ) {
 			wc_collector_unset_sessions();
-			if ( ! WC()->session->get( 'collector_error_no_reload_needed' ) ) {
-				WC()->session->reload_checkout = true;
-			}
+			WC()->session->reload_checkout = true;
 		}
 
 		return $clear_session;

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -43,7 +43,12 @@ function collector_wc_show_snippet() {
 	$collector_currency = WC()->session->get( 'collector_currency' );
 	$private_id         = WC()->session->get( 'collector_private_id' );
 	$session_profile    = WC()->session->get( 'collector_profile' );
-	WC()->session->set( 'collector_error_no_reload_needed', false );
+
+	if ( method_exists( WC()->session, '__unset' ) ) {
+		if ( WC()->session->get( 'collector_error_no_reload_needed' ) ) {
+			WC()->session->__unset( 'collector_error_no_reload_needed' );
+		}
+	}
 
 	// If we don't have a public token or private id, or if the currency or profile has changed since the last request, we need to initialize a new checkout.
 	if ( empty( $public_token ) || empty( $private_id ) || get_woocommerce_currency() !== $collector_currency || $profile !== $session_profile ) {

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -56,7 +56,6 @@ function collector_wc_show_snippet() {
 
 		if ( is_wp_error( $collector_order ) ) {
 			$return = '<ul class="woocommerce-error"><li>' . sprintf( '%s <a href="%s" class="button wc-forward">%s</a>', __( 'Could not connect to Walley. Error message: ', 'collector-checkout-for-woocommerce' ) . $collector_order->get_error_message(), wc_get_checkout_url(), __( 'Try again', 'collector-checkout-for-woocommerce' ) ) . '</li></ul>';
-			WC()->session->set( 'collector_error_no_reload_needed', true );
 		} else {
 			WC()->session->set( 'collector_public_token', $collector_order['data']['publicToken'] );
 			WC()->session->set( 'collector_private_id', $collector_order['data']['privateId'] );

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -43,6 +43,7 @@ function collector_wc_show_snippet() {
 	$collector_currency = WC()->session->get( 'collector_currency' );
 	$private_id         = WC()->session->get( 'collector_private_id' );
 	$session_profile    = WC()->session->get( 'collector_profile' );
+	WC()->session->set( 'collector_error_no_reload_needed', false );
 
 	// If we don't have a public token or private id, or if the currency or profile has changed since the last request, we need to initialize a new checkout.
 	if ( empty( $public_token ) || empty( $private_id ) || get_woocommerce_currency() !== $collector_currency || $profile !== $session_profile ) {
@@ -56,6 +57,7 @@ function collector_wc_show_snippet() {
 
 		if ( is_wp_error( $collector_order ) ) {
 			$return = '<ul class="woocommerce-error"><li>' . sprintf( '%s <a href="%s" class="button wc-forward">%s</a>', __( 'Could not connect to Walley. Error message: ', 'collector-checkout-for-woocommerce' ) . $collector_order->get_error_message(), wc_get_checkout_url(), __( 'Try again', 'collector-checkout-for-woocommerce' ) ) . '</li></ul>';
+			WC()->session->set( 'collector_error_no_reload_needed', true );
 		} else {
 			WC()->session->set( 'collector_public_token', $collector_order['data']['publicToken'] );
 			WC()->session->set( 'collector_private_id', $collector_order['data']['privateId'] );
@@ -1247,9 +1249,9 @@ function walley_is_delivery_enabled( $country, $settings = null ) {
  * @return string 'fi' or 'eu'.
  */
 function walley_get_eur_country( $default_to_store = true ) {
-	$order = false;
+	$order         = false;
 	$customer_type = 'b2c';
-	$location = '';
+	$location      = '';
 	if ( isset( WC()->session ) && method_exists( WC()->session, 'get' ) ) {
 		$customer_type = WC()->session->get( 'collector_customer_type' );
 	} else {

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -44,12 +44,6 @@ function collector_wc_show_snippet() {
 	$private_id         = WC()->session->get( 'collector_private_id' );
 	$session_profile    = WC()->session->get( 'collector_profile' );
 
-	if ( method_exists( WC()->session, '__unset' ) ) {
-		if ( WC()->session->get( 'collector_error_no_reload_needed' ) ) {
-			WC()->session->__unset( 'collector_error_no_reload_needed' );
-		}
-	}
-
 	// If we don't have a public token or private id, or if the currency or profile has changed since the last request, we need to initialize a new checkout.
 	if ( empty( $public_token ) || empty( $private_id ) || get_woocommerce_currency() !== $collector_currency || $profile !== $session_profile ) {
 		// Get a new public token from Collector.


### PR DESCRIPTION
Prevents an infinite checkout refresh loop when the store ID does not support subscriptions.

This does work in this case, but I'm not sure if a different solution is preferred?