### PR TITLE
Remove usage of transient for metabox status

### DIFF
--- a/.changelogs/2026-05-05-fix-metabox-status
+++ b/.changelogs/2026-05-05-fix-metabox-status
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed an issue where the "Walley order status" in the order metabox was left blank when the WooCommerce order status was updated.

--- a/.changelogs/2026-05-05-fix-metabox-status
+++ b/.changelogs/2026-05-05-fix-metabox-status
@@ -1,4 +1,4 @@
 Type: Fix
 Needs Documentation: no
 
-Fixed an issue where the "Walley order status" in the order metabox was left blank when the WooCommerce order status was updated.
+Fixed an issue where the "Walley order status" in the order metabox was sometimes left blank when the WooCommerce order status was updated.

--- a/classes/class-collector-checkout-ajax-calls.php
+++ b/classes/class-collector-checkout-ajax-calls.php
@@ -359,17 +359,6 @@ class Collector_Checkout_Ajax_Calls extends WC_AJAX {
 				// Translators: Request response http status.
 				$order->add_order_note( sprintf( __( 'Walley order sync started. Unknown http status response. Status: %1$s.', 'collector-checkout-for-woocommerce' ), $response['status'] ) );
 			}
-
-			// Save received data to WP transient.
-			walley_save_order_data_to_transient(
-				array(
-					'order_id'     => $order_id,
-					'status'       => $response['status'],
-					'total_amount' => $order->get_total(),
-					'currency'     => $order->get_currency(),
-				)
-			);
-
 		} else {
 			// Translators: Request error message & request error code.
 			$order->add_order_note( sprintf( __( 'Could not update order lines in Walley. Error message: %1$s. Error code: %2$s</i>', 'collector-checkout-for-woocommerce' ), $response->get_error_message(), $response->get_error_code() ) );

--- a/classes/class-walley-checkout-meta-box.php
+++ b/classes/class-walley-checkout-meta-box.php
@@ -67,8 +67,9 @@ class Walley_Checkout_Meta_Box {
 			$walley_order_status   = $walley_order['data']['status'] ?? 'unknown';
 			$walley_order_total    = $walley_order['data']['totalAmount'] ?? '';
 			$walley_order_currency = $walley_order['data']['currency'] ?? '';
+			$wc_order_total        = Collector_Checkout_Requests_Helper_Order_Om::get_order_lines_total_amount( $order_id );
 			// Translators: Woo order total & Walley order total.
-			$order_total_mismatch = floatval( Collector_Checkout_Requests_Helper_Order_Om::get_order_lines_total_amount( $order_id ) ) !== floatval( $walley_order_total ) ? sprintf( '<i>%s</i>', sprintf( __( 'Order total differs between systems (WooCommerce: %1$s, Walley: %2$s)', 'collector-checkout-for-woocommerce' ), Collector_Checkout_Requests_Helper_Order_Om::get_order_lines_total_amount( $order_id ), $walley_order_total ) ) : '';
+			$order_total_mismatch = floatval( $wc_order_total ) !== floatval( $walley_order_total ) ? sprintf( '<i>%s</i>', sprintf( __( 'Order total differs between systems (WooCommerce: %1$s, Walley: %2$s)', 'collector-checkout-for-woocommerce' ), $wc_order_total, $walley_order_total ) ) : '';
 		}
 
 		$keys_for_meta_box = array(

--- a/classes/class-walley-checkout-meta-box.php
+++ b/classes/class-walley-checkout-meta-box.php
@@ -69,15 +69,6 @@ class Walley_Checkout_Meta_Box {
 			$walley_order_currency = $walley_order['data']['currency'] ?? '';
 			// Translators: Woo order total & Walley order total.
 			$order_total_mismatch = floatval( Collector_Checkout_Requests_Helper_Order_Om::get_order_lines_total_amount( $order_id ) ) !== floatval( $walley_order_total ) ? sprintf( '<i>%s</i>', sprintf( __( 'Order total differs between systems (WooCommerce: %1$s, Walley: %2$s)', 'collector-checkout-for-woocommerce' ), Collector_Checkout_Requests_Helper_Order_Om::get_order_lines_total_amount( $order_id ), $walley_order_total ) ) : '';
-			// Save received data to WP transient.
-			walley_save_order_data_to_transient(
-				array(
-					'order_id'     => $order_id,
-					'status'       => $walley_order_status,
-					'total_amount' => $walley_order_total,
-					'currency'     => $walley_order_currency,
-				)
-			);
 		}
 
 		$keys_for_meta_box = array(

--- a/classes/class-walley-checkout-meta-box.php
+++ b/classes/class-walley-checkout-meta-box.php
@@ -68,7 +68,7 @@ class Walley_Checkout_Meta_Box {
 			$walley_order_total    = $walley_order['data']['totalAmount'] ?? '';
 			$walley_order_currency = $walley_order['data']['currency'] ?? '';
 			// Translators: Woo order total & Walley order total.
-			$order_total_mismatch = floatval( Collector_Checkout_Requests_Helper_Order_Om::get_order_lines_total_amount( $order_id ) ) !== floatval( $walley_order_total ) ? sprintf( __( '<i>Order total differs between systems (WooCommerce: %1$s, Walley: %2$s)</i>', 'collector-checkout-for-woocommerce' ), Collector_Checkout_Requests_Helper_Order_Om::get_order_lines_total_amount( $order_id ), $walley_order_total ) : '';
+			$order_total_mismatch = floatval( Collector_Checkout_Requests_Helper_Order_Om::get_order_lines_total_amount( $order_id ) ) !== floatval( $walley_order_total ) ? sprintf( '<i>%s</i>', sprintf( __( 'Order total differs between systems (WooCommerce: %1$s, Walley: %2$s)', 'collector-checkout-for-woocommerce' ), Collector_Checkout_Requests_Helper_Order_Om::get_order_lines_total_amount( $order_id ), $walley_order_total ) ) : '';
 			// Save received data to WP transient.
 			walley_save_order_data_to_transient(
 				array(
@@ -112,4 +112,6 @@ class Walley_Checkout_Meta_Box {
 		$manage_orders = wc_string_to_bool( get_option( 'woocommerce_collector_checkout_settings', array() )['manage_collector_orders'] ?? 'no' );
 		include COLLECTOR_BANK_PLUGIN_DIR . '/templates/walley-checkout-meta-box.php';
 	}
-} new Walley_Checkout_Meta_Box();
+}
+
+new Walley_Checkout_Meta_Box();

--- a/classes/class-walley-checkout-meta-box.php
+++ b/classes/class-walley-checkout-meta-box.php
@@ -56,36 +56,28 @@ class Walley_Checkout_Meta_Box {
 		$title_walley_order_total   = __( 'Walley order total', 'collector-checkout-for-woocommerce' );
 		$title_order_total_mismatch = __( 'Order total mismatch', 'collector-checkout-for-woocommerce' );
 
-		if ( empty( $walley_order_status_from_transient = get_transient( "walley_order_status_{$order_id}" ) ) ) {
-			$walley_order = CCO_WC()->api->get_walley_order( $walley_order_id );
+		$walley_order = CCO_WC()->api->get_walley_order( $walley_order_id );
 
-			if ( is_wp_error( $walley_order ) ) {
-				$walley_order_status   = 'unknown';
-				$walley_order_total    = '';
-				$walley_order_currency = '';
-				$order_total_mismatch  = '';
-			} else {
-				$walley_order_status   = $walley_order['data']['status'] ?? 'unknown';
-				$walley_order_total    = $walley_order['data']['totalAmount'] ?? '';
-				$walley_order_currency = $walley_order['data']['currency'] ?? '';
-				// Translators: Woo order total & Walley order total.
-				$order_total_mismatch = floatval( Collector_Checkout_Requests_Helper_Order_Om::get_order_lines_total_amount( $order_id ) ) !== floatval( $walley_order_total ) ? sprintf( __( '<i>Order total differs between systems (WooCommerce: %1$s, Walley: %2$s)</i>', 'collector-checkout-for-woocommerce' ), Collector_Checkout_Requests_Helper_Order_Om::get_order_lines_total_amount( $order_id ), $walley_order_total ) : '';
-				// Save received data to WP transient.
-				walley_save_order_data_to_transient(
-					array(
-						'order_id'     => $order_id,
-						'status'       => $walley_order_status,
-						'total_amount' => $walley_order_total,
-						'currency'     => $walley_order_currency,
-					)
-				);
-			}
+		if ( is_wp_error( $walley_order ) ) {
+			$walley_order_status   = 'unknown';
+			$walley_order_total    = '';
+			$walley_order_currency = '';
+			$order_total_mismatch  = '';
 		} else {
-			$walley_order_status   = $walley_order_status_from_transient['status'] ?? 'unknown';
-			$walley_order_total    = $walley_order_status_from_transient['total_amount'] ?? '';
-			$walley_order_currency = $walley_order_status_from_transient['currency'] ?? '';
+			$walley_order_status   = $walley_order['data']['status'] ?? 'unknown';
+			$walley_order_total    = $walley_order['data']['totalAmount'] ?? '';
+			$walley_order_currency = $walley_order['data']['currency'] ?? '';
 			// Translators: Woo order total & Walley order total.
 			$order_total_mismatch = floatval( Collector_Checkout_Requests_Helper_Order_Om::get_order_lines_total_amount( $order_id ) ) !== floatval( $walley_order_total ) ? sprintf( __( '<i>Order total differs between systems (WooCommerce: %1$s, Walley: %2$s)</i>', 'collector-checkout-for-woocommerce' ), Collector_Checkout_Requests_Helper_Order_Om::get_order_lines_total_amount( $order_id ), $walley_order_total ) : '';
+			// Save received data to WP transient.
+			walley_save_order_data_to_transient(
+				array(
+					'order_id'     => $order_id,
+					'status'       => $walley_order_status,
+					'total_amount' => $walley_order_total,
+					'currency'     => $walley_order_currency,
+				)
+			);
 		}
 
 		$keys_for_meta_box = array(

--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -112,15 +112,6 @@ class Walley_Checkout_Order_Management {
 			$order->add_order_note( sprintf( __( 'Order part activated with Walley Checkout. Activated amount %s', 'collector-checkout-for-woocommerce' ), wc_price( $order->get_total(), array( 'currency' => $order->get_currency() ) ) ) );
 			$order->update_meta_data( '_collector_order_activated', time() );
 			$order->save();
-
-			// Save received data to WP transient.
-			walley_save_order_data_to_transient(
-				array(
-					'order_id'     => $order_id,
-					'total_amount' => $order->get_total(),
-					'currency'     => $order->get_currency(),
-				)
-			);
 			return;
 		} else {
 			$response = CCO_WC()->api->capture_walley_order( $order_id );
@@ -144,15 +135,6 @@ class Walley_Checkout_Order_Management {
 			$order->add_order_note( $note );
 			$order->update_meta_data( '_collector_order_activated', time() );
 			$order->save();
-
-			// Save received data to WP transient.
-			walley_save_order_data_to_transient(
-				array(
-					'order_id'     => $order_id,
-					'total_amount' => $order->get_total(),
-					'currency'     => $order->get_currency(),
-				)
-			);
 			return;
 		}
 	}
@@ -211,15 +193,6 @@ class Walley_Checkout_Order_Management {
 		$order->add_order_note( $note );
 		$order->update_meta_data( '_collector_order_cancelled', time() );
 		$order->save();
-
-		// Save received data to WP transient.
-		walley_save_order_data_to_transient(
-			array(
-				'order_id'     => $order_id,
-				'total_amount' => $order->get_total(),
-				'currency'     => $order->get_currency(),
-			)
-		);
 	}
 
 	/**
@@ -280,14 +253,6 @@ class Walley_Checkout_Order_Management {
 
 			return $response;
 		}
-
-		// Save received data to WP transient.
-		walley_save_order_data_to_transient(
-			array(
-				'order_id' => $order_id,
-				'currency' => $order->get_currency(),
-			)
-		);
 
 		// Translators: Refunded amount.
 		$order->add_order_note( sprintf( __( 'Walley Checkout order refunded with %s.', 'collector-checkout-for-woocommerce' ), wc_price( $amount ) ) );

--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -372,7 +372,7 @@ class Walley_Checkout_Order_Management {
 			}
 
 			$current_screen = get_current_screen();
-			if ( isset( $current_screen ) && in_array( $current_screen->id, array( 'woocommerce_page_wc-orders', 'edit-shop_order' ) ) ) {
+			if ( isset( $current_screen ) && in_array( $current_screen->id, array( 'woocommerce_page_wc-orders', 'edit-shop_order' ), true ) ) {
 				$collector_payment_id = $order->get_meta( '_collector_payment_id' );
 				if ( ! empty( $collector_payment_id ) ) {
 					$order_number .= ' (' . $collector_payment_id . ')';

--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -233,16 +233,7 @@ class Walley_Checkout_Order_Management {
 			return new WP_Error( 'error', __( 'Could not refund Walley reservation, Walley order ID is missing.', 'collector-checkout-for-woocommerce' ) );
 		}
 
-		// Currently we always need to do a refund by amount since rounding fee in refund can differ from original order and Walley does not accept that.
-		/*
-		if ( $this->order_contain_goodwill_refund( $order_id ) ) {
-			$response = CCO_WC()->api->refund_walley_order_by_amount( $order_id, $amount, $reason );
-		} else {
-			$response = CCO_WC()->api->refund_walley_order( $order_id, $amount, $reason );
-		}
-		*/
 		$response = CCO_WC()->api->refund_walley_order_by_amount( $order_id, $amount, $reason );
-
 		if ( is_wp_error( $response ) ) {
 			// If error save error message.
 			$code          = $response->get_error_code();

--- a/classes/class-walley-checkout-order-management.php
+++ b/classes/class-walley-checkout-order-management.php
@@ -276,12 +276,12 @@ class Walley_Checkout_Order_Management {
 				return true;
 			} else {
 				// Translators: Walley payment status.
-				$order->add_order_note( sprintf( __( 'Cancel Walley order request will not be triggered. Order have status <i>%s</i> in Walley Merchant Hub.', 'dibs-easy-for-woocommerce' ), $response['data']['status'] ) );
+				$order->add_order_note( sprintf( __( 'Cancel Walley order request will not be triggered. Order have status <i>%s</i> in Walley Merchant Hub.', 'collector-checkout-for-woocommerce' ), $response['data']['status'] ) );
 				return false;
 			}
 		}
 		// Translators: Request error message.
-		$order->add_order_note( sprintf( __( 'Unable to get the Walley order. Error message: <i>%s</i>.', 'dibs-easy-for-woocommerce' ), $response->get_error_message() ) );
+		$order->add_order_note( sprintf( __( 'Unable to get the Walley order. Error message: <i>%s</i>.', 'collector-checkout-for-woocommerce' ), $response->get_error_message() ) );
 		return false;
 	}
 

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -232,8 +232,8 @@ function wc_collector_get_order_by_private_id( $private_id = null ) {
 	}
 
 	$args = array(
-		'meta_key'     => '_collector_private_id',
-		'meta_value'   => $private_id,
+		'meta_key'     => '_collector_private_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Required to locate order by specific metadata key.
+		'meta_value'   => $private_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Required to locate order by specific metadata value.
 		'meta_compare' => '=',
 		'order'        => 'DESC',
 		'orderby'      => 'date',
@@ -626,8 +626,8 @@ function walley_get_order_id_by_public_token( $public_token ) {
 function walley_get_order_by_key( $key, $value ) {
 	$orders = wc_get_orders(
 		array(
-			'meta_key'   => $key,
-			'meta_value' => $value,
+			'meta_key'   => $key, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Required to locate order by specific metadata key.
+			'meta_value' => $value, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Required to locate order by specific metadata value.
 			'limit'      => 1,
 			'orderby'    => 'date',
 			'order'      => 'DESC',
@@ -1137,6 +1137,8 @@ function walley_is_order_page() {
  * @param WC_Order $order The WooCommerce order.
  * @param string   $payment_status The payment status.
  * @param string   $payment_id The payment ID.
+ * @param bool     $save_order Whether to save the order after setting the status. Default is true.
+ * @param bool     $is_callback Whether the status update is triggered from a callback. Default is false.
  *
  * @return void
  */

--- a/includes/collector-checkout-for-woocommerce-functions.php
+++ b/includes/collector-checkout-for-woocommerce-functions.php
@@ -606,21 +606,6 @@ function walley_use_new_api() {
 }
 
 /**
- * Save Walley order data to transient in WordPress.
- *
- * @param array $walley_order the returned Walley order data.
- * @return void
- */
-function walley_save_order_data_to_transient( $walley_order ) {
-	$walley_order_status_data = array(
-		'status'       => $walley_order['status'] ?? '',
-		'total_amount' => $walley_order['total_amount'] ?? '',
-		'currency'     => $walley_order['currency'] ?? '',
-	);
-	set_transient( "walley_order_status_{$walley_order['order_id']}", $walley_order_status_data, 30 );
-}
-
-/**
  * Finds an Order ID based on a Walley public token.
  *
  * @param string $public_token Walley public token.


### PR DESCRIPTION
Remove usage of transient for the metabox status and simply get the order on every page load for the metabox.

@MichaelBengtsson I was having some issues with the PR not reflecting the recent changes in develop despite no changes being available when attempting to merge develop into current branch (not sure why), so I made a fresh PR.

Do I understand you correctly in that this is the only thing that really needs to be done? **Edit:** Also removed all setting of the transient, since it is the only thing we seem to use this particular transient for.

Tested and resolves the blank status issue.